### PR TITLE
Transcript with Poseidon hasher

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -39,7 +39,7 @@ blake2b_simd = "1"
 pairing = { git = 'https://github.com/appliedzkp/pairing', package = "pairing_bn256" }
 subtle = "2.3"
 cfg-if = "0.1"
-poseidon = { git = 'https://github.com/kilic/poseidon', branch = "padding" }
+poseidon = { git = "https://github.com/appliedzkp/poseidon.git", rev = "a21422a307e43c9de1dd32c1024618e30d805667" }
 num-bigint = { version = "0.4" }
 num-traits = "0.2"
 

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -39,6 +39,9 @@ blake2b_simd = "1"
 pairing = { git = 'https://github.com/appliedzkp/pairing', package = "pairing_bn256" }
 subtle = "2.3"
 cfg-if = "0.1"
+poseidon = { git = 'https://github.com/kilic/poseidon', branch = "padding" }
+num-bigint = { version = "0.4" }
+num-traits = "0.2"
 
 # Developer tooling dependencies
 plotters = { version = "0.3.0", optional = true }

--- a/halo2_proofs/benches/plonk.rs
+++ b/halo2_proofs/benches/plonk.rs
@@ -10,7 +10,7 @@ use halo2_proofs::poly::{
     commitment::{Params, ParamsVerifier},
     Rotation,
 };
-use halo2_proofs::transcript::{Blake2bRead, Blake2bWrite, Challenge255};
+use halo2_proofs::transcript::{blake2b::Blake2bRead, blake2b::Blake2bWrite, Challenge255};
 use rand_core::OsRng;
 
 use std::marker::PhantomData;

--- a/halo2_proofs/examples/simple-example-2.rs
+++ b/halo2_proofs/examples/simple-example-2.rs
@@ -3,7 +3,10 @@ use halo2_proofs::{
     circuit::{Cell, Layouter, SimpleFloorPlanner},
     plonk::*,
     poly::{commitment::Params, commitment::ParamsVerifier, Rotation},
-    transcript::{Blake2bRead, Blake2bWrite, Challenge255},
+    transcript::{
+        poseidon::{LimbRepresentation, PoseidonRead, PoseidonWrite},
+        Challenge,
+    },
 };
 use pairing::bn256::{Bn256, Fr as Fp, G1Affine};
 use rand_core::OsRng;
@@ -258,7 +261,12 @@ fn main() {
     };
 
     // Create a proof
-    let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+    let mut transcript =
+        PoseidonWrite::<_, G1Affine, Challenge<_>, LimbRepresentation<_, 4, 68>, 3, 2>::init(
+            vec![],
+            8,
+            57,
+        );
 
     use std::time::Instant;
     let _dur = Instant::now();
