### PR TITLE
Params,ParamsVerifier: make k & n public

### DIFF
--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -20,7 +20,10 @@ use std::io;
 /// These are the prover parameters for the polynomial commitment scheme.
 #[derive(Debug)]
 pub struct Params<C: CurveAffine> {
+    /// This is a common term used for deriving the amount of field elements `n = 1 << k`.
+    /// Also known as the domain size.
     pub k: u32,
+    /// This represents the amount of available field elements
     pub n: u64,
     pub(crate) g: Vec<C>,
     pub(crate) g_lagrange: Vec<C>,
@@ -30,7 +33,10 @@ pub struct Params<C: CurveAffine> {
 /// These are the verifier parameters for the polynomial commitment scheme.
 #[derive(Debug)]
 pub struct ParamsVerifier<E: Engine> {
+    /// This is a common term used for deriving the amount of field elements `n = 1 << k`.
+    /// Also known as the domain size.
     pub k: u32,
+    /// This represents the amount of available field elements
     pub n: u64,
     pub(crate) g1: E::G1Affine,
     pub(crate) g2: E::G2Affine,

--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -20,8 +20,8 @@ use std::io;
 /// These are the prover parameters for the polynomial commitment scheme.
 #[derive(Debug)]
 pub struct Params<C: CurveAffine> {
-    pub(crate) k: u32,
-    pub(crate) n: u64,
+    pub k: u32,
+    pub n: u64,
     pub(crate) g: Vec<C>,
     pub(crate) g_lagrange: Vec<C>,
     pub(crate) additional_data: Vec<u8>,
@@ -30,8 +30,8 @@ pub struct Params<C: CurveAffine> {
 /// These are the verifier parameters for the polynomial commitment scheme.
 #[derive(Debug)]
 pub struct ParamsVerifier<E: Engine> {
-    pub(crate) k: u32,
-    pub(crate) n: u64,
+    pub k: u32,
+    pub n: u64,
     pub(crate) g1: E::G1Affine,
     pub(crate) g2: E::G2Affine,
     pub(crate) s_g2: E::G2Affine,


### PR DESCRIPTION
Used for decision making in downstream projects that want to infer
certain bounds given a `Params{Verifier}` structure.