### PR TITLE
Configurable instance query

### DIFF
--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -88,27 +88,28 @@ pub fn create_proof<
                         return Err(Error::InstanceTooLarge);
                     }
                     for (poly, value) in poly.iter_mut().zip(values.iter()) {
+                        transcript.common_scalar(*value)?;
                         *poly = *value;
                     }
                     Ok(poly)
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            let instance_commitments_projective: Vec<_> = instance_values
-                .iter()
-                .map(|poly| params.commit_lagrange(poly, Blind::default()))
-                .collect();
-            let mut instance_commitments =
-                vec![Scheme::Curve::identity(); instance_commitments_projective.len()];
-            <Scheme::Curve as CurveAffine>::CurveExt::batch_normalize(
-                &instance_commitments_projective,
-                &mut instance_commitments,
-            );
-            let instance_commitments = instance_commitments;
-            drop(instance_commitments_projective);
+            // let instance_commitments_projective: Vec<_> = instance_values
+            //     .iter()
+            //     .map(|poly| params.commit_lagrange(poly, Blind::default()))
+            //     .collect();
+            // let mut instance_commitments =
+            //     vec![Scheme::Curve::identity(); instance_commitments_projective.len()];
+            // <Scheme::Curve as CurveAffine>::CurveExt::batch_normalize(
+            //     &instance_commitments_projective,
+            //     &mut instance_commitments,
+            // );
+            // let instance_commitments = instance_commitments;
+            // drop(instance_commitments_projective);
 
-            for commitment in &instance_commitments {
-                transcript.common_point(*commitment)?;
-            }
+            // for commitment in &instance_commitments {
+            //     transcript.common_point(*commitment)?;
+            // }
 
             let instance_polys: Vec<_> = instance_values
                 .iter()
@@ -505,24 +506,24 @@ pub fn create_proof<
     let xn = x.pow(&[params.n() as u64, 0, 0, 0]);
 
     // Compute and hash instance evals for each circuit instance