@@ -271,7 +279,13 @@ fn main() {
     let proof = transcript.finalize();
 
     let strategy = SingleVerifier::new(&params_verifier);
-    let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+
+    let mut transcript =
+        PoseidonRead::<_, G1Affine, Challenge<_>, LimbRepresentation<_, 4, 68>, 3, 2>::init(
+            &proof[..],
+            8,
+            57,
+        );
 
     verify_proof(
         &params_verifier,

--- a/halo2_proofs/src/poly/multiopen/shplonk.rs
+++ b/halo2_proofs/src/poly/multiopen/shplonk.rs
@@ -168,10 +168,6 @@ mod tests {
         multiopen::{ProverQuery, Query, VerifierQuery},
         Coeff, Polynomial, Rotation,
     };
-    use crate::transcript::{
-        Blake2bRead, Blake2bWrite, Challenge255, ChallengeScalar, Transcript, TranscriptRead,
-        TranscriptWrite,
-    };
 
     use ff::Field;
     use rand::RngCore;

--- a/halo2_proofs/src/transcript.rs
+++ b/halo2_proofs/src/transcript.rs
@@ -10,14 +10,11 @@ use crate::arithmetic::{BaseExt, Coordinates, CurveAffine, FieldExt};
 use std::io::{self, Read, Write};
 use std::marker::PhantomData;
 
-/// Prefix to a prover's message soliciting a challenge
-const BLAKE2B_PREFIX_CHALLENGE: u8 = 0;
+/// Transcript with blake2b hasher.
+pub mod blake2b;
 
-/// Prefix to a prover's message containing a curve point
-const BLAKE2B_PREFIX_POINT: u8 = 1;
-
-/// Prefix to a prover's message containing a scalar
-const BLAKE2B_PREFIX_SCALAR: u8 = 2;
+/// Transcript with Poseidon hasher.
+pub mod poseidon;
 
 /// Generic transcript view (from either the prover or verifier's perspective)
 pub trait Transcript<C: CurveAffine, E: EncodedChallenge<C>> {
@@ -59,164 +56,6 @@ pub trait TranscriptWrite<C: CurveAffine, E: EncodedChallenge<C>>: Transcript<C,
 
     /// Write a scalar to the proof and the transcript.
     fn write_scalar(&mut self, scalar: C::Scalar) -> io::Result<()>;
-}
-
-/// We will replace BLAKE2b with an algebraic hash function in a later version.
-#[derive(Debug, Clone)]
-pub struct Blake2bRead<R: Read, C: CurveAffine, E: EncodedChallenge<C>> {
-    state: Blake2bState,
-    reader: R,
-    _marker: PhantomData<(C, E)>,
-}
-
-impl<R: Read, C: CurveAffine, E: EncodedChallenge<C>> Blake2bRead<R, C, E> {
-    /// Initialize a transcript given an input buffer.
-    pub fn init(reader: R) -> Self {
-        Blake2bRead {
-            state: Blake2bParams::new()
-                .hash_length(64)
-                .personal(b"Halo2-Transcript")
-                .to_state(),
-            reader,
-            _marker: PhantomData,
-        }
-    }
-}
-
-impl<R: Read, C: CurveAffine> TranscriptRead<C, Challenge255<C>>
-    for Blake2bRead<R, C, Challenge255<C>>
-{
-    fn read_point(&mut self) -> io::Result<C> {
-        let mut compressed = C::Repr::default();
-        self.reader.read_exact(compressed.as_mut())?;
-        let point: C = Option::from(C::from_bytes(&compressed)).ok_or_else(|| {
-            io::Error::new(io::ErrorKind::Other, "invalid point encoding in proof")
-        })?;
-        self.common_point(point)?;
-
-        Ok(point)
-    }
-
-    fn read_scalar(&mut self) -> io::Result<C::Scalar> {
-        let mut data = <C::Scalar as PrimeField>::Repr::default();
-        self.reader.read_exact(data.as_mut())?;
-        let scalar: C::Scalar = Option::from(C::Scalar::from_repr(data)).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "invalid field element encoding in proof",
-            )
-        })?;
-        self.common_scalar(scalar)?;
-
-        Ok(scalar)
-    }
-}
-
-impl<R: Read, C: CurveAffine> Transcript<C, Challenge255<C>>
-    for Blake2bRead<R, C, Challenge255<C>>
-{
-    fn squeeze_challenge(&mut self) -> Challenge255<C> {
-        self.state.update(&[BLAKE2B_PREFIX_CHALLENGE]);
-        let hasher = self.state.clone();
-        let result: [u8; 64] = hasher.finalize().as_bytes().try_into().unwrap();
-        Challenge255::<C>::new(&result)
-    }
-
-    fn common_point(&mut self, point: C) -> io::Result<()> {
-        self.state.update(&[BLAKE2B_PREFIX_POINT]);
-        let coords: Coordinates<C> = Option::from(point.coordinates()).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "cannot write points at infinity to the transcript",
-            )
-        })?;
-        coords.x().write(&mut self.state)?;
-        coords.y().write(&mut self.state)?;
-
-        Ok(())
-    }
-
-    fn common_scalar(&mut self, scalar: C::Scalar) -> io::Result<()> {
-        self.state.update(&[BLAKE2B_PREFIX_SCALAR]);
-        self.state.update(scalar.to_repr().as_ref());
-
-        Ok(())
-    }
-}
-
-/// We will replace BLAKE2b with an algebraic hash function in a later version.
-#[derive(Debug, Clone)]
-pub struct Blake2bWrite<W: Write, C: CurveAffine, E: EncodedChallenge<C>> {
-    state: Blake2bState,
-    writer: W,
-    _marker: PhantomData<(C, E)>,
-}
-
-impl<W: Write, C: CurveAffine, E: EncodedChallenge<C>> Blake2bWrite<W, C, E> {
-    /// Initialize a transcript given an output buffer.
-    pub fn init(writer: W) -> Self {
-        Blake2bWrite {
-            state: Blake2bParams::new()
-                .hash_length(64)
-                .personal(b"Halo2-Transcript")
-                .to_state(),
-            writer,
-            _marker: PhantomData,
-        }
-    }
-
-    /// Conclude the interaction and return the output buffer (writer).
-    pub fn finalize(self) -> W {
-        // TODO: handle outstanding scalars? see issue #138
-        self.writer
-    }
-}
-
-impl<W: Write, C: CurveAffine> TranscriptWrite<C, Challenge255<C>>
-    for Blake2bWrite<W, C, Challenge255<C>>
-{
-    fn write_point(&mut self, point: C) -> io::Result<()> {
-        self.common_point(point)?;
-        let compressed = point.to_bytes();
-        self.writer.write_all(compressed.as_ref())
-    }
-    fn write_scalar(&mut self, scalar: C::Scalar) -> io::Result<()> {
-        self.common_scalar(scalar)?;
-        let data = scalar.to_repr();
-        self.writer.write_all(data.as_ref())
-    }
-}
-
-impl<W: Write, C: CurveAffine> Transcript<C, Challenge255<C>>
-    for Blake2bWrite<W, C, Challenge255<C>>
-{
-    fn squeeze_challenge(&mut self) -> Challenge255<C> {
-        self.state.update(&[BLAKE2B_PREFIX_CHALLENGE]);
-        let hasher = self.state.clone();
-        let result: [u8; 64] = hasher.finalize().as_bytes().try_into().unwrap();
-        Challenge255::<C>::new(&result)
-    }
-
-    fn common_point(&mut self, point: C) -> io::Result<()> {
-        self.state.update(&[BLAKE2B_PREFIX_POINT]);
-        let coords: Coordinates<C> = Option::from(point.coordinates()).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "cannot write points at infinity to the transcript",
-            )
-        })?;
-        coords.x().write(&mut self.state)?;
-        coords.y().write(&mut self.state)?;
-
-        Ok(())
-    }
-
-    fn common_scalar(&mut self, scalar: C::Scalar) -> io::Result<()> {
-        self.state.update(&[BLAKE2B_PREFIX_SCALAR]);
-        self.state.update(scalar.to_repr().as_ref());
-
-        Ok(())
-    }
 }
 
 /// The scalar representation of a verifier challenge.
