### PR TITLE
Introduce `Expression::Challenge` as extra randomness for custom gates

### DIFF
--- a/halo2_proofs/examples/shuffle.rs
+++ b/halo2_proofs/examples/shuffle.rs
@@ -1,0 +1,328 @@
+use ff::BatchInvert;
+use halo2_proofs::{
+    arithmetic::{FieldExt, MultiMillerLoop},
+    circuit::{Layouter, SimpleFloorPlanner},
+    dev::{MockProver, VerifyFailure},
+    plonk::*,
+    poly::{
+        commitment::{Params, ParamsVerifier},
+        Rotation,
+    },
+    transcript::{Blake2bRead, Blake2bWrite, Challenge255},
+};
+use pairing::bn256::Bn256;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand_core::OsRng;
+use std::{iter, marker::PhantomData};
+
+fn rand_2d_array<F: FieldExt, R: Rng, const W: usize, const H: usize>(rng: &mut R) -> [[F; H]; W] {
+    [(); W].map(|_| [(); H].map(|_| F::random(&mut *rng)))
+}
+
+fn shuffled<F: FieldExt, R: Rng, const W: usize, const H: usize>(
+    original: [[F; H]; W],
+    rng: &mut R,
+) -> [[F; H]; W] {
+    let mut shuffled = original;
+
+    for row in (1..H).rev() {
+        let rand_row = rng.gen_range(0..=row);
+        for column in shuffled.iter_mut() {
+            column.swap(row, rand_row);
+        }
+    }
+
+    shuffled
+}
+
+#[derive(Clone)]
+struct MyConfig<F, const W: usize> {
+    q_shuffle: Selector,
+    q_first: Selector,
+    q_last: Selector,
+    original: [Column<Advice>; W],
+    shuffled: [Column<Advice>; W],
+    theta: Challenge,
+    gamma: Challenge,
+    z: Column<Advice>,
+    _marker: PhantomData<F>,
+}
+
+impl<F: FieldExt, const W: usize> MyConfig<F, W> {
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self {
+        // Round 0
+        let [q_shuffle, q_first, q_last] = [(); 3].map(|_| meta.selector());
+        // Round 1
+        let original = [(); W].map(|_| meta.advice_column());
+        let shuffled = [(); W].map(|_| meta.advice_column());
+        let [theta, gamma] = [(); 2].map(|_| meta.challenge());
+        // Round 2
+        let z = meta.advice_column();
+
+        meta.create_gate("z should start with 1", |meta| {
+            let q_first = meta.query_selector(q_first);
+            let z = meta.query_advice(z, Rotation::cur());
+            let one = Expression::Constant(F::one());
+
+            vec![q_first * (one - z)]
+        });
+
+        meta.create_gate("z should end with 1", |meta| {
+            let q_last = meta.query_selector(q_last);
+            let z = meta.query_advice(z, Rotation::cur());
+            let one = Expression::Constant(F::one());
+
+            vec![q_last * (one - z)]
+        });
+
+        meta.create_gate("z should have valid transition", |meta| {
+            let q_shuffle = meta.query_selector(q_shuffle);
+            let original = original.map(|advice| meta.query_advice(advice, Rotation::cur()));
+            let shuffled = shuffled.map(|advice| meta.query_advice(advice, Rotation::cur()));
+            let [theta, gamma] = [theta, gamma].map(|challenge| meta.query_challenge(challenge));
+            let [z, z_w] =
+                [Rotation::cur(), Rotation::next()].map(|rotation| meta.query_advice(z, rotation));
+
+            // compress
+            let original = original
+                .iter()
+                .cloned()
+                .reduce(|acc, a| acc * theta.clone() + a)
+                .unwrap();
+            let shuffled = shuffled
+                .iter()
+                .cloned()
+                .reduce(|acc, a| acc * theta.clone() + a)
+                .unwrap();
+
+            vec![q_shuffle * (z * (original + gamma.clone()) - z_w * (shuffled + gamma))]
+        });
+
+        Self {
+            q_shuffle,
+            q_first,
+            q_last,
+            original,
+            shuffled,
+            theta,
+            gamma,
+            z,
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+struct MyCircuit<F: FieldExt, const W: usize, const H: usize> {
+    original: Option<[[F; H]; W]>,
+    shuffled: Option<[[F; H]; W]>,
+}
+
+impl<F: FieldExt, const W: usize, const H: usize> MyCircuit<F, W, H> {
+    fn rand<R: Rng>(rng: &mut R) -> Self {
+        let original = rand_2d_array::<F, _, W, H>(rng);
+        let shuffled = shuffled(original, rng);
+
+        Self {
+            original: Some(original),
+            shuffled: Some(shuffled),
+        }
+    }
+}
+
+impl<F: FieldExt, const W: usize, const H: usize> Circuit<F> for MyCircuit<F, W, H> {
+    type Config = MyConfig<F, W>;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        MyConfig::configure(meta)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        layouter.assign_region(
+            || "Shuffle original into shuffled",
+            |mut region| {
+                // Keygen (Round 0)
+                config.q_first.enable(&mut region, 0)?;
+                config.q_last.enable(&mut region, H)?;
+                for offset in 0..H {
+                    config.q_shuffle.enable(&mut region, offset)?;
+                }
+
+                // Round 1
+                if let (Some(original), Some(shuffled)) = (&self.original, &self.shuffled) {
+                    for (idx, (&column, value)) in
+                        config.original.iter().zip(original.iter()).enumerate()
+                    {
+                        for (offset, &value) in value.iter().enumerate() {
+                            region.assign_advice(
+                                || format!("original[{}]", idx),
+                                column,
+                                offset,
+                                || Ok(value),
+                            )?;
+                        }
+                    }
+                    for (idx, (&column, value)) in
+                        config.shuffled.iter().zip(shuffled.iter()).enumerate()
+                    {
+                        for (offset, &value) in value.iter().enumerate() {
+                            region.assign_advice(
+                                || format!("shuffled[{}]", idx),
+                                column,
+                                offset,
+                                || Ok(value),
+                            )?;
+                        }
+                    }
+                }
+
+                // Round 2
+                if let (Some(theta), Some(gamma), Some(original), Some(shuffled)) = (
+                    region.query_challenge(config.theta)?,
+                    region.query_challenge(config.gamma)?,
+                    &self.original,
+                    &self.shuffled,
+                ) {
+                    let mut product = vec![F::zero(); H];
+                    for (idx, product) in product.iter_mut().enumerate() {
+                        let mut compressed = F::zero();
+                        for value in shuffled.iter() {
+                            compressed *= theta;
+                            compressed += value[idx];
+                        }
+
+                        *product = compressed + gamma
+                    }
+
+                    product.iter_mut().batch_invert();
+
+                    for (idx, product) in product.iter_mut().enumerate() {
+                        let mut compressed = F::zero();
+                        for value in original.iter() {
+                            compressed *= theta;
+                            compressed += value[idx];
+                        }
+
+                        *product *= compressed + gamma
+                    }
+
+                    let z = iter::once(F::one())
+                        .chain(product)
+                        .scan(F::one(), |state, cur| {
+                            *state *= &cur;
+                            Some(*state)
+                        })
+                        .take(H + 1)
+                        .collect::<Vec<_>>();
+
+                    #[cfg(feature = "sanity-checks")]
+                    assert_eq!(F::one(), *z.last().unwrap());
+
+                    for (offset, &value) in z.iter().enumerate() {
+                        region.assign_advice(|| "Grand product", config.z, offset, || Ok(value))?;
+                    }
+                }
+
+                Ok(())
+            },
+        )
+    }
+}
+
+fn test_mock_prover<F: FieldExt, const W: usize, const H: usize>(
+    k: u32,
+    circuit: MyCircuit<F, W, H>,
+    expected: Result<(), Vec<VerifyFailure>>,
+) {
+    let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+    assert_eq!(prover.verify(), expected);
+}
+
+fn test_prover<C: MultiMillerLoop, const W: usize, const H: usize>(
+    k: u32,
+    circuit: MyCircuit<C::Scalar, W, H>,
+    expected: bool,
+) {
+    let params: Params<C::G1Affine> = Params::<C::G1Affine>::unsafe_setup::<C>(k);
+    let params_verifier: ParamsVerifier<C> = params.verifier(0).unwrap();
+
+    let vk = keygen_vk(&params, &MyCircuit::<C::Scalar, W, H>::default()).unwrap();
+    let pk = keygen_pk(&params, vk, &MyCircuit::<C::Scalar, W, H>::default()).unwrap();
+
+    let proof = {
+        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+
+        create_proof(&params, &pk, &[circuit], &[&[]], OsRng, &mut transcript)
+            .expect("proof generation should not fail");
+
+        transcript.finalize()
+    };
+
+    let accepted = {
+        let strategy = SingleVerifier::new(&params_verifier);
+        let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+
+        verify_proof(
+            &params_verifier,
+            pk.get_vk(),
+            strategy,
+            &[&[]],
+            &mut transcript,
+        )
+        .is_ok()
+    };
+
+    assert_eq!(accepted, expected);
+}
+
+fn main() {
+    const W: usize = 4;
+    const H: usize = 32;
+    const K: u32 = 8;
+
+    let mut rng = StdRng::from_seed([
+        5, 77, 48, 115, 120, 129, 86, 16, 166, 157, 124, 134, 199, 233, 248, 174, //
+        105, 136, 137, 241, 61, 39, 252, 57, 31, 208, 170, 133, 166, 169, 184, 11,
+    ]);
+    let circuit = &MyCircuit::<_, W, H>::rand(&mut rng);
+
+    {
+        test_mock_prover(K, circuit.clone(), Ok(()));
+        test_prover::<Bn256, W, H>(K, circuit.clone(), true);
+    }
+
+    #[cfg(not(feature = "sanity-checks"))]
+    {
+        use halo2_proofs::dev::FailureLocation;
+        use std::ops::IndexMut;
+
+        let mut circuit = circuit.clone();
+        circuit.shuffled.as_mut().unwrap().index_mut(0).swap(0, 1);
+
+        test_mock_prover(
+            K,
+            circuit.clone(),
+            Err(vec![VerifyFailure::ConstraintNotSatisfied {
+                constraint: ((1, "z should end with 1").into(), 0, "").into(),
+                location: FailureLocation::InRegion {
+                    region: (0, "Shuffle original into shuffled").into(),
+                    offset: 32,
+                },
+                cell_values: vec![(
+                    ((Any::Advice, 8).into(), 0).into(),
+                    "0x608d5ce5ebdeff516eb21e242ed4926777f1675c883438a84a94d859fb93907".to_string(),
+                )],
+            }]),
+        );
+        test_prover::<Bn256, W, H>(K, circuit, false);
+    }
+}

--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -6,7 +6,9 @@ use ff::Field;
 
 use crate::{
     arithmetic::FieldExt,
-    plonk::{Advice, Any, Assigned, Column, Error, Fixed, Instance, Selector, TableColumn},
+    plonk::{
+        Advice, Any, Assigned, Challenge, Column, Error, Fixed, Instance, Selector, TableColumn,
+    },
 };
 
 pub mod floor_planner;
@@ -333,6 +335,11 @@ impl<'r, F: Field> Region<'r, F> {
     /// has not been enabled.
     pub fn constrain_equal(&mut self, left: Cell, right: Cell) -> Result<(), Error> {
         self.region.constrain_equal(left, right)
+    }
+
+    /// Query challenge.
+    pub fn query_challenge(&mut self, challenge: Challenge) -> Result<Option<F>, Error> {
+        self.region.query_challenge(challenge)
     }
 }
 

--- a/halo2_proofs/src/circuit/floor_planner/single_pass.rs
+++ b/halo2_proofs/src/circuit/floor_planner/single_pass.rs
@@ -11,8 +11,8 @@ use crate::{
         Cell, Layouter, Region, RegionIndex, RegionStart, Table,
     },
     plonk::{
-        Advice, Any, Assigned, Assignment, Circuit, Column, Error, Fixed, FloorPlanner, Instance,
-        Selector, TableColumn,
+        Advice, Any, Assigned, Assignment, Challenge, Circuit, Column, Error, Fixed, FloorPlanner,
+        Instance, Selector, TableColumn,
     },
 };
 
@@ -368,6 +368,10 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F>
         )?;
 
         Ok(())