-    for instance in instance.iter() {
-        // Evaluate polynomials at omega^i x
-        let instance_evals: Vec<_> = meta
-            .instance_queries
-            .iter()
-            .map(|&(column, at)| {
-                eval_polynomial(
-                    &instance.instance_polys[column.index()],
-                    domain.rotate_omega(*x, at),
-                )
-            })
-            .collect();
+    // for instance in instance.iter() {
+    //     // Evaluate polynomials at omega^i x
+    //     let instance_evals: Vec<_> = meta
+    //         .instance_queries
+    //         .iter()
+    //         .map(|&(column, at)| {
+    //             eval_polynomial(
+    //                 &instance.instance_polys[column.index()],
+    //                 domain.rotate_omega(*x, at),
+    //             )
+    //         })
+    //         .collect();
 
-        // Hash each instance column evaluation
-        for eval in instance_evals.iter() {
-            transcript.write_scalar(*eval)?;
-        }
-    }
+    //     // Hash each instance column evaluation
+    //     for eval in instance_evals.iter() {
+    //         transcript.write_scalar(*eval)?;
+    //     }
+    // }
 
     // Compute and hash advice evals for each circuit instance
     for advice in advice.iter() {
@@ -580,24 +581,27 @@ pub fn create_proof<
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    let instances = instance
+    // let instances = instance
+    //     .iter()
+    //     .zip(advice.iter())
+    let instances = advice
         .iter()
-        .zip(advice.iter())
         .zip(permutations.iter())
         .zip(lookups.iter())
-        .flat_map(|(((instance, advice), permutation), lookups)| {
+        // .flat_map(|(((instance, advice), permutation), lookups)| {
+        .flat_map(|((advice, permutation), lookups)| {
             iter::empty()
-                .chain(
-                    pk.vk
-                        .cs
-                        .instance_queries
-                        .iter()
-                        .map(move |&(column, at)| ProverQuery {
-                            point: domain.rotate_omega(*x, at),
-                            poly: &instance.instance_polys[column.index()],
-                            blind: Blind::default(),
-                        }),
-                )
+                // .chain(
+                //     pk.vk
+                //         .cs
+                //         .instance_queries
+                //         .iter()
+                //         .map(move |&(column, at)| ProverQuery {
+                //             point: domain.rotate_omega(*x, at),
+                //             poly: &instance.instance_polys[column.index()],
+                //             blind: Blind::default(),
+                //         }),
+                // )
                 .chain(
                     pk.vk
                         .cs

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -88,28 +88,33 @@ pub fn create_proof<
                         return Err(Error::InstanceTooLarge);
                     }
                     for (poly, value) in poly.iter_mut().zip(values.iter()) {
-                        transcript.common_scalar(*value)?;
+                        if !P::QUERY_INSTANCE {
+                            transcript.common_scalar(*value)?;
+                        }
                         *poly = *value;
                     }
                     Ok(poly)
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            // let instance_commitments_projective: Vec<_> = instance_values
-            //     .iter()
-            //     .map(|poly| params.commit_lagrange(poly, Blind::default()))
-            //     .collect();
-            // let mut instance_commitments =
-            //     vec![Scheme::Curve::identity(); instance_commitments_projective.len()];
-            // <Scheme::Curve as CurveAffine>::CurveExt::batch_normalize(
-            //     &instance_commitments_projective,
-            //     &mut instance_commitments,
-            // );
-            // let instance_commitments = instance_commitments;
-            // drop(instance_commitments_projective);
 
-            // for commitment in &instance_commitments {
-            //     transcript.common_point(*commitment)?;
-            // }
+            if P::QUERY_INSTANCE {
+                let instance_commitments_projective: Vec<_> = instance_values
+                    .iter()
+                    .map(|poly| params.commit_lagrange(poly, Blind::default()))
+                    .collect();
+                let mut instance_commitments =
+                    vec![Scheme::Curve::identity(); instance_commitments_projective.len()];
+                <Scheme::Curve as CurveAffine>::CurveExt::batch_normalize(
+                    &instance_commitments_projective,
+                    &mut instance_commitments,
+                );
+                let instance_commitments = instance_commitments;
+                drop(instance_commitments_projective);
+
+                for commitment in &instance_commitments {
+                    transcript.common_point(*commitment)?;
+                }
+            }
 
             let instance_polys: Vec<_> = instance_values
                 .iter()
@@ -505,25 +510,27 @@ pub fn create_proof<
     let x: ChallengeX<_> = transcript.squeeze_challenge_scalar();
     let xn = x.pow(&[params.n() as u64, 0, 0, 0]);
 
-    // Compute and hash instance evals for each circuit instance
-    // for instance in instance.iter() {
-    //     // Evaluate polynomials at omega^i x
-    //     let instance_evals: Vec<_> = meta
-    //         .instance_queries
-    //         .iter()
-    //         .map(|&(column, at)| {
-    //             eval_polynomial(
-    //                 &instance.instance_polys[column.index()],
-    //                 domain.rotate_omega(*x, at),
-    //             )
-    //         })
-    //         .collect();
+    if P::QUERY_INSTANCE {
+        // Compute and hash instance evals for each circuit instance
+        for instance in instance.iter() {
+            // Evaluate polynomials at omega^i x
+            let instance_evals: Vec<_> = meta
+                .instance_queries
+                .iter()
+                .map(|&(column, at)| {
+                    eval_polynomial(
+                        &instance.instance_polys[column.index()],
+                        domain.rotate_omega(*x, at),
+                    )
+                })
+                .collect();
 
-    //     // Hash each instance column evaluation
-    //     for eval in instance_evals.iter() {
-    //         transcript.write_scalar(*eval)?;
-    //     }
-    // }
+            // Hash each instance column evaluation
+            for eval in instance_evals.iter() {
+                transcript.write_scalar(*eval)?;
+            }
+        }
+    }
 
     // Compute and hash advice evals for each circuit instance
     for advice in advice.iter() {
@@ -581,27 +588,25 @@ pub fn create_proof<
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    // let instances = instance
-    //     .iter()
-    //     .zip(advice.iter())
-    let instances = advice
+    let instances = instance
         .iter()
+        .zip(advice.iter())
         .zip(permutations.iter())
         .zip(lookups.iter())
-        // .flat_map(|(((instance, advice), permutation), lookups)| {
-        .flat_map(|((advice, permutation), lookups)| {
+        .flat_map(|(((instance, advice), permutation), lookups)| {
             iter::empty()
-                // .chain(
-                //     pk.vk
-                //         .cs
-                //         .instance_queries
-                //         .iter()
-                //         .map(move |&(column, at)| ProverQuery {
-                //             point: domain.rotate_omega(*x, at),
-                //             poly: &instance.instance_polys[column.index()],
-                //             blind: Blind::default(),
-                //         }),
-                // )
+                .chain(
+                    P::QUERY_INSTANCE
+                        .then_some(pk.vk.cs.instance_queries.iter().map(move |&(column, at)| {
+                            ProverQuery {
+                                point: domain.rotate_omega(*x, at),
+                                poly: &instance.instance_polys[column.index()],
+                                blind: Blind::default(),
+                            }
+                        }))
+                        .into_iter()
+                        .flatten(),
+                )
                 .chain(
                     pk.vk
                         .cs

--- a/halo2_proofs/src/plonk/verifier.rs
+++ b/halo2_proofs/src/plonk/verifier.rs
@@ -7,7 +7,7 @@ use super::{
     vanishing, ChallengeBeta, ChallengeGamma, ChallengeTheta, ChallengeX, ChallengeY, Error,
     VerifyingKey,
 };
-use crate::arithmetic::{CurveAffine, FieldExt};
+use crate::arithmetic::{compute_inner_product, CurveAffine, FieldExt};
 use crate::poly::commitment::{CommitmentScheme, Verifier};
 use crate::poly::VerificationStrategy;
 use crate::poly::{
@@ -45,34 +45,42 @@ pub fn verify_proof<
         }
     }
 
-    let instance_commitments = instances
-        .iter()
-        .map(|instance| {
-            instance
-                .iter()
-                .map(|instance| {
-                    if instance.len() > params.n() as usize - (vk.cs.blinding_factors() + 1) {
-                        return Err(Error::InstanceTooLarge);
-                    }
-                    let mut poly = instance.to_vec();
-                    poly.resize(params.n() as usize, Scheme::Scalar::zero());
-                    let poly = vk.domain.lagrange_from_vec(poly);
+    // let instance_commitments = instances
+    //     .iter()
+    //     .map(|instance| {
+    //         instance
+    //             .iter()
+    //             .map(|instance| {
+    //                 if instance.len() > params.n() as usize - (vk.cs.blinding_factors() + 1) {
+    //                     return Err(Error::InstanceTooLarge);
+    //                 }
+    //                 let mut poly = instance.to_vec();
+    //                 poly.resize(params.n() as usize, Scheme::Scalar::zero());
+    //                 let poly = vk.domain.lagrange_from_vec(poly);
 
-                    Ok(params.commit_lagrange(&poly, Blind::default()).to_affine())
-                })
-                .collect::<Result<Vec<_>, _>>()
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    //                 Ok(params.commit_lagrange(&poly, Blind::default()).to_affine())
+    //             })
+    //             .collect::<Result<Vec<_>, _>>()
+    //     })
+    //     .collect::<Result<Vec<_>, _>>()?;
 
-    let num_proofs = instance_commitments.len();
+    let num_proofs = instances.len();
 
     // Hash verification key into transcript
     vk.hash_into(transcript)?;
 
-    for instance_commitments in instance_commitments.iter() {
-        // Hash the instance (external) commitments into the transcript
-        for commitment in instance_commitments {
-            transcript.common_point(*commitment)?
+    // for instance_commitments in instance_commitments.iter() {
+    //     // Hash the instance (external) commitments into the transcript
+    //     for commitment in instance_commitments {
+    //         transcript.common_point(*commitment)?
+    //     }
+    // }
+
+    for instance in instances.iter() {
+        for instance in instance.iter() {
+            for value in instance.iter() {
+                transcript.common_scalar(*value)?;
+            }
         }
     }
 
@@ -153,9 +161,30 @@ pub fn verify_proof<
     // Sample x challenge, which is used to ensure the circuit is
     // satisfied with high probability.
     let x: ChallengeX<_> = transcript.squeeze_challenge_scalar();
-    let instance_evals = (0..num_proofs)
-        .map(|_| -> Result<Vec<_>, _> { read_n_scalars(transcript, vk.cs.instance_queries.len()) })
-        .collect::<Result<Vec<_>, _>>()?;
+    // let instance_evals = (0..num_proofs)
+    //     .map(|_| -> Result<Vec<_>, _> { read_n_scalars(transcript, vk.cs.instance_queries.len()) })
+    //     .collect::<Result<Vec<_>, _>>()?;
+    let instance_evals = {
+        let xn = x.pow(&[params.n() as u64, 0, 0, 0]);
+        let l_i_s = &vk.domain.l_i_range(
+            *x,
+            xn,
+            0..instances
+                .iter()
+                .flat_map(|instance| instance.iter().map(|instance| instance.len()))
+                .max_by(Ord::cmp)
+                .unwrap_or_default() as i32,
+        );
+        instances
+            .iter()
+            .map(|instance| {
+                instance
+                    .iter()
+                    .map(|instance| compute_inner_product(instance, &l_i_s[..instance.len()]))
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>()
+    };
 
     let advice_evals = (0..num_proofs)
         .map(|_| -> Result<Vec<_>, _> { read_n_scalars(transcript, vk.cs.advice_queries.len()) })
@@ -266,31 +295,35 @@ pub fn verify_proof<
         vanishing.verify(params, expressions, y, xn)
     };
 
-    let queries = instance_commitments
+    // let queries = instance_commitments
+    //     .iter()
+    //     .zip(instance_evals.iter())
+    //     .zip(advice_commitments.iter())
+    let queries = advice_commitments
         .iter()
-        .zip(instance_evals.iter())
-        .zip(advice_commitments.iter())
         .zip(advice_evals.iter())
         .zip(permutations_evaluated.iter())
         .zip(lookups_evaluated.iter())
+        // .flat_map(
+        //     |(
+        //         (
+        //             (((instance_commitments, instance_evals), advice_commitments), advice_evals),
+        //             permutation,
+        //         ),
+        //         lookups,
+        //     )| {
         .flat_map(
-            |(
-                (
-                    (((instance_commitments, instance_evals), advice_commitments), advice_evals),
-                    permutation,
-                ),
-                lookups,
-            )| {
+            |(((advice_commitments, advice_evals), permutation), lookups)| {
                 iter::empty()
-                    .chain(vk.cs.instance_queries.iter().enumerate().map(
-                        move |(query_index, &(column, at))| {
-                            VerifierQuery::new_commitment(
-                                &instance_commitments[column.index()],
-                                vk.domain.rotate_omega(*x, at),
-                                instance_evals[query_index],
-                            )
-                        },
-                    ))
+                    // .chain(vk.cs.instance_queries.iter().enumerate().map(
+                    //     move |(query_index, &(column, at))| {
+                    //         VerifierQuery::new_commitment(
+                    //             &instance_commitments[column.index()],
+                    //             vk.domain.rotate_omega(*x, at),
+                    //             instance_evals[query_index],
+                    //         )
+                    //     },
+                    // ))
                     .chain(vk.cs.advice_queries.iter().enumerate().map(
                         move |(query_index, &(column, at))| {
                             VerifierQuery::new_commitment(

--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -126,6 +126,9 @@ pub trait MSM<C: CurveAffine>: Clone + Debug {
 
 /// Common multi-open prover interface for various commitment schemes
 pub trait Prover<'params, Scheme: CommitmentScheme> {
+    /// Query instance or not
+    const QUERY_INSTANCE: bool;
+
     /// Creates new prover instance
     fn new(params: &'params Scheme::ParamsProver) -> Self;
 
@@ -155,6 +158,9 @@ pub trait Verifier<'params, Scheme: CommitmentScheme> {
 
     /// Accumulator fot comressed verification
     type MSMAccumulator;
+
+    /// Query instance or not
+    const QUERY_INSTANCE: bool;
 
     /// Creates new verifier instance
     fn new(params: &'params Scheme::ParamsVerifier) -> Self;

--- a/halo2_proofs/src/poly/ipa/multiopen/prover.rs
+++ b/halo2_proofs/src/poly/ipa/multiopen/prover.rs
@@ -22,6 +22,8 @@ pub struct ProverIPA<'params, C: CurveAffine> {
 }
 
 impl<'params, C: CurveAffine> Prover<'params, IPACommitmentScheme<C>> for ProverIPA<'params, C> {
+    const QUERY_INSTANCE: bool = true;
+
     fn new(params: &'params ParamsIPA<C>) -> Self {
         Self { params }
     }

--- a/halo2_proofs/src/poly/ipa/multiopen/verifier.rs
+++ b/halo2_proofs/src/poly/ipa/multiopen/verifier.rs
@@ -30,6 +30,8 @@ impl<'params, C: CurveAffine> Verifier<'params, IPACommitmentScheme<C>>
     type Guard = GuardIPA<'params, C>;
     type MSMAccumulator = MSMIPA<'params, C>;
 
+    const QUERY_INSTANCE: bool = true;
+
     fn new(params: &'params ParamsVerifierIPA<C>) -> Self {
         Self { params }
     }

--- a/halo2_proofs/src/poly/kzg/multiopen/gwc/prover.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/gwc/prover.rs
@@ -28,6 +28,8 @@ pub struct ProverGWC<'params, E: Engine> {
 
 /// Create a multi-opening proof
 impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>> for ProverGWC<'params, E> {
+    const QUERY_INSTANCE: bool = false;
+
     fn new(params: &'params ParamsKZG<E>) -> Self {
         Self { params }
     }

--- a/halo2_proofs/src/poly/kzg/multiopen/gwc/verifier.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/gwc/verifier.rs
@@ -36,6 +36,8 @@ impl<'params, E: MultiMillerLoop + Debug> Verifier<'params, KZGCommitmentScheme<
     type Guard = GuardKZG<'params, E>;
     type MSMAccumulator = DualMSM<'params, E>;
 
+    const QUERY_INSTANCE: bool = false;
+
     fn new(params: &'params ParamsKZG<E>) -> Self {
         Self { params }
     }

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs
@@ -104,6 +104,8 @@ impl<'a, E: Engine> ProverSHPLONK<'a, E> {
 impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>>
     for ProverSHPLONK<'params, E>
 {
+    const QUERY_INSTANCE: bool = false;
+
     fn new(params: &'params ParamsKZG<E>) -> Self {
         Self { params }
     }

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk/verifier.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk/verifier.rs
@@ -39,6 +39,8 @@ impl<'params, E: MultiMillerLoop + Debug> Verifier<'params, KZGCommitmentScheme<
     type Guard = GuardKZG<'params, E>;
     type MSMAccumulator = DualMSM<'params, E>;
 
+    const QUERY_INSTANCE: bool = false;
+
     fn new(params: &'params ParamsKZG<E>) -> Self {
         Self { params }
     }


### PR DESCRIPTION
This PR aims to make KZG commitment scheme not to query the instance columns from prover, instead calculate the evaluation directly in verifier side.

Current implementation is adding a `const QUERY_INSTANCE: bool` in `Prover` and `Verifier` traits, then in `create_proof` and `verify_proof` it gets the instance evaluation from transcript or by evaluating respectively.