@@ -290,6 +129,22 @@ impl<C: CurveAffine> EncodedChallenge<C> for Challenge255<C> {
         let mut repr = <C::Scalar as PrimeField>::Repr::default();
         repr.as_mut().copy_from_slice(&self.0);
         C::Scalar::from_repr(repr).unwrap()
+    }
+}
+
+/// A scalar challenge.
+#[derive(Copy, Clone, Debug)]
+pub struct Challenge<C: CurveAffine>(C::Scalar);
+
+impl<C: CurveAffine> EncodedChallenge<C> for Challenge<C> {
+    type Input = C::Scalar;
+
+    fn new(challenge_input: &C::Scalar) -> Self {
+        Challenge(*challenge_input)
+    }
+
+    fn get_scalar(&self) -> C::Scalar {
+        self.0
     }
 }
 

--- a/halo2_proofs/src/transcript/blake2b.rs
+++ b/halo2_proofs/src/transcript/blake2b.rs
@@ -7,7 +7,7 @@ use crate::arithmetic::{BaseExt, Coordinates, CurveAffine, FieldExt};
 use std::io::{self, Read, Write};
 use std::marker::PhantomData;
 
-use super::{EncodedChallenge, TranscriptRead, Challenge255, Transcript, TranscriptWrite};
+use super::{Challenge255, EncodedChallenge, Transcript, TranscriptRead, TranscriptWrite};
 
 /// Prefix to a prover's message soliciting a challenge
 const BLAKE2B_PREFIX_CHALLENGE: u8 = 0;