+    }
+
+    fn query_challenge(&mut self, challenge: Challenge) -> Result<Option<F>, Error> {
+        self.layouter.cs.query_challenge(challenge)
     }
 }
 

--- a/halo2_proofs/src/circuit/floor_planner/v1.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1.rs
@@ -9,8 +9,8 @@ use crate::{
         Cell, Layouter, Region, RegionIndex, RegionStart, Table,
     },
     plonk::{
-        Advice, Any, Assigned, Assignment, Circuit, Column, Error, Fixed, FloorPlanner, Instance,
-        Selector, TableColumn,
+        Advice, Any, Assigned, Assignment, Challenge, Circuit, Column, Error, Fixed, FloorPlanner,
+        Instance, Selector, TableColumn,
     },
 };
 
@@ -484,6 +484,10 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F> for V1Region<'r
         )?;
 
         Ok(())
+    }
+
+    fn query_challenge(&mut self, challenge: Challenge) -> Result<Option<F>, Error> {
+        self.plan.cs.query_challenge(challenge)
     }
 }
 

--- a/halo2_proofs/src/circuit/layouter.rs
+++ b/halo2_proofs/src/circuit/layouter.rs
@@ -7,7 +7,9 @@ use std::fmt;
 use ff::Field;
 
 use super::{Cell, RegionIndex};
