### PR TITLE
Optional zero-knowledge by const generic

### DIFF
--- a/halo2_gadgets/benches/poseidon.rs
+++ b/halo2_gadgets/benches/poseidon.rs
@@ -32,6 +32,8 @@ use halo2_proofs::{
     transcript::{TranscriptReadBuffer, TranscriptWriterBuffer},
 };
 
+const ZK: bool = true;
+
 #[derive(Clone, Copy)]
 struct HashCircuit<S, const WIDTH: usize, const RATE: usize, const L: usize>
 where
@@ -204,8 +206,9 @@ fn bench_poseidon<S, const WIDTH: usize, const RATE: usize, const L: usize>(
     };
 
     // Initialize the proving key
-    let vk = keygen_vk(&params, &empty_circuit).expect("keygen_vk should not fail");
-    let pk = keygen_pk(&params, vk, &empty_circuit).expect("keygen_pk should not fail");
+    let vk = keygen_vk::<_, _, _, ZK>(&params, &empty_circuit).expect("keygen_vk should not fail");
+    let pk =
+        keygen_pk::<_, _, _, ZK>(&params, vk, &empty_circuit).expect("keygen_pk should not fail");
 
     let prover_name = name.to_string() + "-prover";
     let verifier_name = name.to_string() + "-verifier";