--- a/halo2_proofs/src/transcript/blake2b.rs
+++ b/halo2_proofs/src/transcript/blake2b.rs
@@ -1,0 +1,177 @@
+use blake2b_simd::{Params as Blake2bParams, State as Blake2bState};
+use group::ff::PrimeField;
+use std::convert::TryInto;
+
+use crate::arithmetic::{BaseExt, Coordinates, CurveAffine, FieldExt};
+
+use std::io::{self, Read, Write};
+use std::marker::PhantomData;
+
+use super::{EncodedChallenge, TranscriptRead, Challenge255, Transcript, TranscriptWrite};
+
+/// Prefix to a prover's message soliciting a challenge
+const BLAKE2B_PREFIX_CHALLENGE: u8 = 0;
+
+/// Prefix to a prover's message containing a curve point
+const BLAKE2B_PREFIX_POINT: u8 = 1;
+
+/// Prefix to a prover's message containing a scalar
+const BLAKE2B_PREFIX_SCALAR: u8 = 2;
+
+/// We will replace BLAKE2b with an algebraic hash function in a later version.
+#[derive(Debug, Clone)]
+pub struct Blake2bRead<R: Read, C: CurveAffine, E: EncodedChallenge<C>> {
+    state: Blake2bState,
+    reader: R,
+    _marker: PhantomData<(C, E)>,
+}
+
+impl<R: Read, C: CurveAffine, E: EncodedChallenge<C>> Blake2bRead<R, C, E> {
+    /// Initialize a transcript given an input buffer.
+    pub fn init(reader: R) -> Self {
+        Blake2bRead {
+            state: Blake2bParams::new()
+                .hash_length(64)
+                .personal(b"Halo2-Transcript")
+                .to_state(),
+            reader,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<R: Read, C: CurveAffine> TranscriptRead<C, Challenge255<C>>
+    for Blake2bRead<R, C, Challenge255<C>>
+{
+    fn read_point(&mut self) -> io::Result<C> {
+        let mut compressed = C::Repr::default();
+        self.reader.read_exact(compressed.as_mut())?;
+        let point: C = Option::from(C::from_bytes(&compressed)).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::Other, "invalid point encoding in proof")
+        })?;
+        self.common_point(point)?;
+
+        Ok(point)
+    }
+
+    fn read_scalar(&mut self) -> io::Result<C::Scalar> {
+        let mut data = <C::Scalar as PrimeField>::Repr::default();
+        self.reader.read_exact(data.as_mut())?;
+        let scalar: C::Scalar = Option::from(C::Scalar::from_repr(data)).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                "invalid field element encoding in proof",
+            )
+        })?;
+        self.common_scalar(scalar)?;
+
+        Ok(scalar)
+    }
+}
+
+impl<R: Read, C: CurveAffine> Transcript<C, Challenge255<C>>
+    for Blake2bRead<R, C, Challenge255<C>>
+{
+    fn squeeze_challenge(&mut self) -> Challenge255<C> {
+        self.state.update(&[BLAKE2B_PREFIX_CHALLENGE]);
+        let hasher = self.state.clone();
+        let result: [u8; 64] = hasher.finalize().as_bytes().try_into().unwrap();
+        Challenge255::<C>::new(&result)
+    }
+
+    fn common_point(&mut self, point: C) -> io::Result<()> {
+        self.state.update(&[BLAKE2B_PREFIX_POINT]);
+        let coords: Coordinates<C> = Option::from(point.coordinates()).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                "cannot write points at infinity to the transcript",
+            )
+        })?;
+        coords.x().write(&mut self.state)?;
+        coords.y().write(&mut self.state)?;
+
+        Ok(())
+    }
+
+    fn common_scalar(&mut self, scalar: C::Scalar) -> io::Result<()> {
+        self.state.update(&[BLAKE2B_PREFIX_SCALAR]);
+        self.state.update(scalar.to_repr().as_ref());
+
+        Ok(())
+    }
+}
+
+/// We will replace BLAKE2b with an algebraic hash function in a later version.
+#[derive(Debug, Clone)]
+pub struct Blake2bWrite<W: Write, C: CurveAffine, E: EncodedChallenge<C>> {
+    state: Blake2bState,
+    writer: W,
+    _marker: PhantomData<(C, E)>,
+}
+
+impl<W: Write, C: CurveAffine, E: EncodedChallenge<C>> Blake2bWrite<W, C, E> {
+    /// Initialize a transcript given an output buffer.
+    pub fn init(writer: W) -> Self {
+        Blake2bWrite {
+            state: Blake2bParams::new()
+                .hash_length(64)
+                .personal(b"Halo2-Transcript")
+                .to_state(),
+            writer,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Conclude the interaction and return the output buffer (writer).
+    pub fn finalize(self) -> W {
+        // TODO: handle outstanding scalars? see issue #138
+        self.writer
+    }
+}
+
+impl<W: Write, C: CurveAffine> TranscriptWrite<C, Challenge255<C>>
+    for Blake2bWrite<W, C, Challenge255<C>>
+{
+    fn write_point(&mut self, point: C) -> io::Result<()> {
+        self.common_point(point)?;
+        let compressed = point.to_bytes();
+        self.writer.write_all(compressed.as_ref())
+    }
+    fn write_scalar(&mut self, scalar: C::Scalar) -> io::Result<()> {
+        self.common_scalar(scalar)?;
+        let data = scalar.to_repr();
+        self.writer.write_all(data.as_ref())
+    }
+}
+
+impl<W: Write, C: CurveAffine> Transcript<C, Challenge255<C>>
+    for Blake2bWrite<W, C, Challenge255<C>>
+{
+    fn squeeze_challenge(&mut self) -> Challenge255<C> {
+        self.state.update(&[BLAKE2B_PREFIX_CHALLENGE]);
+        let hasher = self.state.clone();
+        let result: [u8; 64] = hasher.finalize().as_bytes().try_into().unwrap();
+        Challenge255::<C>::new(&result)
+    }
+
+    fn common_point(&mut self, point: C) -> io::Result<()> {
+        self.state.update(&[BLAKE2B_PREFIX_POINT]);
+        let coords: Coordinates<C> = Option::from(point.coordinates()).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                "cannot write points at infinity to the transcript",
+            )
+        })?;
+        coords.x().write(&mut self.state)?;
+        coords.y().write(&mut self.state)?;
+
+        Ok(())
+    }
+
+    fn common_scalar(&mut self, scalar: C::Scalar) -> io::Result<()> {
+        self.state.update(&[BLAKE2B_PREFIX_SCALAR]);
+        self.state.update(scalar.to_repr().as_ref());
+
+        Ok(())
+    }
+}