-use crate::plonk::{Advice, Any, Assigned, Column, Error, Fixed, Instance, Selector, TableColumn};
+use crate::plonk::{
+    Advice, Any, Assigned, Challenge, Column, Error, Fixed, Instance, Selector, TableColumn,
+};
 
 /// Helper trait for implementing a custom [`Layouter`].
 ///
@@ -102,6 +104,11 @@ pub trait RegionLayouter<F: Field>: fmt::Debug {
     ///
     /// Returns an error if either of the cells is not within the given permutation.
     fn constrain_equal(&mut self, left: Cell, right: Cell) -> Result<(), Error>;
+
+    /// Query challenge.
+    ///
+    /// Returns the challange's value, if known.
+    fn query_challenge(&mut self, challenge: Challenge) -> Result<Option<F>, Error>;
 }
 
 /// Helper trait for implementing a custom [`Layouter`].
@@ -283,5 +290,9 @@ impl<F: Field> RegionLayouter<F> for RegionShape {
     fn constrain_equal(&mut self, _left: Cell, _right: Cell) -> Result<(), Error> {
         // Equality constraints don't affect the region shape.
         Ok(())
+    }
+
+    fn query_challenge(&mut self, _: Challenge) -> Result<Option<F>, Error> {
+        Ok(Some(F::zero()))
     }
 }