@@ -228,7 +231,7 @@ fn bench_poseidon<S, const WIDTH: usize, const RATE: usize, const L: usize>(
         b.iter(|| {
             // Create a proof
             let mut transcript = Blake2bWrite::<_, EqAffine, Challenge255<_>>::init(vec![]);
-            create_proof::<IPACommitmentScheme<_>, ProverIPA<_>, _, _, _, _>(
+            create_proof::<IPACommitmentScheme<_>, ProverIPA<_>, _, _, _, _, ZK>(
                 &params,
                 &pk,
                 &[circuit],
@@ -242,7 +245,7 @@ fn bench_poseidon<S, const WIDTH: usize, const RATE: usize, const L: usize>(
 
     // Create a proof
     let mut transcript = Blake2bWrite::<_, EqAffine, Challenge255<_>>::init(vec![]);
-    create_proof::<IPACommitmentScheme<_>, ProverIPA<_>, _, _, _, _>(
+    create_proof::<IPACommitmentScheme<_>, ProverIPA<_>, _, _, _, _, ZK>(
         &params,
         &pk,
         &[circuit],
@@ -257,7 +260,14 @@ fn bench_poseidon<S, const WIDTH: usize, const RATE: usize, const L: usize>(
         b.iter(|| {
             let strategy = SingleStrategy::new(&params);
             let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
-            assert!(verify_proof(&params, pk.get_vk(), strategy, &[&[]], &mut transcript).is_ok());
+            assert!(verify_proof::<_, _, _, _, _, ZK>(
+                &params,
+                pk.get_vk(),
+                strategy,
+                &[&[]],
+                &mut transcript
+            )
+            .is_ok());
         });
     });
 }

--- a/halo2_gadgets/benches/sha256.rs
+++ b/halo2_gadgets/benches/sha256.rs
@@ -29,6 +29,8 @@ use halo2_proofs::{
     transcript::{TranscriptReadBuffer, TranscriptWriterBuffer},
 };
 
+const ZK: bool = true;
+
 #[allow(dead_code)]
 fn bench(name: &str, k: u32, c: &mut Criterion) {
     #[derive(Default)]
@@ -106,8 +108,9 @@ fn bench(name: &str, k: u32, c: &mut Criterion) {
     let empty_circuit: MyCircuit = MyCircuit {};
 
     // Initialize the proving key
-    let vk = keygen_vk(&params, &empty_circuit).expect("keygen_vk should not fail");
-    let pk = keygen_pk(&params, vk, &empty_circuit).expect("keygen_pk should not fail");
+    let vk = keygen_vk::<_, _, _, ZK>(&params, &empty_circuit).expect("keygen_vk should not fail");
+    let pk =
+        keygen_pk::<_, _, _, ZK>(&params, vk, &empty_circuit).expect("keygen_pk should not fail");
 
     let circuit: MyCircuit = MyCircuit {};
 
@@ -128,7 +131,7 @@ fn bench(name: &str, k: u32, c: &mut Criterion) {
     let proof_path = Path::new("./benches/sha256_assets/sha256_proof");
     if File::open(&proof_path).is_err() {
         let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
-        create_proof::<IPACommitmentScheme<_>, ProverIPA<_>, _, _, _, _>(
+        create_proof::<IPACommitmentScheme<_>, ProverIPA<_>, _, _, _, _, ZK>(
             &params,
             &pk,
             &[circuit],
@@ -153,7 +156,7 @@ fn bench(name: &str, k: u32, c: &mut Criterion) {
             use halo2_proofs::poly::VerificationStrategy;
             let strategy = AccumulatorStrategy::new(&params);
             let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
-            let strategy = verify_proof::<IPACommitmentScheme<_>, VerifierIPA<_>, _, _, _>(
+            let strategy = verify_proof::<IPACommitmentScheme<_>, VerifierIPA<_>, _, _, _, ZK>(
                 &params,
                 pk.get_vk(),
                 strategy,

--- a/halo2_gadgets/src/ecc.rs
+++ b/halo2_gadgets/src/ecc.rs
@@ -895,9 +895,11 @@ pub(crate) mod tests {
 
     #[test]
     fn ecc_chip() {
+        const ZK: bool = true;
+
         let k = 13;
         let circuit = MyCircuit { test_errors: true };
-        let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+        let prover = MockProver::run::<_, ZK>(k, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()))
     }
 
@@ -906,13 +908,15 @@ pub(crate) mod tests {
     fn print_ecc_chip() {
         use plotters::prelude::*;
 
+        const ZK: bool = true;
+
         let root = BitMapBackend::new("ecc-chip-layout.png", (1024, 7680)).into_drawing_area();
         root.fill(&WHITE).unwrap();
         let root = root.titled("Ecc Chip Layout", ("sans-serif", 60)).unwrap();
 
         let circuit = MyCircuit { test_errors: false };
         halo2_proofs::dev::CircuitLayout::default()
-            .render(13, &circuit, &root)
+            .render::<_, _, _, ZK>(13, &circuit, &root)
             .unwrap();
     }
 }

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
@@ -403,6 +403,8 @@ pub mod tests {
         Ok(())
     }
 
+    const ZK: bool = true;
+
     #[test]
     fn invalid_magnitude_sign() {
         use crate::{
@@ -562,7 +564,7 @@ pub mod tests {
             ];
 
             for circuit in circuits.iter() {
-                let prover = MockProver::<pallas::Base>::run(11, circuit, vec![]).unwrap();
+                let prover = MockProver::<pallas::Base>::run::<_, ZK>(11, circuit, vec![]).unwrap();
                 circuit.magnitude_error.assert_if_known(|magnitude_error| {
                     assert_eq!(
                         prover.verify(),
@@ -620,7 +622,7 @@ pub mod tests {
                     .y()
             };
 
-            let prover = MockProver::<pallas::Base>::run(11, &circuit, vec![]).unwrap();
+            let prover = MockProver::<pallas::Base>::run::<_, ZK>(11, &circuit, vec![]).unwrap();
             assert_eq!(
                 prover.verify(),
                 Err(vec![

--- a/halo2_gadgets/src/poseidon/pow5.rs
+++ b/halo2_gadgets/src/poseidon/pow5.rs
@@ -711,9 +711,11 @@ mod tests {
 
     #[test]
     fn poseidon_permute() {
+        const ZK: bool = true;
+
         let k = 6;
         let circuit = PermuteCircuit::<OrchardNullifier, 3, 2>(PhantomData);
-        let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+        let prover = MockProver::run::<_, ZK>(k, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()))
     }
 
@@ -810,6 +812,8 @@ mod tests {
 
     #[test]
     fn poseidon_hash() {
+        const ZK: bool = true;
+
         let rng = OsRng;
 
         let message = [Fp::random(rng), Fp::random(rng)];
@@ -822,12 +826,14 @@ mod tests {
             output: Value::known(output),
             _spec: PhantomData,
         };
-        let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+        let prover = MockProver::run::<_, ZK>(k, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()))
     }
 
     #[test]
     fn poseidon_hash_longer_input() {
+        const ZK: bool = true;
+
         let rng = OsRng;
 
         let message = [Fp::random(rng), Fp::random(rng), Fp::random(rng)];
@@ -840,12 +846,14 @@ mod tests {
             output: Value::known(output),
             _spec: PhantomData,
         };
-        let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+        let prover = MockProver::run::<_, ZK>(k, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()))
     }
 
     #[test]
     fn hash_test_vectors() {
+        const ZK: bool = true;
+
         for tv in crate::poseidon::primitives::test_vectors::fp::hash() {
             let message = [
                 pallas::Base::from_repr(tv.input[0]).unwrap(),
@@ -860,7 +868,7 @@ mod tests {
                 output: Value::known(output),
                 _spec: PhantomData,
             };
-            let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+            let prover = MockProver::run::<_, ZK>(k, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), Ok(()));
         }
     }
@@ -869,6 +877,8 @@ mod tests {
     #[test]
     fn print_poseidon_chip() {
         use plotters::prelude::*;
+
+        const ZK: bool = true;
 
         let root = BitMapBackend::new("poseidon-chip-layout.png", (1024, 768)).into_drawing_area();
         root.fill(&WHITE).unwrap();
@@ -882,7 +892,7 @@ mod tests {
             _spec: PhantomData,
         };
         halo2_proofs::dev::CircuitLayout::default()
-            .render(6, &circuit, &root)
+            .render::<_, _, _, ZK>(6, &circuit, &root)
             .unwrap();
     }
 }

--- a/halo2_gadgets/src/sha256/table16.rs
+++ b/halo2_gadgets/src/sha256/table16.rs
@@ -460,6 +460,8 @@ mod tests {
     };
     use halo2curves::pasta::pallas;
 
+    const ZK: bool = true;
+
     #[test]
     fn print_sha256_circuit() {
         use plotters::prelude::*;
@@ -509,7 +511,7 @@ mod tests {
 
         let circuit = MyCircuit {};
         halo2_proofs::dev::CircuitLayout::default()
-            .render::<pallas::Base, _, _>(17, &circuit, &root)
+            .render::<pallas::Base, _, _, ZK>(17, &circuit, &root)
             .unwrap();
     }
 }

--- a/halo2_gadgets/src/sha256/table16/compression.rs
+++ b/halo2_gadgets/src/sha256/table16/compression.rs
@@ -947,6 +947,8 @@ mod tests {
     };
     use halo2curves::pasta::pallas;
 
+    const ZK: bool = true;
+
     #[test]
     fn compress() {
         struct MyCircuit {}
@@ -996,7 +998,7 @@ mod tests {
 
         let circuit: MyCircuit = MyCircuit {};
 
-        let prover = match MockProver::<pallas::Base>::run(17, &circuit, vec![]) {
+        let prover = match MockProver::<pallas::Base>::run::<_, ZK>(17, &circuit, vec![]) {
             Ok(prover) => prover,
             Err(e) => panic!("{:?}", e),
         };

--- a/halo2_gadgets/src/sha256/table16/message_schedule.rs
+++ b/halo2_gadgets/src/sha256/table16/message_schedule.rs
@@ -404,6 +404,8 @@ mod tests {
     };
     use halo2curves::pasta::pallas;
 
+    const ZK: bool = true;
+
     #[test]
     fn message_schedule() {
         struct MyCircuit {}
@@ -446,7 +448,7 @@ mod tests {
 
         let circuit: MyCircuit = MyCircuit {};
 
-        let prover = match MockProver::<pallas::Base>::run(17, &circuit, vec![]) {
+        let prover = match MockProver::<pallas::Base>::run::<_, ZK>(17, &circuit, vec![]) {
             Ok(prover) => prover,
             Err(e) => panic!("{:?}", e),
         };

--- a/halo2_gadgets/src/sha256/table16/spread_table.rs
+++ b/halo2_gadgets/src/sha256/table16/spread_table.rs
@@ -295,6 +295,8 @@ mod tests {
     };
     use halo2curves::pasta::Fp;
 
+    const ZK: bool = true;
+
     #[test]
     fn lookup_table() {
         /// This represents an advice column at a certain row in the ConstraintSystem
@@ -439,7 +441,7 @@ mod tests {
 
         let circuit: MyCircuit = MyCircuit {};
 
-        let prover = match MockProver::<Fp>::run(17, &circuit, vec![]) {
+        let prover = match MockProver::<Fp>::run::<_, ZK>(17, &circuit, vec![]) {
             Ok(prover) => prover,
             Err(e) => panic!("{:?}", e),
         };

--- a/halo2_gadgets/src/sinsemilla.rs
+++ b/halo2_gadgets/src/sinsemilla.rs
@@ -731,9 +731,11 @@ pub(crate) mod tests {
 
     #[test]
     fn sinsemilla_chip() {
+        const ZK: bool = true;
+
         let k = 11;
         let circuit = MyCircuit {};
-        let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+        let prover = MockProver::run::<_, ZK>(k, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()))
     }
 
@@ -742,6 +744,8 @@ pub(crate) mod tests {
     fn print_sinsemilla_chip() {
         use plotters::prelude::*;
 
+        const ZK: bool = true;
+
         let root =
             BitMapBackend::new("sinsemilla-hash-layout.png", (1024, 7680)).into_drawing_area();
         root.fill(&WHITE).unwrap();
@@ -749,7 +753,7 @@ pub(crate) mod tests {
 
         let circuit = MyCircuit {};
         halo2_proofs::dev::CircuitLayout::default()
-            .render(11, &circuit, &root)
+            .render::<_, _, _, ZK>(11, &circuit, &root)
             .unwrap();
     }
 }

--- a/halo2_gadgets/src/sinsemilla/merkle.rs
+++ b/halo2_gadgets/src/sinsemilla/merkle.rs
@@ -357,6 +357,8 @@ pub mod tests {
 
     #[test]
     fn merkle_chip() {
+        const ZK: bool = true;
+
         let mut rng = OsRng;
 
         // Choose a random leaf and position
@@ -376,7 +378,7 @@ pub mod tests {
             merkle_path: Value::known(path.try_into().unwrap()),
         };
 
-        let prover = MockProver::run(11, &circuit, vec![]).unwrap();
+        let prover = MockProver::run::<_, ZK>(11, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()))
     }
 
@@ -385,6 +387,8 @@ pub mod tests {
     fn print_merkle_chip() {
         use plotters::prelude::*;
 
+        const ZK: bool = true;
+
         let root = BitMapBackend::new("merkle-path-layout.png", (1024, 7680)).into_drawing_area();
         root.fill(&WHITE).unwrap();
         let root = root.titled("MerkleCRH Path", ("sans-serif", 60)).unwrap();
@@ -392,7 +396,7 @@ pub mod tests {
         let circuit = MyCircuit::default();
         halo2_proofs::dev::CircuitLayout::default()
             .show_labels(false)
-            .render(11, &circuit, &root)
+            .render::<_, _, _, ZK>(11, &circuit, &root)
             .unwrap();
     }
 }

--- a/halo2_gadgets/src/utilities.rs
+++ b/halo2_gadgets/src/utilities.rs
@@ -312,15 +312,17 @@ mod tests {
             }
         }
 
+        const ZK: bool = true;
+
         for i in 0..8 {
             let circuit: MyCircuit<8> = MyCircuit(i);
-            let prover = MockProver::<pallas::Base>::run(3, &circuit, vec![]).unwrap();
+            let prover = MockProver::<pallas::Base>::run::<_, ZK>(3, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), Ok(()));
         }
 
         {
             let circuit: MyCircuit<8> = MyCircuit(8);
-            let prover = MockProver::<pallas::Base>::run(3, &circuit, vec![]).unwrap();
+            let prover = MockProver::<pallas::Base>::run::<_, ZK>(3, &circuit, vec![]).unwrap();
             assert_eq!(
                 prover.verify(),
                 Err(vec![VerifyFailure::ConstraintNotSatisfied {

--- a/halo2_gadgets/src/utilities/cond_swap.rs
+++ b/halo2_gadgets/src/utilities/cond_swap.rs
@@ -266,6 +266,8 @@ mod tests {
             }
         }
 
+        const ZK: bool = true;
+
         let rng = OsRng;
 
         // Test swap case
@@ -275,7 +277,7 @@ mod tests {
                 b: Value::known(Base::random(rng)),
                 swap: Value::known(true),
             };
-            let prover = MockProver::<Base>::run(3, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run::<_, ZK>(3, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), Ok(()));
         }
 
@@ -286,7 +288,7 @@ mod tests {
                 b: Value::known(Base::random(rng)),
                 swap: Value::known(false),
             };
-            let prover = MockProver::<Base>::run(3, &circuit, vec![]).unwrap();
+            let prover = MockProver::<Base>::run::<_, ZK>(3, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), Ok(()));
         }
     }

--- a/halo2_gadgets/src/utilities/decompose_running_sum.rs
+++ b/halo2_gadgets/src/utilities/decompose_running_sum.rs
@@ -237,6 +237,8 @@ mod tests {
             strict: bool,
         }
 
+        const ZK: bool = true;
+
         impl<
                 F: FieldExt + PrimeFieldBits,
                 const WORD_NUM_BITS: usize,
@@ -309,7 +311,7 @@ mod tests {
                     alpha: Value::known(alpha),
                     strict: true,
                 };
-            let prover = MockProver::<pallas::Base>::run(8, &circuit, vec![]).unwrap();
+            let prover = MockProver::<pallas::Base>::run::<_, ZK>(8, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), Ok(()));
         }
 
@@ -327,7 +329,7 @@ mod tests {
                 alpha: Value::known(alpha),
                 strict: true,
             };
-            let prover = MockProver::<pallas::Base>::run(8, &circuit, vec![]).unwrap();
+            let prover = MockProver::<pallas::Base>::run::<_, ZK>(8, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), Ok(()));
         }
 
@@ -345,7 +347,7 @@ mod tests {
                 alpha: Value::known(alpha),
                 strict: true,
             };
-            let prover = MockProver::<pallas::Base>::run(8, &circuit, vec![]).unwrap();
+            let prover = MockProver::<pallas::Base>::run::<_, ZK>(8, &circuit, vec![]).unwrap();
             assert_eq!(
                 prover.verify(),
                 Err(vec![
@@ -384,7 +386,7 @@ mod tests {
                 alpha: Value::known(alpha),
                 strict: false,
             };
-            let prover = MockProver::<pallas::Base>::run(8, &circuit, vec![]).unwrap();
+            let prover = MockProver::<pallas::Base>::run::<_, ZK>(8, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), Ok(()));
         }
     }

--- a/halo2_gadgets/src/utilities/lookup_range_check.rs
+++ b/halo2_gadgets/src/utilities/lookup_range_check.rs
@@ -485,13 +485,15 @@ mod tests {
             }
         }
 
+        const ZK: bool = true;
+
         {
             let circuit: MyCircuit<pallas::Base> = MyCircuit {
                 num_words: 6,
                 _marker: PhantomData,
             };
 
-            let prover = MockProver::<pallas::Base>::run(11, &circuit, vec![]).unwrap();
+            let prover = MockProver::<pallas::Base>::run::<_, ZK>(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), Ok(()));
         }
     }
@@ -542,13 +544,15 @@ mod tests {
             }
         }
 
+        const ZK: bool = true;
+
         // Edge case: zero bits
         {
             let circuit: MyCircuit<pallas::Base> = MyCircuit {
                 element: Value::known(pallas::Base::zero()),
                 num_bits: 0,
             };
-            let prover = MockProver::<pallas::Base>::run(11, &circuit, vec![]).unwrap();
+            let prover = MockProver::<pallas::Base>::run::<_, ZK>(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), Ok(()));
         }
 
@@ -558,7 +562,7 @@ mod tests {
                 element: Value::known(pallas::Base::from((1 << K) - 1)),
                 num_bits: K,
             };
-            let prover = MockProver::<pallas::Base>::run(11, &circuit, vec![]).unwrap();
+            let prover = MockProver::<pallas::Base>::run::<_, ZK>(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), Ok(()));
         }
 
@@ -568,7 +572,7 @@ mod tests {
                 element: Value::known(pallas::Base::from((1 << 6) - 1)),
                 num_bits: 6,
             };
-            let prover = MockProver::<pallas::Base>::run(11, &circuit, vec![]).unwrap();
+            let prover = MockProver::<pallas::Base>::run::<_, ZK>(11, &circuit, vec![]).unwrap();
             assert_eq!(prover.verify(), Ok(()));
         }
 
@@ -578,7 +582,7 @@ mod tests {
                 element: Value::known(pallas::Base::from(1 << 6)),
                 num_bits: 6,
             };
-            let prover = MockProver::<pallas::Base>::run(11, &circuit, vec![]).unwrap();
+            let prover = MockProver::<pallas::Base>::run::<_, ZK>(11, &circuit, vec![]).unwrap();
             assert_eq!(
                 prover.verify(),
                 Err(vec![VerifyFailure::Lookup {
@@ -598,7 +602,7 @@ mod tests {
                 element: Value::known(pallas::Base::from(1 << K)),
                 num_bits: 6,
             };
-            let prover = MockProver::<pallas::Base>::run(11, &circuit, vec![]).unwrap();
+            let prover = MockProver::<pallas::Base>::run::<_, ZK>(11, &circuit, vec![]).unwrap();
             assert_eq!(
                 prover.verify(),
                 Err(vec![
@@ -637,7 +641,7 @@ mod tests {
                 element: Value::known(element),
                 num_bits: num_bits as usize,
             };
-            let prover = MockProver::<pallas::Base>::run(11, &circuit, vec![]).unwrap();
+            let prover = MockProver::<pallas::Base>::run::<_, ZK>(11, &circuit, vec![]).unwrap();
             assert_eq!(
                 prover.verify(),
                 Err(vec![VerifyFailure::Lookup {

--- a/halo2_proofs/benches/dev_lookup.rs
+++ b/halo2_proofs/benches/dev_lookup.rs
@@ -12,6 +12,8 @@ use std::marker::PhantomData;
 
 use criterion::{BenchmarkId, Criterion};
 
+const ZK: bool = true;
+
 fn criterion_benchmark(c: &mut Criterion) {
     #[derive(Clone, Default)]
     struct MyCircuit<F: FieldExt> {
@@ -94,7 +96,8 @@ fn criterion_benchmark(c: &mut Criterion) {
         let circuit = MyCircuit::<pallas::Base> {
             _marker: PhantomData,
         };
-        let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+
+        let prover = MockProver::run::<_, ZK>(k, &circuit, vec![]).unwrap();
         assert_eq!(prover.verify(), Ok(()))
     }
 

--- a/halo2_proofs/benches/plonk.rs
+++ b/halo2_proofs/benches/plonk.rs
@@ -26,6 +26,8 @@ use std::marker::PhantomData;
 
 use criterion::{BenchmarkId, Criterion};
 
+const ZK: bool = true;
+
 fn criterion_benchmark(c: &mut Criterion) {
     /// This represents an advice column at a certain row in the ConstraintSystem
     #[derive(Copy, Clone, Debug)]
@@ -271,8 +273,10 @@ fn criterion_benchmark(c: &mut Criterion) {
             a: Value::unknown(),
             k,
         };
-        let vk = keygen_vk(&params, &empty_circuit).expect("keygen_vk should not fail");
-        let pk = keygen_pk(&params, vk, &empty_circuit).expect("keygen_pk should not fail");
+        let vk =
+            keygen_vk::<_, _, _, ZK>(&params, &empty_circuit).expect("keygen_vk should not fail");
+        let pk = keygen_pk::<_, _, _, ZK>(&params, vk, &empty_circuit)
+            .expect("keygen_pk should not fail");
         (params, pk)
     }
 
@@ -285,7 +289,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         };
 
         let mut transcript = Blake2bWrite::<_, _, Challenge255<EqAffine>>::init(vec![]);
-        create_proof::<IPACommitmentScheme<EqAffine>, ProverIPA<EqAffine>, _, _, _, _>(
+        create_proof::<IPACommitmentScheme<EqAffine>, ProverIPA<EqAffine>, _, _, _, _, ZK>(
             params,
             pk,
             &[circuit],
@@ -300,7 +304,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     fn verifier(params: &ParamsIPA<EqAffine>, vk: &VerifyingKey<EqAffine>, proof: &[u8]) {
         let strategy = SingleStrategy::new(params);
         let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(proof);
-        assert!(verify_proof(params, vk, strategy, &[&[]], &mut transcript).is_ok());
+        assert!(
+            verify_proof::<_, _, _, _, _, ZK>(params, vk, strategy, &[&[]], &mut transcript)
+                .is_ok()
+        );
     }
 
     let k_range = 8..=16;

--- a/halo2_proofs/examples/circuit-layout.rs
+++ b/halo2_proofs/examples/circuit-layout.rs
@@ -272,6 +272,8 @@ impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
 
 // ANCHOR: dev-graph
 fn main() {
+    const ZK: bool = true;
+
     // Prepare the circuit you want to render.
     // You don't need to include any witness variables.
     let a = Fp::random(OsRng);
@@ -299,7 +301,7 @@ fn main() {
         .show_labels(false)
         // Render the circuit onto your area!
         // The first argument is the size parameter for the circuit.
-        .render(5, &circuit, &root)
+        .render::<_, _, _, ZK>(5, &circuit, &root)
         .unwrap();
 }
 // ANCHOR_END: dev-graph

--- a/halo2_proofs/examples/shuffle.rs
+++ b/halo2_proofs/examples/shuffle.rs
@@ -253,12 +253,12 @@ impl<F: FieldExt, const W: usize, const H: usize> Circuit<F> for MyCircuit<F, W,
     }
 }
 
-fn test_mock_prover<F: FieldExt, const W: usize, const H: usize>(
+fn test_mock_prover<F: FieldExt, const W: usize, const H: usize, const ZK: bool>(
     k: u32,
     circuit: MyCircuit<F, W, H>,
     expected: Result<(), Vec<(metadata::Constraint, FailureLocation)>>,
 ) {
-    let prover = MockProver::run::<_>(k, &circuit, vec![]).unwrap();
+    let prover = MockProver::run::<_, ZK>(k, &circuit, vec![]).unwrap();
     match (prover.verify(), expected) {
         (Ok(_), Ok(_)) => {}
         (Err(err), Err(expected)) => {
@@ -280,19 +280,19 @@ fn test_mock_prover<F: FieldExt, const W: usize, const H: usize>(
     };
 }
 
-fn test_prover<C: CurveAffine, const W: usize, const H: usize>(
+fn test_prover<C: CurveAffine, const W: usize, const H: usize, const ZK: bool>(
     k: u32,
     circuit: MyCircuit<C::Scalar, W, H>,
     expected: bool,
 ) {
     let params = ParamsIPA::<C>::new(k);
-    let vk = keygen_vk(&params, &circuit).unwrap();
-    let pk = keygen_pk(&params, vk, &circuit).unwrap();
+    let vk = keygen_vk::<_, _, _, ZK>(&params, &circuit).unwrap();
+    let pk = keygen_pk::<_, _, _, ZK>(&params, vk, &circuit).unwrap();
 
     let proof = {
         let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
 
-        create_proof::<IPACommitmentScheme<C>, ProverIPA<C>, _, _, _, _>(
+        create_proof::<IPACommitmentScheme<C>, ProverIPA<C>, _, _, _, _, ZK>(
             &params,
             &pk,
             &[circuit],
@@ -309,7 +309,7 @@ fn test_prover<C: CurveAffine, const W: usize, const H: usize>(
         let strategy = AccumulatorStrategy::new(&params);
         let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
 
-        verify_proof::<IPACommitmentScheme<C>, VerifierIPA<C>, _, _, _>(
+        verify_proof::<IPACommitmentScheme<C>, VerifierIPA<C>, _, _, _, ZK>(
             &params,
             pk.get_vk(),
             strategy,
@@ -324,6 +324,7 @@ fn test_prover<C: CurveAffine, const W: usize, const H: usize>(
 }
 
 fn main() {
+    const ZK: bool = true;
     const W: usize = 4;
     const H: usize = 32;
     const K: u32 = 8;
@@ -331,8 +332,8 @@ fn main() {
     let circuit = &MyCircuit::<_, W, H>::rand(&mut OsRng);
 
     {
-        test_mock_prover(K, circuit.clone(), Ok(()));
-        test_prover::<EqAffine, W, H>(K, circuit.clone(), true);
+        test_mock_prover::<_, W, H, ZK>(K, circuit.clone(), Ok(()));
+        test_prover::<EqAffine, W, H, ZK>(K, circuit.clone(), true);
     }
 
     #[cfg(not(feature = "sanity-checks"))]
@@ -345,7 +346,7 @@ fn main() {
             shuffled
         });
 
-        test_mock_prover(
+        test_mock_prover::<_, W, H, ZK>(
             K,
             circuit.clone(),
             Err(vec![(
@@ -356,6 +357,6 @@ fn main() {
                 },
             )]),
         );
-        test_prover::<EqAffine, W, H>(K, circuit, false);
+        test_prover::<EqAffine, W, H, ZK>(K, circuit, false);
     }
 }

--- a/halo2_proofs/examples/simple-example.rs
+++ b/halo2_proofs/examples/simple-example.rs
@@ -306,6 +306,9 @@ fn main() {
     use halo2_proofs::dev::MockProver;
     use halo2curves::pasta::Fp;
 
+    const ZK: bool = true;
+    const ZKFREE: bool = false;
+
     // ANCHOR: test-circuit
     // The number of rows in our circuit cannot exceed 2^k. Since our example
     // circuit is very small, we can pick a very small value here.
@@ -327,14 +330,29 @@ fn main() {
     // Arrange the public input. We expose the multiplication result in row 0
     // of the instance column, so we position it there in our public inputs.
     let mut public_inputs = vec![c];
+    {
+        // Given the correct public input, our circuit will verify.
+        let prover = MockProver::run::<_, ZK>(k, &circuit, vec![public_inputs.clone()]).unwrap();
+        assert_eq!(prover.verify(), Ok(()));
 
-    // Given the correct public input, our circuit will verify.
-    let prover = MockProver::run(k, &circuit, vec![public_inputs.clone()]).unwrap();
-    assert_eq!(prover.verify(), Ok(()));
+        // If we try some other public input, the proof will fail!
+        public_inputs[0] += Fp::one();
+        let prover = MockProver::run::<_, ZK>(k, &circuit, vec![public_inputs]).unwrap();
+        assert!(prover.verify().is_err());
+        // ANCHOR_END: test-circuit
+    }
 
-    // If we try some other public input, the proof will fail!
-    public_inputs[0] += Fp::one();
-    let prover = MockProver::run(k, &circuit, vec![public_inputs]).unwrap();
-    assert!(prover.verify().is_err());
-    // ANCHOR_END: test-circuit
+    let mut public_inputs = vec![c];
+    {
+        // Given the correct public input, our circuit will verify.
+        let prover =
+            MockProver::run::<_, ZKFREE>(k, &circuit, vec![public_inputs.clone()]).unwrap();
+        assert_eq!(prover.verify(), Ok(()));
+
+        // If we try some other public input, the proof will fail!
+        public_inputs[0] += Fp::one();
+        let prover = MockProver::run::<_, ZKFREE>(k, &circuit, vec![public_inputs]).unwrap();
+        assert!(prover.verify().is_err());
+        // ANCHOR_END: test-circuit
+    }
 }

--- a/halo2_proofs/examples/two-chip.rs
+++ b/halo2_proofs/examples/two-chip.rs
@@ -501,6 +501,9 @@ fn main() {
     use halo2curves::pasta::Fp;
     use rand_core::OsRng;
 
+    const ZK: bool = true;
+    const ZKFREE: bool = false;
+
     // ANCHOR: test-circuit
     // The number of rows in our circuit cannot exceed 2^k. Since our example
     // circuit is very small, we can pick a very small value here.
@@ -523,14 +526,29 @@ fn main() {
     // Arrange the public input. We expose the multiplication result in row 0
     // of the instance column, so we position it there in our public inputs.
     let mut public_inputs = vec![d];
+    {
+        // Given the correct public input, our circuit will verify.
+        let prover = MockProver::run::<_, ZK>(k, &circuit, vec![public_inputs.clone()]).unwrap();
+        assert_eq!(prover.verify(), Ok(()));
 
-    // Given the correct public input, our circuit will verify.
-    let prover = MockProver::run(k, &circuit, vec![public_inputs.clone()]).unwrap();
-    assert_eq!(prover.verify(), Ok(()));
+        // If we try some other public input, the proof will fail!
+        public_inputs[0] += Fp::one();
+        let prover = MockProver::run::<_, ZK>(k, &circuit, vec![public_inputs]).unwrap();
+        assert!(prover.verify().is_err());
+        // ANCHOR_END: test-circuit
+    }
 
-    // If we try some other public input, the proof will fail!
-    public_inputs[0] += Fp::one();
-    let prover = MockProver::run(k, &circuit, vec![public_inputs]).unwrap();
-    assert!(prover.verify().is_err());
-    // ANCHOR_END: test-circuit
+    let mut public_inputs = vec![c];
+    {
+        // Given the correct public input, our circuit will verify.
+        let prover =
+            MockProver::run::<_, ZKFREE>(k, &circuit, vec![public_inputs.clone()]).unwrap();
+        assert_eq!(prover.verify(), Ok(()));
+
+        // If we try some other public input, the proof will fail!
+        public_inputs[0] += Fp::one();
+        let prover = MockProver::run::<_, ZK>(k, &circuit, vec![public_inputs]).unwrap();
+        assert!(prover.verify().is_err());
+        // ANCHOR_END: test-circuit
+    }
 }

--- a/halo2_proofs/src/circuit/floor_planner/single_pass.rs
+++ b/halo2_proofs/src/circuit/floor_planner/single_pass.rs
@@ -466,6 +466,8 @@ mod tests {
 
     #[test]
     fn not_enough_columns_for_constants() {
+        const ZK: bool = true;
+
         struct MyCircuit {}
 
         impl Circuit<vesta::Scalar> for MyCircuit {
@@ -503,7 +505,7 @@ mod tests {
 
         let circuit = MyCircuit {};
         assert!(matches!(
-            MockProver::run(3, &circuit, vec![]).unwrap_err(),
+            MockProver::run::<_, ZK>(3, &circuit, vec![]).unwrap_err(),
             Error::NotEnoughColumnsForConstants,
         ));
     }

--- a/halo2_proofs/src/circuit/floor_planner/v1.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1.rs
@@ -504,6 +504,8 @@ mod tests {
 
     #[test]
     fn not_enough_columns_for_constants() {
+        const ZK: bool = true;
+
         struct MyCircuit {}
 
         impl Circuit<vesta::Scalar> for MyCircuit {
@@ -541,7 +543,7 @@ mod tests {
 
         let circuit = MyCircuit {};
         assert!(matches!(
-            MockProver::run(3, &circuit, vec![]).unwrap_err(),
+            MockProver::run::<_, ZK>(3, &circuit, vec![]).unwrap_err(),
             Error::NotEnoughColumnsForConstants,
         ));
     }

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -250,8 +250,8 @@ impl<F: Group + Field> Mul<F> for Value<F> {
 ///
 /// // This circuit has no public inputs.
 /// let instance = vec![];
-///
-/// let prover = MockProver::<Fp>::run(K, &circuit, instance).unwrap();
+/// const ZK :bool = true;
+/// let prover = MockProver::<Fp>::run::<_, ZK>(K, &circuit, instance).unwrap();
 /// assert_eq!(
 ///     prover.verify(),
 ///     Err(vec![VerifyFailure::ConstraintNotSatisfied {
@@ -270,7 +270,7 @@ impl<F: Group + Field> Mul<F> for Value<F> {
 ///
 /// // If we provide a too-small K, we get an error.
 /// assert!(matches!(
-///     MockProver::<Fp>::run(2, &circuit, vec![]).unwrap_err(),
+///     MockProver::<Fp>::run::<_, ZK>(2, &circuit, vec![]).unwrap_err(),
 ///     Error::NotEnoughRowsAvailable {
 ///         current_k,
 ///     } if current_k == 2,
@@ -489,7 +489,7 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
 impl<F: FieldExt> MockProver<F> {
     /// Runs a synthetic keygen-and-prove operation on the given circuit, collecting data
     /// about the constraints and their assignments.
-    pub fn run<ConcreteCircuit: Circuit<F>>(
+    pub fn run<ConcreteCircuit: Circuit<F>, const ZK: bool>(
         k: u32,
         circuit: &ConcreteCircuit,
         instance: Vec<Vec<F>>,
@@ -500,7 +500,7 @@ impl<F: FieldExt> MockProver<F> {
         let config = ConcreteCircuit::configure(&mut cs);
         let cs = cs;
 
-        if n < cs.minimum_rows() {
+        if n < cs.minimum_rows::<ZK>() {
             return Err(Error::not_enough_rows_available(k));
         }
 
@@ -511,7 +511,7 @@ impl<F: FieldExt> MockProver<F> {
         let instance = instance
             .into_iter()
             .map(|mut instance| {
-                if instance.len() > n - (cs.blinding_factors() + 1) {
+                if instance.len() > cs.usable_rows::<ZK>(n).end {
                     return Err(Error::InstanceTooLarge);
                 }
 
@@ -524,8 +524,7 @@ impl<F: FieldExt> MockProver<F> {
         let fixed = vec![vec![CellValue::Unassigned; n]; cs.num_fixed_columns];
         let selectors = vec![vec![false; n]; cs.num_selectors];
         // Advice columns contain blinding factors.
-        let blinding_factors = cs.blinding_factors();
-        let usable_rows = n - (blinding_factors + 1);
+        let usable_rows = cs.usable_rows::<ZK>(n).end;
         let advice = vec![
             {
                 let mut column = vec![CellValue::Unassigned; n];
@@ -568,7 +567,7 @@ impl<F: FieldExt> MockProver<F> {
 
         ConcreteCircuit::FloorPlanner::synthesize(&mut prover, circuit, config, constants)?;
 
-        let (cs, selector_polys) = prover.cs.compress_selectors(prover.selectors.clone());
+        let (cs, selector_polys) = prover.cs.compress_selectors::<ZK>(prover.selectors.clone());
         prover.cs = cs;
         prover.fixed.extend(selector_polys.into_iter().map(|poly| {
             let mut v = vec![CellValue::Unassigned; n];
@@ -661,8 +660,7 @@ impl<F: FieldExt> MockProver<F> {
                 .iter()
                 .enumerate()
                 .flat_map(|(gate_index, gate)| {
-                    let blinding_rows =
-                        (self.n as usize - (self.cs.blinding_factors() + 1))..(self.n as usize);
+                    let blinding_rows = self.usable_rows.end..self.n as usize;
                     (gate_row_ids
                         .clone()
                         .into_iter()
@@ -1027,8 +1025,7 @@ impl<F: FieldExt> MockProver<F> {
             .iter()
             .enumerate()
             .flat_map(|(gate_index, gate)| {
-                let blinding_rows =
-                    (self.n as usize - (self.cs.blinding_factors() + 1))..(self.n as usize);
+                let blinding_rows = self.usable_rows.end..self.n as usize;
                 (gate_row_ids
                     .clone()
                     .into_par_iter()
@@ -1333,6 +1330,7 @@ mod tests {
 
     #[test]
     fn unassigned_cell() {
+        const ZK: bool = true;
         const K: u32 = 4;
 
         #[derive(Clone)]
@@ -1390,8 +1388,7 @@ mod tests {
                 )
             }
         }
-
-        let prover = MockProver::run(K, &FaultyCircuit {}, vec![]).unwrap();
+        let prover = MockProver::run::<_, ZK>(K, &FaultyCircuit {}, vec![]).unwrap();
         assert_eq!(
             prover.verify(),
             Err(vec![VerifyFailure::CellNotAssigned {
@@ -1406,6 +1403,7 @@ mod tests {
 
     #[test]
     fn bad_lookup() {
+        const ZK: bool = true;
         const K: u32 = 4;
 
         #[derive(Clone)]
@@ -1519,7 +1517,7 @@ mod tests {
             }
         }
 
-        let prover = MockProver::run(K, &FaultyCircuit {}, vec![]).unwrap();
+        let prover = MockProver::run::<_, ZK>(K, &FaultyCircuit {}, vec![]).unwrap();
         assert_eq!(
             prover.verify(),
             Err(vec![VerifyFailure::Lookup {

--- a/halo2_proofs/src/dev/cost.rs
+++ b/halo2_proofs/src/dev/cost.rs
@@ -139,7 +139,7 @@ impl<G: PrimeGroup, ConcreteCircuit: Circuit<G::Scalar>> CircuitCost<G, Concrete
     /// Measures a circuit with parameter constant `k`.
     ///
     /// Panics if `k` is not large enough for the circuit.
-    pub fn measure(k: usize, circuit: &ConcreteCircuit) -> Self {
+    pub fn measure<const ZK: bool>(k: usize, circuit: &ConcreteCircuit) -> Self {
         // Collect the layout details.
         let mut cs = ConstraintSystem::default();
         let config = ConcreteCircuit::configure(&mut cs);
@@ -153,9 +153,9 @@ impl<G: PrimeGroup, ConcreteCircuit: Circuit<G::Scalar>> CircuitCost<G, Concrete
             cs.constants.clone(),
         )
         .unwrap();
-        let (cs, _) = cs.compress_selectors(assembly.selectors);
+        let (cs, _) = cs.compress_selectors::<ZK>(assembly.selectors);
 
-        assert!((1 << k) >= cs.minimum_rows());
+        assert!((1 << k) >= cs.minimum_rows::<ZK>());
 
         // Figure out how many point sets we have due to queried cells.
         let mut column_queries: HashMap<Column<Any>, HashSet<i32>> = HashMap::new();
@@ -191,11 +191,11 @@ impl<G: PrimeGroup, ConcreteCircuit: Circuit<G::Scalar>> CircuitCost<G, Concrete
 
         // Include permutation polynomials in point sets.
         point_sets.insert(vec![0, 1]); // permutation_product_poly
-        let max_deg = cs.degree();
+        let max_deg = cs.degree::<ZK>();
         let permutation_cols = cs.permutation.get_columns().len();
         if permutation_cols > max_deg - 2 {
             // permutation_product_poly for chaining chunks.
-            point_sets.insert(vec![-((cs.blinding_factors() + 1) as i32), 0, 1]);
+            point_sets.insert(vec![-((cs.blinding_factors::<ZK>() + 1) as i32), 0, 1]);
         }
 
         CircuitCost {

--- a/halo2_proofs/src/dev/graph/layout.rs
+++ b/halo2_proofs/src/dev/graph/layout.rs
@@ -36,7 +36,7 @@ use crate::{
 ///
 /// let circuit = MyCircuit::default();
 /// let k = 5; // Suitable size for MyCircuit
-/// CircuitLayout::default().render(k, &circuit, &drawing_area).unwrap();
+/// CircuitLayout::default().render::<_, _, _, true>(k, &circuit, &drawing_area).unwrap();
 /// ```
 #[derive(Debug, Default)]
 pub struct CircuitLayout {
@@ -85,7 +85,7 @@ impl CircuitLayout {
     }
 
     /// Renders the given circuit on the given drawing area.
-    pub fn render<F: Field, ConcreteCircuit: Circuit<F>, DB: DrawingBackend>(
+    pub fn render<F: Field, ConcreteCircuit: Circuit<F>, DB: DrawingBackend, const ZK: bool>(
         self,
         k: u32,
         circuit: &ConcreteCircuit,
@@ -106,7 +106,7 @@ impl CircuitLayout {
             cs.constants.clone(),
         )
         .unwrap();
-        let (cs, selector_polys) = cs.compress_selectors(layout.selectors);
+        let (cs, selector_polys) = cs.compress_selectors::<ZK>(layout.selectors);
         let non_selector_fixed_columns = cs.num_fixed_columns - selector_polys.len();
 
         // Figure out what order to render the columns in.
@@ -171,7 +171,7 @@ impl CircuitLayout {
         }
 
         // Mark the unusable rows of the circuit.
-        let usable_rows = n - (cs.blinding_factors() + 1);
+        let usable_rows = n - (cs.blinding_factors::<ZK>() + 1);
         if view_bottom > usable_rows {
             root.draw(&Rectangle::new(
                 [(0, usable_rows), (total_columns, view_bottom)],

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -53,14 +53,14 @@ pub struct VerifyingKey<C: CurveAffine> {
 }
 
 impl<C: CurveAffine> VerifyingKey<C> {
-    fn from_parts(
+    fn from_parts<const ZK: bool>(
         domain: EvaluationDomain<C::Scalar>,
         fixed_commitments: Vec<C>,
         permutation: permutation::VerifyingKey<C>,
         cs: ConstraintSystem<C::Scalar>,
     ) -> Self {
         // Compute cached values.
-        let cs_degree = cs.degree();
+        let cs_degree = cs.degree::<ZK>();
 
         let mut vk = Self {
             domain,

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -3,7 +3,7 @@ use core::ops::{Add, Mul};
 use ff::Field;
 use std::{
     convert::TryFrom,
-    ops::{Neg, Sub},
+    ops::{Neg, Range, Sub},
 };
 
 use super::{lookup, permutation, Assigned, Error};
@@ -1677,7 +1677,10 @@ impl<F: Field> ConstraintSystem<F> {
     /// find which fixed column corresponds with a given `Selector`.
     ///
     /// Do not call this twice. Yes, this should be a builder pattern instead.
-    pub(crate) fn compress_selectors(mut self, selectors: Vec<Vec<bool>>) -> (Self, Vec<Vec<F>>) {
+    pub(crate) fn compress_selectors<const ZK: bool>(
+        mut self,
+        selectors: Vec<Vec<bool>>,
+    ) -> (Self, Vec<Vec<F>>) {
         // The number of provided selector assignments must be the number we
         // counted for this constraint system.
         assert_eq!(selectors.len(), self.num_selectors);
@@ -1695,7 +1698,7 @@ impl<F: Field> ConstraintSystem<F> {
 
         // We will not increase the degree of the constraint system, so we limit
         // ourselves to the largest existing degree constraint.
-        let max_degree = self.degree();
+        let max_degree = self.degree::<ZK>();
 
         let mut new_columns = vec![];
         let (polys, selector_assignment) = compress_selectors::process(
@@ -1900,7 +1903,7 @@ impl<F: Field> ConstraintSystem<F> {
 
     /// Compute the degree of the constraint system (the maximum degree of all
     /// constraints).
-    pub fn degree(&self) -> usize {
+    pub fn degree<const ZK: bool>(&self) -> usize {
         // The permutation argument will serve alongside the gates, so must be
         // accounted for.
         let mut degree = self.permutation.required_degree();
@@ -1911,7 +1914,7 @@ impl<F: Field> ConstraintSystem<F> {
             degree,
             self.lookups
                 .iter()
-                .map(|l| l.required_degree())
+                .map(|l| l.required_degree::<ZK>())
                 .max()
                 .unwrap_or(1),
         );
@@ -1932,7 +1935,11 @@ impl<F: Field> ConstraintSystem<F> {
 
     /// Compute the number of blinding factors necessary to perfectly blind
     /// each of the prover's witness polynomials.
-    pub fn blinding_factors(&self) -> usize {
+    pub fn blinding_factors<const ZK: bool>(&self) -> usize {
+        if !ZK {
+            return 0;
+        }
+
         // All of the prover's advice columns are evaluated at no more than
         let factors = *self.num_advice_queries.iter().max().unwrap_or(&1);
         // distinct points during gate checks.
@@ -1959,16 +1966,29 @@ impl<F: Field> ConstraintSystem<F> {
         factors + 1
     }
 
+    /// Returns usable rows of circuit.
+    pub fn usable_rows<const ZK: bool>(&self, n: usize) -> Range<usize> {
+        if ZK {
+            0..n - (self.blinding_factors::<ZK>() + 1)
+        } else {
+            0..n
+        }
+    }
+
     /// Returns the minimum necessary rows that need to exist in order to
     /// account for e.g. blinding factors.
-    pub fn minimum_rows(&self) -> usize {
-        self.blinding_factors() // m blinding factors
-            + 1 // for l_{-(m + 1)} (l_last)
-            + 1 // for l_0 (just for extra breathing room for the permutation
-                // argument, to essentially force a separation in the
-                // permutation polynomial between the roles of l_last, l_0
-                // and the interstitial values.)
-            + 1 // for at least one row
+    pub fn minimum_rows<const ZK: bool>(&self) -> usize {
+        if !ZK {
+            return 1; // for at least one row
+        }
+
+        self.blinding_factors::<ZK>() // m blinding factors
+        + 1 // for l_{-(m + 1)} (l_last)
+        + 1 // for l_0 (just for extra breathing room for the permutation
+            // argument, to essentially force a separation in the
+            // permutation polynomial between the roles of l_last, l_0
+            // and the interstitial values.)
+        + 1 // for at least one row
     }
 
     /// Returns number of fixed columns

--- a/halo2_proofs/src/plonk/lookup/prover.rs
+++ b/halo2_proofs/src/plonk/lookup/prover.rs
@@ -69,6 +69,7 @@ impl<F: FieldExt> Argument<F> {
         E: EncodedChallenge<C>,
         R: RngCore,
         T: TranscriptWrite<C, E>,
+        const ZK: bool,
     >(
         &self,
         pk: &ProvingKey<C>,
@@ -114,14 +115,15 @@ impl<F: FieldExt> Argument<F> {
         let compressed_table_expression = compress_expressions(&self.table_expressions);
 
         // Permute compressed (InputExpression, TableExpression) pair
-        let (permuted_input_expression, permuted_table_expression) = permute_expression_pair(
-            pk,
-            params,
-            domain,
-            &mut rng,
-            &compressed_input_expression,
-            &compressed_table_expression,
-        )?;
+        let (permuted_input_expression, permuted_table_expression) =
+            permute_expression_pair::<_, _, _, ZK>(
+                pk,
+                params,
+                domain,
+                &mut rng,
+                &compressed_input_expression,
+                &compressed_table_expression,
+            )?;
 
         // Closure to construct commitment to vector of values
         let mut commit_values = |values: &Polynomial<C::Scalar, LagrangeCoeff>| {
@@ -170,6 +172,7 @@ impl<C: CurveAffine> Permuted<C> {
         E: EncodedChallenge<C>,
         R: RngCore,
         T: TranscriptWrite<C, E>,
+        const ZK: bool,
     >(
         self,
         pk: &ProvingKey<C>,
@@ -179,7 +182,7 @@ impl<C: CurveAffine> Permuted<C> {
         mut rng: R,
         transcript: &mut T,
     ) -> Result<Committed<C>, Error> {
-        let blinding_factors = pk.vk.cs.blinding_factors();
+        let blinding_factors = pk.vk.cs.blinding_factors::<ZK>();
         // Goal is to compute the products of fractions
         //
         // Numerator: (\theta^{m-1} a_0(\omega^i) + \theta^{m-2} a_1(\omega^i) + ... + \theta a_{m-2}(\omega^i) + a_{m-1}(\omega^i) + \beta)
@@ -254,7 +257,7 @@ impl<C: CurveAffine> Permuted<C> {
         // It can be used for debugging purposes.
         {
             // While in Lagrange basis, check that product is correctly constructed
-            let u = (params.n() as usize) - (blinding_factors + 1);
+            let u = pk.vk.cs.usable_rows::<ZK>(params.n() as usize).end;
 
             // l_0(X) * (1 - z(X)) = 0
             assert_eq!(z[0], C::Scalar::one());
@@ -262,7 +265,7 @@ impl<C: CurveAffine> Permuted<C> {
             // z(\omega X) (a'(X) + \beta) (s'(X) + \gamma)
             // - z(X) (\theta^{m-1} a_0(X) + ... + a_{m-1}(X) + \beta) (\theta^{m-1} s_0(X) + ... + s_{m-1}(X) + \gamma)
             for i in 0..u {
-                let mut left = z[i + 1];
+                let mut left = z[(i + 1) % params.n() as usize];
                 let permuted_input_value = &self.permuted_input_expression[i];
 
                 let permuted_table_value = &self.permuted_table_expression[i];
@@ -284,7 +287,7 @@ impl<C: CurveAffine> Permuted<C> {
             // l_last(X) * (z(X)^2 - z(X)) = 0
             // Assertion will fail only when soundness is broken, in which
             // case this z[u] value will be zero. (bad!)
-            assert_eq!(z[u], C::Scalar::one());
+            assert_eq!(z[u % params.n() as usize], C::Scalar::one());
         }
 
         let product_blind = Blind(C::Scalar::random(rng));
@@ -294,7 +297,7 @@ impl<C: CurveAffine> Permuted<C> {
         // Hash product commitment
         transcript.write_point(product_commitment)?;
 
-        Ok(Committed::<C> {
+        Ok(Committed {
             permuted_input_poly: self.permuted_input_poly,
             permuted_input_blind: self.permuted_input_blind,
             permuted_table_poly: self.permuted_table_poly,
@@ -388,7 +391,13 @@ type ExpressionPair<F> = (Polynomial<F, LagrangeCoeff>, Polynomial<F, LagrangeCo
 /// - the first row in a sequence of like values in A' is the row
 ///   that has the corresponding value in S'.
 /// This method returns (A', S') if no errors are encountered.
-fn permute_expression_pair<'params, C: CurveAffine, P: Params<'params, C>, R: RngCore>(
+fn permute_expression_pair<
+    'params,
+    C: CurveAffine,
+    P: Params<'params, C>,
+    R: RngCore,
+    const ZK: bool,
+>(
     pk: &ProvingKey<C>,
     params: &P,
     domain: &EvaluationDomain<C::Scalar>,
@@ -396,8 +405,7 @@ fn permute_expression_pair<'params, C: CurveAffine, P: Params<'params, C>, R: Rn
     input_expression: &Polynomial<C::Scalar, LagrangeCoeff>,
     table_expression: &Polynomial<C::Scalar, LagrangeCoeff>,
 ) -> Result<ExpressionPair<C::Scalar>, Error> {
-    let blinding_factors = pk.vk.cs.blinding_factors();
-    let usable_rows = params.n() as usize - (blinding_factors + 1);
+    let usable_rows = pk.vk.cs.usable_rows::<ZK>(params.n() as usize).end;
 
     let mut permuted_input_expression: Vec<C::Scalar> = input_expression.to_vec();
     permuted_input_expression.truncate(usable_rows);
@@ -448,8 +456,9 @@ fn permute_expression_pair<'params, C: CurveAffine, P: Params<'params, C>, R: Rn
     assert!(repeated_input_rows.is_empty());
 
     permuted_input_expression
-        .extend((0..(blinding_factors + 1)).map(|_| C::Scalar::random(&mut rng)));
-    permuted_table_coeffs.extend((0..(blinding_factors + 1)).map(|_| C::Scalar::random(&mut rng)));
+        .extend((usable_rows..params.n() as usize).map(|_| C::Scalar::random(&mut rng)));
+    permuted_table_coeffs
+        .extend((usable_rows..params.n() as usize).map(|_| C::Scalar::random(&mut rng)));
     assert_eq!(permuted_input_expression.len(), params.n() as usize);
     assert_eq!(permuted_table_coeffs.len(), params.n() as usize);
 

--- a/halo2_proofs/src/plonk/permutation/prover.rs
+++ b/halo2_proofs/src/plonk/permutation/prover.rs
@@ -49,6 +49,7 @@ impl Argument {
         E: EncodedChallenge<C>,
         R: RngCore,
         T: TranscriptWrite<C, E>,
+        const ZK: bool,
     >(
         &self,
         params: &P,
@@ -69,8 +70,12 @@ impl Argument {
         // will never underflow because of the requirement of at least a degree
         // 3 circuit for the permutation argument.
         assert!(pk.vk.cs_degree >= 3);
-        let chunk_len = pk.vk.cs_degree - 2;
-        let blinding_factors = pk.vk.cs.blinding_factors();
+        let chunk_len = if ZK || self.columns.len() >= pk.vk.cs_degree {
+            pk.vk.cs_degree - 2
+        } else {
+            pk.vk.cs_degree - 1
+        };
+        let blinding_factors = pk.vk.cs.blinding_factors::<ZK>();
 
         // Each column gets its own delta power.
         let mut deltaomega = C::Scalar::one();
@@ -158,12 +163,17 @@ impl Argument {
                 z.push(tmp);
             }
             let mut z = domain.lagrange_from_vec(z);
-            // Set blinding factors
-            for z in &mut z[params.n() as usize - blinding_factors..] {
-                *z = C::Scalar::random(&mut rng);
+            if ZK {
+                // Set blinding factors
+                for z in &mut z[params.n() as usize - blinding_factors..] {
+                    *z = C::Scalar::random(&mut rng);
+                }
+                // Set new last_z
+                last_z = z[params.n() as usize - (blinding_factors + 1)];
+            } else {
+                // Set new last_z
+                last_z = *z.last().unwrap() * modified_values.last().unwrap();
             }
-            // Set new last_z
-            last_z = z[params.n() as usize - (blinding_factors + 1)];
 
             let blind = Blind(C::Scalar::random(&mut rng));
 
@@ -233,14 +243,18 @@ impl<C: CurveAffine> super::ProvingKey<C> {
 }
 
 impl<C: CurveAffine> Constructed<C> {
-    pub(in crate::plonk) fn evaluate<E: EncodedChallenge<C>, T: TranscriptWrite<C, E>>(
+    pub(in crate::plonk) fn evaluate<
+        E: EncodedChallenge<C>,
+        T: TranscriptWrite<C, E>,
+        const ZK: bool,
+    >(
         self,
         pk: &plonk::ProvingKey<C>,
         x: ChallengeX<C>,
         transcript: &mut T,
     ) -> Result<Evaluated<C>, Error> {
         let domain = &pk.vk.domain;
-        let blinding_factors = pk.vk.cs.blinding_factors();
+        let blinding_factors = pk.vk.cs.blinding_factors::<ZK>();
 
         {
             let mut sets = self.sets.iter();
@@ -261,16 +275,18 @@ impl<C: CurveAffine> Constructed<C> {
                     transcript.write_scalar(*eval)?;
                 }
 
-                // If we have any remaining sets to process, evaluate this set at omega^u
-                // so we can constrain the last value of its running product to equal the
-                // first value of the next set's running product, chaining them together.
-                if sets.len() > 0 {
-                    let permutation_product_last_eval = eval_polynomial(
-                        &set.permutation_product_poly,
-                        domain.rotate_omega(*x, Rotation(-((blinding_factors + 1) as i32))),
-                    );
+                if ZK {
+                    // If we have any remaining sets to process, evaluate this set at omega^u
+                    // so we can constrain the last value of its running product to equal the
+                    // first value of the next set's running product, chaining them together.
+                    if sets.len() > 0 {
+                        let permutation_product_last_eval = eval_polynomial(
+                            &set.permutation_product_poly,
+                            domain.rotate_omega(*x, Rotation(-((blinding_factors + 1) as i32))),
+                        );
 
-                    transcript.write_scalar(permutation_product_last_eval)?;
+                        transcript.write_scalar(permutation_product_last_eval)?;
+                    }
                 }
             }
         }
@@ -280,12 +296,12 @@ impl<C: CurveAffine> Constructed<C> {
 }
 
 impl<C: CurveAffine> Evaluated<C> {
-    pub(in crate::plonk) fn open<'a>(
+    pub(in crate::plonk) fn open<'a, const ZK: bool>(
         &'a self,
         pk: &'a plonk::ProvingKey<C>,
         x: ChallengeX<C>,
     ) -> impl Iterator<Item = ProverQuery<'a, C>> + Clone {
-        let blinding_factors = pk.vk.cs.blinding_factors();
+        let blinding_factors = pk.vk.cs.blinding_factors::<ZK>();
         let x_next = pk.vk.domain.rotate_omega(*x, Rotation::next());
         let x_last = pk
             .vk
@@ -310,7 +326,7 @@ impl<C: CurveAffine> Evaluated<C> {
             // Open it at \omega^{last} x for all but the last set. This rotation is only
             // sensical for the first row, but we only use this rotation in a constraint
             // that is gated on l_0.
-            .chain(
+            .chain(if ZK {
                 self.constructed
                     .sets
                     .iter()
@@ -322,7 +338,10 @@ impl<C: CurveAffine> Evaluated<C> {
                             poly: &set.permutation_product_poly,
                             blind: set.permutation_product_blind,
                         })
-                    }),
-            )
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            })
     }
 }


### PR DESCRIPTION
This PR aims to extend `halo2` to allow developers to enable/disable zero-knowledge with const generic `const ZK: bool`.

## Protocol adjustment for non-ZK

Notations are following the ones used in [halo2 book](https://zcash.github.io/halo2).

### Blinding factors

The final `max(3, max(num_advice_queries)) + 2` rows of every advice column, including permuted columns in lookup argument, and grand-product columns in lookup and permutation argument, are loaded with random blinding factors, which aims for zero knowledge.

When we turn off zero-knowledge, we don't need to reserve these final rows, then all rows are usable.

### Lookup argument

Currently the constraints of lookup argument are:

- $\ell_0(X) \cdot (1 - Z(X))$
- $q_{last}(X) \cdot (Z(X)^2 - Z(X))$
- $(1 - (q_{last}(X) + q_{blind}(X))) \cdot (Z(\omega X)\cdot(A^\prime(X) + \beta)\cdot(S^\prime(X) + \gamma) - Z(X)\cdot(A(X) + \beta)\cdot(S(X) + \gamma))$
- $\ell_0(X) \cdot (A^\prime(X) - S^\prime(X))$
- $(1 - (q_{last}(X) + q_{blind}(X))) \cdot (A^\prime(X) - S^\prime(X)) \cdot (A^\prime(X) - A^\prime(\omega^{-1}X))$

When we turn off zero-knowledge, the constraints could be simplified to the orange parts only:

- $\color{orange}{\ell_0(X) \cdot (1 - Z(X))}$
- $\color{darkgray}{q_{last}(X) \cdot (Z(X)^2 - Z(X))}$
- $\color{darkgray}{(1 - (q_{last}(X) + q_{blind}(X))) \cdot(}\color{orange}{Z(\omega X)\cdot(A^\prime(X) + \beta)\cdot(S^\prime(X) + \gamma) - Z(X)\cdot(A(X) + \beta)\cdot(S(X) + \gamma)}\color{darkgray}{)}$
- $\color{darkgray}{\ell_0(X) \cdot (A^\prime(X) - S^\prime(X))}$
- $\color{darkgray}{(1 - (q_{last}(X) + q_{blind}(X))) \cdot}\color{orange}{(A^\prime(X) - S^\prime(X)) \cdot (A^\prime(X) - A^\prime(\omega^{-1}X))}$

### Permutation argument

Currently the constraints of permutation argument are:

- $\ell_0(X) \cdot (1 - Z_{P,0}(X))$
- $q_{last}(X) \cdot (Z_{P,b}(X)^2 - Z_{P,b}(X))$
- $\text{For}\ 0 < a < b$
    - $\ell_0(X) \cdot (Z_{P,a}(X) - Z_{P,a-1}(\omega^\mu X))$
- $\text{For}\ 0 \le a < b$
    - $(1 - (q_{last}(X) + q_{blind}(X))) \cdot \Big(Z_{P,a}(\omega X) \cdot \prod\limits_{i=am}^{(a+1)m-1}(v_i(X) + \beta \cdot s_i(X) + \gamma) - Z_{P,a}(X) \cdot \prod\limits_{i=am}^{(a+1)m-1}(v_i(X) + \beta \cdot \delta^i \cdot X + \gamma)\Big)$ 

When we turn off zero-knowledge, the constraints could be simplified to the orange parts only:

- $\text{If}\ m \le d-1, \text{then}\ b = 1$
    - $\color{orange}{\ell_0(X) \cdot (1 - Z_{P,0}(X))}$
    - $\color{darkgray}{q_{last}(X) \cdot (Z_{P,b}(X)^2 - Z_{P,b}(X))}$
    - $\color{darkgray}{\text{For}\ 0 < a < b}$
        - $\color{darkgray}{\ell_0(X) \cdot (Z_{P,a}(X) - Z_{P,a-1}(\omega^\mu X))}$
    - $\color{orange}{\text{For}\ 0 \le a < b}$
        - $\color{darkgray}{(1 - (q_{last}(X) + q_{blind}(X))) \cdot \Big(}\color{orange}{Z_{P,a}(\omega X) \cdot \prod\limits_{i=am}^{(a+1)m-1}(v_i(X) + \beta \cdot s_i(X) + \gamma) - Z_{P,a}(X) \cdot \prod\limits_{i=am}^{(a+1)m-1}(v_i(X) + \beta \cdot \delta^i \cdot X + \gamma)}\color{darkgray}{\Big)}$ 
- $\text{Otherwise}$
    - $\color{orange}{\ell_0(X) \cdot (1 - Z_{P,0}(X))}$
    - $\color{darkgray}{q_{last}(X) \cdot (Z_{P,b}(X)^2 - Z_{P,b}(X))}$
    - $\color{darkgray}{\text{For}\ 0 < a < b}$
        - $\color{darkgray}{\ell_0(X) \cdot (Z_{P,a}(X) - Z_{P,a-1}(\omega^\mu X))}$
    - $\color{orange}{\text{For}\ 0 \le a < b}$
        - $\color{darkgray}{(1 - (q_{last}(X) + q_{blind}(X))) \cdot \Big(}\color{red}{(}\color{orange}{Z_{P,a}(\omega X)}\color{red}{ + q_{last}(X) \cdot (Z_{P,a+1}(\omega X) - Z_{P,a}(\omega X)))}\color{orange}{ \cdot \prod\limits_{i=am}^{(a+1)m-1}(v_i(X) + \beta \cdot s_i(X) + \gamma) - Z_{P,a}(X) \cdot \prod\limits_{i=am}^{(a+1)m-1}(v_i(X) + \beta \cdot \delta^i \cdot X + \gamma)}\color{darkgray}{\Big)}$ 

Where the red part is adjustment to make all rows copyable.

### Vanishing argument

Currently we add a random polynomial in the vanishing argument to reveal nothing about $h(X)$. When we turn off zero-knowledge, it's on longer needed.