--- a/halo2_proofs/src/transcript/poseidon.rs
+++ b/halo2_proofs/src/transcript/poseidon.rs
@@ -1,0 +1,363 @@
+use poseidon::Poseidon;
+
+use crate::arithmetic::{Coordinates, CurveAffine, Field};
+use crate::transcript::{EncodedChallenge, Transcript, TranscriptRead, TranscriptWrite};
+use group::ff::PrimeField;
+
+use std::io::{self, Read, Write};
+use std::marker::PhantomData;
+
+/// x and y coordinates of a point are in base field. With
+/// strategies implements PointRepresentation base field elements are encoded as
+/// scalar field elements.
+pub trait PointRepresentation<C: CurveAffine> {
+    /// Given point returns elements that should be written to the state
+    fn encode(point: C) -> io::Result<Vec<C::Scalar>>;
+    /// Returns x and y coordinates. Panics if point is at infinity
+    fn xy(point: C) -> io::Result<(C::Base, C::Base)> {
+        let coords: Coordinates<C> = Option::from(point.coordinates()).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                "cannot write points at infinity to the transcript",
+            )
+        })?;
+        Ok((*coords.x(), *coords.y()))
+    }
+}
+
+/// Decomposes `x` coordinate which is a base field element into smaller limbs
+/// that should fit into the scalar field size. In order to avoid contribution
+/// only sign of the `y` coordinate which is one or zero is appended after `x`.
+#[derive(Debug)]
+pub struct LimbRepresentation<C: CurveAffine, const NUMBER_OF_LIMBS: usize, const BITLEN: usize> {
+    _marker: PhantomData<C>,
+}
+
+impl<C: CurveAffine, const NUMBER_OF_LIMBS: usize, const BITLEN: usize> PointRepresentation<C>
+    for LimbRepresentation<C, NUMBER_OF_LIMBS, BITLEN>
+{
+    fn encode(point: C) -> io::Result<Vec<C::Scalar>> {
+        assert!(bool::from(point.is_on_curve()));
+        assert!(!bool::from(point.is_identity()));
+        let (x, y) = Self::xy(point)?;
+        let mut encoded: Vec<C::Scalar> = decompose(x, NUMBER_OF_LIMBS, BITLEN);
+        encoded.push(if sign(y) {
+            C::Scalar::one()
+        } else {
+            C::Scalar::zero()
+        });
+        Ok(encoded)
+    }
+}
+
+/// Native representation approach assumes there is no such `P0` and `P1` points
+/// that satisfies `(x_0 == x_1) mod n` and `(y_0 == y_1) mod n` where n is
+/// scalar field moduli. This approach might be completely wrong so just don't
+/// use it.
+#[derive(Debug)]
+pub struct NativeRepresentation<C: CurveAffine> {
+    _marker: PhantomData<C>,
+}
+
+impl<C: CurveAffine> PointRepresentation<C> for NativeRepresentation<C> {
+    fn encode(point: C) -> io::Result<Vec<C::Scalar>> {
+        let (x, y) = Self::xy(point)?;
+        Ok(vec![native(x), native(y)])
+    }
+}
+
+/// Transcript reader with Poseidon
+#[derive(Debug, Clone)]
+pub struct PoseidonRead<
+    R: Read,
+    C: CurveAffine,
+    E: EncodedChallenge<C>,
+    Z: PointRepresentation<C>,
+    const T: usize,
+    const RATE: usize,
+> {
+    state: Poseidon<C::Scalar, T, RATE>,
+    reader: R,
+    _marker: PhantomData<(E, Z)>,
+}
+
+impl<
+        R: Read,
+        C: CurveAffine,
+        E: EncodedChallenge<C>,
+        Z: PointRepresentation<C>,
+        const T: usize,
+        const RATE: usize,
+    > PoseidonRead<R, C, E, Z, T, RATE>
+{
+    /// Initialize a transcript given an input buffer.
+    pub fn init(reader: R, r_f: usize, r_p: usize) -> Self {
+        PoseidonRead {
+            state: Poseidon::new(r_f, r_p),
+            reader,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<R: Read, C: CurveAffine, Z: PointRepresentation<C>, const T: usize, const RATE: usize>
+    TranscriptRead<C, Challenge<C>> for PoseidonRead<R, C, Challenge<C>, Z, T, RATE>
+{
+    fn read_point(&mut self) -> io::Result<C> {
+        let mut compressed = C::Repr::default();
+        self.reader.read_exact(compressed.as_mut())?;
+        let point: C = Option::from(C::from_bytes(&compressed)).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::Other, "invalid point encoding in proof")
+        })?;
+        self.common_point(point)?;
+
+        Ok(point)
+    }
+
+    fn read_scalar(&mut self) -> io::Result<C::Scalar> {
+        let mut data = <C::Scalar as PrimeField>::Repr::default();
+        self.reader.read_exact(data.as_mut())?;
+        let scalar: C::Scalar = Option::from(C::Scalar::from_repr(data)).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                "invalid field element encoding in proof",
+            )
+        })?;
+        self.common_scalar(scalar)?;
+
+        Ok(scalar)
+    }
+}
+
+impl<R: Read, C: CurveAffine, Z: PointRepresentation<C>, const T: usize, const RATE: usize>
+    Transcript<C, Challenge<C>> for PoseidonRead<R, C, Challenge<C>, Z, T, RATE>
+{
+    fn squeeze_challenge(&mut self) -> Challenge<C> {
+        self.state.update(&[/* PREFIX_CHALLENGE */]);
+        // TODO/FIX: should we clone state at this point or are we ok with squeezing
+        // advances the state?
+        Challenge::<C>::new(&self.state.squeeze())
+    }
+
+    fn common_point(&mut self, point: C) -> io::Result<()> {
+        self.state.update(&[/* PREFIX_POINT */]);
+        self.state.update(&Z::encode(point)?[..]);
+
+        Ok(())
+    }
+
+    fn common_scalar(&mut self, scalar: C::Scalar) -> io::Result<()> {
+        self.state.update(&[/* PREFIX_SCALAR */]);
+        self.state.update(&[scalar]);
+
+        Ok(())
+    }
+}
+
+/// Poseidon transcript writer.
+#[derive(Debug, Clone)]
+pub struct PoseidonWrite<
+    W: Write,
+    C: CurveAffine,
+    E: EncodedChallenge<C>,
+    Z: PointRepresentation<C>,
+    const T: usize,
+    const RATE: usize,
+> {
+    state: Poseidon<C::Scalar, T, RATE>,
+    writer: W,
+    _marker: PhantomData<(E, Z)>,
+}
+
+impl<
+        W: Write,
+        C: CurveAffine,
+        E: EncodedChallenge<C>,
+        Z: PointRepresentation<C>,
+        const T: usize,
+        const RATE: usize,
+    > PoseidonWrite<W, C, E, Z, T, RATE>
+{
+    /// Initialize a transcript given an output buffer and round parameters
+    pub fn init(writer: W, r_f: usize, r_p: usize) -> Self {
+        PoseidonWrite {
+            state: Poseidon::new(r_f, r_p),
+            writer,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Conclude the interaction and return the output buffer (writer).
+    pub fn finalize(self) -> W {
+        self.writer
+    }
+}
+
+impl<W: Write, C: CurveAffine, Z: PointRepresentation<C>, const T: usize, const RATE: usize>
+    TranscriptWrite<C, Challenge<C>> for PoseidonWrite<W, C, Challenge<C>, Z, T, RATE>
+{
+    fn write_point(&mut self, point: C) -> io::Result<()> {
+        self.common_point(point)?;
+        let compressed = point.to_bytes();
+        self.writer.write_all(compressed.as_ref())
+    }
+    fn write_scalar(&mut self, scalar: C::Scalar) -> io::Result<()> {
+        self.common_scalar(scalar)?;
+        let data = scalar.to_repr();
+        self.writer.write_all(data.as_ref())
+    }
+}
+
+impl<W: Write, C: CurveAffine, Z: PointRepresentation<C>, const T: usize, const RATE: usize>
+    Transcript<C, Challenge<C>> for PoseidonWrite<W, C, Challenge<C>, Z, T, RATE>
+{
+    fn squeeze_challenge(&mut self) -> Challenge<C> {
+        self.state.update(&[/* PREFIX_CHALLENGE */]);
+        // TODO/FIX: should we clone state at this point or are we ok with squeezing
+        // advances the state?
+        Challenge::<C>::new(&self.state.squeeze())
+    }
+
+    fn common_point(&mut self, point: C) -> io::Result<()> {
+        self.state.update(&[/* PREFIX_POINT */]);
+        self.state.update(&Z::encode(point)?[..]);
+
+        Ok(())
+    }
+
+    fn common_scalar(&mut self, scalar: C::Scalar) -> io::Result<()> {
+        self.state.update(&[/* PREFIX_SCALAR */]);
+        self.state.update(&[scalar]);
+
+        Ok(())
+    }
+}
+
+use num_bigint::BigUint;
+use num_traits::Num;
+use pairing::arithmetic::{BaseExt, FieldExt};
+use std::ops::Shl;
+
+use super::Challenge;
+
+pub(crate) fn decompose<Base: BaseExt, Scalar: FieldExt>(
+    e: Base,
+    number_of_limbs: usize,
+    bit_len: usize,
+) -> Vec<Scalar> {
+    decompose_big(fe_to_big(e), number_of_limbs, bit_len)
+}
+
+fn native<Base: BaseExt, Scalar: FieldExt>(e: Base) -> Scalar {
+    big_to_fe(fe_to_big(e) % modulus::<Scalar>())
+}
+
+fn modulus<F: FieldExt>() -> BigUint {
+    BigUint::from_str_radix(&F::MODULUS[2..], 16).unwrap()
+}
+
+fn decompose_big<F: FieldExt>(e: BigUint, number_of_limbs: usize, bit_len: usize) -> Vec<F> {
+    let mut e = e;
+    let mask = BigUint::from(1usize).shl(bit_len) - 1usize;
+    let limbs: Vec<F> = (0..number_of_limbs)
+        .map(|_| {
+            let limb = mask.clone() & e.clone();
+            e = e.clone() >> bit_len;
+            big_to_fe(limb)
+        })
+        .collect();
+
+    limbs
+}
+
+fn big_to_fe<F: FieldExt>(e: BigUint) -> F {
+    let modulus = modulus::<F>();
+    let e = e % modulus;
+    let mut bytes = e.to_bytes_le();
+    bytes.resize(32, 0);
+    let mut bytes = &bytes[..];
+    F::read(&mut bytes).unwrap()
+}
+
+fn fe_to_big<F: BaseExt>(fe: F) -> BigUint {
+    let mut bytes: Vec<u8> = Vec::new();
+    fe.write(&mut bytes).unwrap();
+    BigUint::from_bytes_le(&bytes[..])
+}
+
+fn sign<F: BaseExt>(fe: F) -> bool {
+    let mut bytes: Vec<u8> = Vec::new();
+    fe.write(&mut bytes).unwrap();
+    (bytes[0] & 1) == 0
+}
+
+#[test]
+fn test_transcript() {
+    use pairing::bn256::{Fr, G1Affine};
+    use rand::thread_rng;
+    let mut rng = thread_rng();
+
+    const R_F: usize = 8;
+    const R_P: usize = 57;
+
+    macro_rules! init_writer {
+        () => {
+            PoseidonWrite::<_, G1Affine, Challenge<_>, LimbRepresentation<_, 4, 68>, 3, 2>::init(
+                vec![],
+                R_F,
+                R_P,
+            )
+        };
+    }
+
+    macro_rules! init_reader {
+        ($proof:expr) => {
+            PoseidonRead::<_, G1Affine, Challenge<_>, LimbRepresentation<_, 4, 68>, 3, 2>::init(
+                &$proof[..],
+                R_F,
+                R_P,
+            )
+        };
+    }
+
+    let mut writer = init_writer!();
+    let s_0 = writer.squeeze_challenge();
+    let proof = writer.finalize();
+
+    let mut reader = init_reader!(proof);
+    let s_1 = reader.squeeze_challenge();
+    assert_eq!(s_0.get_scalar(), s_1.get_scalar());
+
+    let p0 = G1Affine::random(&mut rng);
+    let p1 = G1Affine::random(&mut rng);
+    let p2 = G1Affine::random(&mut rng);
+    let p3 = G1Affine::random(&mut rng);
+    let e0 = Fr::random(&mut rng);
+    let e1 = Fr::random(&mut rng);
+    let e2 = Fr::random(&mut rng);
+    let e3 = Fr::random(&mut rng);
+
+    let mut writer = init_writer!();
+    writer.write_point(p0).unwrap();
+    writer.write_point(p1).unwrap();
+    writer.write_scalar(e0).unwrap();
+    writer.write_scalar(e1).unwrap();
+    writer.write_scalar(e2).unwrap();
+    writer.write_scalar(e3).unwrap();
+    writer.write_point(p2).unwrap();
+    writer.write_point(p3).unwrap();
+    let s_0 = writer.squeeze_challenge();
+    let proof = writer.finalize();
+
+    let mut reader = init_reader!(proof);
+    assert_eq!(reader.read_point().unwrap(), p0);
+    assert_eq!(reader.read_point().unwrap(), p1);
+    assert_eq!(reader.read_scalar().unwrap(), e0);
+    assert_eq!(reader.read_scalar().unwrap(), e1);
+    assert_eq!(reader.read_scalar().unwrap(), e2);
+    assert_eq!(reader.read_scalar().unwrap(), e3);
+    assert_eq!(reader.read_point().unwrap(), p2);
+    assert_eq!(reader.read_point().unwrap(), p3);
+    let s_1 = reader.squeeze_challenge();
+    assert_eq!(s_0.get_scalar(), s_1.get_scalar());
+}

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -14,7 +14,7 @@ use halo2_proofs::poly::{
     commitment::{Params, ParamsVerifier},
     Rotation,
 };
-use halo2_proofs::transcript::{Blake2bRead, Blake2bWrite, Challenge255};
+use halo2_proofs::transcript::{blake2b::Blake2bRead, blake2b::Blake2bWrite, Challenge255};
 use rand_core::OsRng;
 use std::marker::PhantomData;
 


### PR DESCRIPTION
This PR adds a new transcript with poseidon hasher. It also moves blake2b transcript to `::transcript::blake2b`  and the new one is implemented at `::transcript::poseidon`. Poseidon transcript depends on [appliedzkp/poseidon](https://github.com/appliedzkp/poseidon/pull/2).

In poseidon transcript prefix contribution is avoided in order to save some space in the circuit implementation. I'm not really sure if this change would introduce some security issues. Because of that status of the PR remains as draft.

And the other alteration is that with `LimbRepresentation` strategy points are added to the state as `(limbs_of_x, sign_of_y)` to reduce cost of adding more limbs of the `y` coordinate. Basically it should be similar with the compressed form of the point.

`NativeRepresentation` strategy assumes that there are no two points `P_0 = (x_0, y_0)` and `P_1 = (x_1, y_1)` where `(x_0 ==  x_1) % scalar_field_modulus` and  `(y_0 ==  y_1) % scalar_field_modulus`. This approach basically reduces contribution of a coordinate to a single element which would be great improvement for circuit side. However assumption might be wrong and should not be used until it's proven.

(Comments are updated @therealyingtong)