--- a/halo2_proofs/src/dev/cost.rs
+++ b/halo2_proofs/src/dev/cost.rs
@@ -12,8 +12,8 @@ use group::prime::PrimeGroup;
 
 use crate::{
     plonk::{
-        Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
-        FloorPlanner, Instance, Selector,
+        Advice, Any, Assigned, Assignment, Challenge, Circuit, Column, ConstraintSystem, Error,
+        Fixed, FloorPlanner, Instance, Selector,
     },
     poly::Rotation,
 };
@@ -70,6 +70,10 @@ impl<F: Field> Assignment<F> for Assembly {
 
     fn query_instance(&self, _: Column<Instance>, _: usize) -> Result<Option<F>, Error> {
         Ok(None)
+    }
+
+    fn query_challenge(&self, _: Challenge) -> Result<Option<F>, Error> {
+        Ok(Some(F::zero()))
     }
 
     fn assign_advice<V, VR, A, AR>(

--- a/halo2_proofs/src/dev/gates.rs
+++ b/halo2_proofs/src/dev/gates.rs
@@ -122,6 +122,7 @@ impl CircuitGates {
                             &|_, column, rotation| format!("F{}@{}", column, rotation.0),
                             &|_, column, rotation| format!("A{}@{}", column, rotation.0),
                             &|_, column, rotation| format!("I{}@{}", column, rotation.0),
+                            &|round, index| format!("C{}@{}", round, index),
                             &|a| {
                                 if a.contains(' ') {
                                     format!("-({})", a)
@@ -168,6 +169,7 @@ impl CircuitGates {
                                     .into_iter()
                                     .collect()
                             },
+                            &|_, _| BTreeSet::default(),
                             &|a| a,
                             &|mut a, mut b| {
                                 a.append(&mut b);
@@ -195,6 +197,7 @@ impl CircuitGates {
                         &|_, _, _| (0, 0, 0),
                         &|_, _, _| (0, 0, 0),
                         &|_, _, _| (0, 0, 0),
+                        &|_, _| (0, 0, 0),
                         &|(a_n, a_a, a_m)| (a_n + 1, a_a, a_m),
                         &|(a_n, a_a, a_m), (b_n, b_a, b_m)| (a_n + b_n, a_a + b_a + 1, a_m + b_m),
                         &|(a_n, a_a, a_m), (b_n, b_a, b_m)| (a_n + b_n, a_a + b_a, a_m + b_m + 1),

--- a/halo2_proofs/src/dev/graph.rs
+++ b/halo2_proofs/src/dev/graph.rs
@@ -2,7 +2,7 @@ use ff::Field;
 use tabbycat::{AttrList, Edge, GraphBuilder, GraphType, Identity, StmtList};
 
 use crate::plonk::{
-    Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
+    Advice, Any, Assigned, Assignment, Challenge, Circuit, Column, ConstraintSystem, Error, Fixed,
     FloorPlanner, Instance, Selector,
 };
 
@@ -98,6 +98,10 @@ impl<F: Field> Assignment<F> for Graph {
 
     fn query_instance(&self, _: Column<Instance>, _: usize) -> Result<Option<F>, Error> {
         Ok(None)
+    }
+
+    fn query_challenge(&self, _: Challenge) -> Result<Option<F>, Error> {
+        Ok(Some(F::zero()))
     }
 
     fn assign_advice<V, VR, A, AR>(

--- a/halo2_proofs/src/dev/graph/layout.rs
+++ b/halo2_proofs/src/dev/graph/layout.rs
@@ -9,7 +9,7 @@ use std::ops::Range;
 
 use crate::circuit::layouter::RegionColumn;
 use crate::plonk::{
-    Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
+    Advice, Any, Assigned, Assignment, Challenge, Circuit, Column, ConstraintSystem, Error, Fixed,
     FloorPlanner, Instance, Selector,
 };
 
@@ -432,6 +432,10 @@ impl<F: Field> Assignment<F> for Layout {
 
     fn query_instance(&self, _: Column<Instance>, _: usize) -> Result<Option<F>, Error> {
         Ok(None)
+    }
+
+    fn query_challenge(&self, _: Challenge) -> Result<Option<F>, Error> {
+        Ok(Some(F::zero()))
     }
 
     fn assign_advice<V, VR, A, AR>(

--- a/halo2_proofs/src/dev/util.rs
+++ b/halo2_proofs/src/dev/util.rs
@@ -68,6 +68,7 @@ pub(super) fn cell_values<'a, F: FieldExt>(
         &cell_value(virtual_cells, Any::Fixed, load_fixed),
         &cell_value(virtual_cells, Any::Advice, load_advice),
         &cell_value(virtual_cells, Any::Instance, load_instance),
+        &|_, _| BTreeMap::default(),
         &|a| a,
         &|mut a, mut b| {
             a.append(&mut b);

--- a/halo2_proofs/src/plonk/circuit/compress_selectors.rs
+++ b/halo2_proofs/src/plonk/circuit/compress_selectors.rs
@@ -328,6 +328,7 @@ mod tests {
                         },
                         &|_, _, _| panic!("should not occur in returned expressions"),
                         &|_, _, _| panic!("should not occur in returned expressions"),
+                        &|_, _| panic!("should not occur in returned expressions"),
                         &|a| -a,
                         &|a, b| a + b,
                         &|a, b| a * b,

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -10,7 +10,7 @@ use super::{
         Advice, Any, Assignment, Circuit, Column, ConstraintSystem, Fixed, FloorPlanner, Instance,
         Selector,
     },
-    permutation, Assigned, Error, LagrangeCoeff, Polynomial, ProvingKey, VerifyingKey,
+    permutation, Assigned, Challenge, Error, LagrangeCoeff, Polynomial, ProvingKey, VerifyingKey,
 };
 use crate::poly::{
     commitment::{Blind, Params},
@@ -85,6 +85,10 @@ impl<F: Field> Assignment<F> for Assembly<F> {
 
         // There is no instance in this context.
         Ok(None)
+    }
+
+    fn query_challenge(&self, _: Challenge) -> Result<Option<F>, Error> {
+        Ok(Some(F::zero()))
     }
 
     fn assign_advice<V, VR, A, AR>(

--- a/halo2_proofs/src/plonk/lookup/prover.rs
+++ b/halo2_proofs/src/plonk/lookup/prover.rs
@@ -87,6 +87,7 @@ impl<F: FieldExt> Argument<F> {
         advice_cosets: &'a [poly::AstLeaf<Ec, ExtendedLagrangeCoeff>],
         fixed_cosets: &'a [poly::AstLeaf<Ec, ExtendedLagrangeCoeff>],
         instance_cosets: &'a [poly::AstLeaf<Ec, ExtendedLagrangeCoeff>],
+        challenge: &'a [Vec<C::Scalar>],
         mut rng: R,
         transcript: &mut T,
     ) -> Result<Permuted<C, Ec>, Error>
@@ -112,6 +113,9 @@ impl<F: FieldExt> Argument<F> {
                         &|_, column_index, rotation| {
                             instance_values[column_index].with_rotation(rotation).into()
                         },
+                        &|round_index, index| {
+                            poly::Ast::ConstantTerm(challenge[round_index][index])
+                        },
                         &|a| -a,
                         &|a, b| a + b,
                         &|a, b| a * b,
@@ -134,6 +138,9 @@ impl<F: FieldExt> Argument<F> {
                         },
                         &|_, column_index, rotation| {
                             instance_cosets[column_index].with_rotation(rotation).into()
+                        },
+                        &|round_index, index| {
+                            poly::Ast::ConstantTerm(challenge[round_index][index])
                         },
                         &|a| -a,
                         &|a, b| a + b,

--- a/halo2_proofs/src/plonk/lookup/verifier.rs
+++ b/halo2_proofs/src/plonk/lookup/verifier.rs
@@ -102,6 +102,7 @@ impl<C: CurveAffine> Evaluated<C> {
         advice_evals: &[C::Scalar],
         fixed_evals: &[C::Scalar],
         instance_evals: &[C::Scalar],
+        challenges: &[Vec<C::Scalar>],
     ) -> impl Iterator<Item = C::Scalar> + 'a {
         let active_rows = C::Scalar::one() - (l_last + l_blind);
 
@@ -122,6 +123,7 @@ impl<C: CurveAffine> Evaluated<C> {
                             &|index, _, _| fixed_evals[index],
                             &|index, _, _| advice_evals[index],
                             &|index, _, _| instance_evals[index],
+                            &|round_index, index| challenges[round_index][index],
                             &|a| -a,
                             &|a, b| a + &b,
                             &|a, b| a * &b,

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -136,145 +136,132 @@ pub fn create_proof<
         _marker: std::marker::PhantomData<F>,
     }
 
-    {
+    impl<'a, F: Field> Assignment<F> for WitnessCollection<'a, F> {
+        fn enter_region<NR, N>(&mut self, _: N)
+        where
+            NR: Into<String>,
+            N: FnOnce() -> NR,
         {
-            impl<'a, F: Field> Assignment<F> for WitnessCollection<'a, F> {
-                fn enter_region<NR, N>(&mut self, _: N)
-                where
-                    NR: Into<String>,
-                    N: FnOnce() -> NR,
-                {
-                    // Do nothing; we don't care about regions in this context.
-                }
+            // Do nothing; we don't care about regions in this context.
+        }
 
-                fn exit_region(&mut self) {
-                    // Do nothing; we don't care about regions in this context.
-                }
+        fn exit_region(&mut self) {
+            // Do nothing; we don't care about regions in this context.
+        }
 
-                fn enable_selector<A, AR>(
-                    &mut self,
-                    _: A,
-                    _: &Selector,
-                    _: usize,
-                ) -> Result<(), Error>
-                where
-                    A: FnOnce() -> AR,
-                    AR: Into<String>,
-                {
-                    // We only care about advice columns here
+        fn enable_selector<A, AR>(&mut self, _: A, _: &Selector, _: usize) -> Result<(), Error>
+        where
+            A: FnOnce() -> AR,
+            AR: Into<String>,
+        {
+            // We only care about advice columns here
 
-                    Ok(())
-                }
+            Ok(())
+        }
 
-                fn query_instance(
-                    &self,
-                    column: Column<Instance>,
-                    row: usize,
-                ) -> Result<Option<F>, Error> {
-                    if !self.usable_rows.contains(&row) {
-                        return Err(Error::not_enough_rows_available(self.k));
-                    }
-
-                    self.instances
-                        .get(column.index())
-                        .and_then(|column| column.get(row))
-                        .map(|v| Some(*v))
-                        .ok_or(Error::BoundsFailure)
-                }
-
-                fn query_challenge(&self, challenge: Challenge) -> Result<Option<F>, Error> {
-                    if challenge.round_index() < self.current_round {
-                        self.challenges
-                            .get(challenge.round_index())
-                            .and_then(|challenges| challenges.get(challenge.index()))
-                            .map(|v| Some(*v))
-                            .ok_or(Error::BoundsFailure)
-                    } else {
-                        Ok(None)
-                    }
-                }
-
-                fn assign_advice<V, VR, A, AR>(
-                    &mut self,
-                    _: A,
-                    column: Column<Advice>,
-                    row: usize,
-                    to: V,
-                ) -> Result<(), Error>
-                where
-                    V: FnOnce() -> Result<VR, Error>,
-                    VR: Into<Assigned<F>>,
-                    A: FnOnce() -> AR,
-                    AR: Into<String>,
-                {
-                    if column.index() < self.current_advice_start {
-                        return Ok(());
-                    }
-
-                    if !self.usable_rows.contains(&row) {
-                        return Err(Error::not_enough_rows_available(self.k));
-                    }
-
-                    *self
-                        .advice
-                        .get_mut(column.index())
-                        .and_then(|v| v.get_mut(row))
-                        .ok_or(Error::BoundsFailure)? = to()?.into();
-
-                    Ok(())
-                }
-
-                fn assign_fixed<V, VR, A, AR>(
-                    &mut self,
-                    _: A,
-                    _: Column<Fixed>,
-                    _: usize,
-                    _: V,
-                ) -> Result<(), Error>
-                where
-                    V: FnOnce() -> Result<VR, Error>,
-                    VR: Into<Assigned<F>>,
-                    A: FnOnce() -> AR,
-                    AR: Into<String>,
-                {
-                    // We only care about advice columns here
-
-                    Ok(())
-                }
-
-                fn copy(
-                    &mut self,
-                    _: Column<Any>,
-                    _: usize,
-                    _: Column<Any>,
-                    _: usize,
-                ) -> Result<(), Error> {
-                    // We only care about advice columns here
-
-                    Ok(())
-                }
-
-                fn fill_from_row(
-                    &mut self,
-                    _: Column<Fixed>,
-                    _: usize,
-                    _: Option<Assigned<F>>,
-                ) -> Result<(), Error> {
-                    Ok(())
-                }
-
-                fn push_namespace<NR, N>(&mut self, _: N)
-                where
-                    NR: Into<String>,
-                    N: FnOnce() -> NR,
-                {
-                    // Do nothing; we don't care about namespaces in this context.
-                }
-
-                fn pop_namespace(&mut self, _: Option<String>) {
-                    // Do nothing; we don't care about namespaces in this context.
-                }
+        fn query_instance(&self, column: Column<Instance>, row: usize) -> Result<Option<F>, Error> {
+            if !self.usable_rows.contains(&row) {
+                return Err(Error::not_enough_rows_available(self.k));
             }
+
+            self.instances
+                .get(column.index())
+                .and_then(|column| column.get(row))
+                .map(|v| Some(*v))
+                .ok_or(Error::BoundsFailure)
+        }
+
+        fn query_challenge(&self, challenge: Challenge) -> Result<Option<F>, Error> {
+            if challenge.round_index() < self.current_round {
+                self.challenges
+                    .get(challenge.round_index())
+                    .and_then(|challenges| challenges.get(challenge.index()))
+                    .map(|v| Some(*v))
+                    .ok_or(Error::BoundsFailure)
+            } else {
+                Ok(None)
+            }
+        }
+
+        fn assign_advice<V, VR, A, AR>(
+            &mut self,
+            _: A,
+            column: Column<Advice>,
+            row: usize,
+            to: V,
+        ) -> Result<(), Error>
+        where
+            V: FnOnce() -> Result<VR, Error>,
+            VR: Into<Assigned<F>>,
+            A: FnOnce() -> AR,
+            AR: Into<String>,
+        {
+            if column.index() < self.current_advice_start {
+                return Ok(());
+            }
+
+            if !self.usable_rows.contains(&row) {
+                return Err(Error::not_enough_rows_available(self.k));
+            }
+
+            *self
+                .advice
+                .get_mut(column.index())
+                .and_then(|v| v.get_mut(row))
+                .ok_or(Error::BoundsFailure)? = to()?.into();
+
+            Ok(())
+        }
+
+        fn assign_fixed<V, VR, A, AR>(
+            &mut self,
+            _: A,
+            _: Column<Fixed>,
+            _: usize,
+            _: V,
+        ) -> Result<(), Error>
+        where
+            V: FnOnce() -> Result<VR, Error>,
+            VR: Into<Assigned<F>>,
+            A: FnOnce() -> AR,
+            AR: Into<String>,
+        {
+            // We only care about advice columns here
+
+            Ok(())
+        }
+
+        fn copy(
+            &mut self,
+            _: Column<Any>,
+            _: usize,
+            _: Column<Any>,
+            _: usize,
+        ) -> Result<(), Error> {
+            // We only care about advice columns here
+
+            Ok(())
+        }
+
+        fn fill_from_row(
+            &mut self,
+            _: Column<Fixed>,
+            _: usize,
+            _: Option<Assigned<F>>,
+        ) -> Result<(), Error> {
+            Ok(())
+        }
+
+        fn push_namespace<NR, N>(&mut self, _: N)
+        where
+            NR: Into<String>,
+            N: FnOnce() -> NR,
+        {
+            // Do nothing; we don't care about namespaces in this context.
+        }
+
+        fn pop_namespace(&mut self, _: Option<String>) {
+            // Do nothing; we don't care about namespaces in this context.
         }
     }
 


### PR DESCRIPTION
This PR aims to prototype the multi-round support for `halo2` and allow allocation of extra randomness. Some potential usages can be found zcash/halo2#527.

The main change can be found in [`3d4ee6b`](https://github.com/appliedzkp/halo2/commit/3d4ee6b79b2246b9ca0a21a924c88cd7c9023d24), and it does some breaking changes including:

1. Introduce variant `Expression::Challenge`
2. Introduce method `ConstraintSystem::challenge` and field `rounds`, and the `ConstraintSystem::advice_column` will start a new round if any challenge has been allocated.
3. Introduce trait method `Assignment::query_challenge` for layouter to query challenge.
4. Introduce trait method `RegionLayouter::query_challenge` for circuit to query challenge when `synthesize`.

Also the `create_proof` is updated to call `ConcreteCircuit::FloorPlanner::synthesize` multiple rounds to collect witness at that round, and squeeze extra challenges for further rounds.

For `MockProver`, since everything is done in one round, so challenges are pre-generated with fixed seed, to make failure testing cases to fail on the same values.