### PR TITLE
Implement multi-phase `ConstraintSystem`

### DIFF
--- a/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
@@ -580,7 +580,7 @@ pub mod tests {
                                     offset: 1,
                                 },
                                 cell_values: vec![(
-                                    ((Any::Advice, 5).into(), 0).into(),
+                                    ((Any::advice(), 5).into(), 0).into(),
                                     format_value(*magnitude_error),
                                 )],
                             },
@@ -589,7 +589,7 @@ pub mod tests {
                                 location: FailureLocation::OutsideRegion { row: 0 },
                             },
                             VerifyFailure::Permutation {
-                                column: (Any::Advice, 4).into(),
+                                column: (Any::advice(), 4).into(),
                                 location: FailureLocation::InRegion {
                                     region: (2, "Short fixed-base mul (incomplete addition)")
                                         .into(),
@@ -631,7 +631,7 @@ pub mod tests {
                             region: (3, "Short fixed-base mul (most significant word)").into(),
                             offset: 1,
                         },
-                        cell_values: vec![(((Any::Advice, 4).into(), 0).into(), "0".to_string())],
+                        cell_values: vec![(((Any::advice(), 4).into(), 0).into(), "0".to_string())],
                     },
                     VerifyFailure::ConstraintNotSatisfied {
                         constraint: (
@@ -646,14 +646,14 @@ pub mod tests {
                         },
                         cell_values: vec![
                             (
-                                ((Any::Advice, 1).into(), 0).into(),
+                                ((Any::advice(), 1).into(), 0).into(),
                                 format_value(negation_check_y),
                             ),
                             (
-                                ((Any::Advice, 3).into(), 0).into(),
+                                ((Any::advice(), 3).into(), 0).into(),
                                 format_value(negation_check_y),
                             ),
-                            (((Any::Advice, 4).into(), 0).into(), "0".to_string()),
+                            (((Any::advice(), 4).into(), 0).into(), "0".to_string()),
                         ],
                     }
                 ])

--- a/halo2_gadgets/src/sha256/table16.rs
+++ b/halo2_gadgets/src/sha256/table16.rs
@@ -141,7 +141,7 @@ impl<const LEN: usize> AssignedBits<LEN> {
 
         let column: Column<Any> = column.into();
         match column.column_type() {
-            Any::Advice => {
+            Any::Advice(_) => {
                 region.assign_advice(annotation, column.try_into().unwrap(), offset, || {
                     value.clone()
                 })
@@ -176,7 +176,7 @@ impl AssignedBits<16> {
         let column: Column<Any> = column.into();
         let value: Value<Bits<16>> = value.map(|v| v.into());
         match column.column_type() {
-            Any::Advice => {
+            Any::Advice(_) => {
                 region.assign_advice(annotation, column.try_into().unwrap(), offset, || {
                     value.clone()
                 })
@@ -211,7 +211,7 @@ impl AssignedBits<32> {
         let column: Column<Any> = column.into();
         let value: Value<Bits<32>> = value.map(|v| v.into());
         match column.column_type() {
-            Any::Advice => {
+            Any::Advice(_) => {
                 region.assign_advice(annotation, column.try_into().unwrap(), offset, || {
                     value.clone()
                 })

--- a/halo2_gadgets/src/utilities.rs
+++ b/halo2_gadgets/src/utilities.rs
@@ -329,7 +329,7 @@ mod tests {
                         region: (0, "range constrain").into(),
                         offset: 0,
                     },
-                    cell_values: vec![(((Any::Advice, 0).into(), 0).into(), "0x8".to_string())],
+                    cell_values: vec![(((Any::advice(), 0).into(), 0).into(), "0x8".to_string())],
                 }])
             );
         }

--- a/halo2_gadgets/src/utilities/decompose_running_sum.rs
+++ b/halo2_gadgets/src/utilities/decompose_running_sum.rs
@@ -358,14 +358,14 @@ mod tests {
                         location: FailureLocation::OutsideRegion { row: 1 },
                     },
                     VerifyFailure::Permutation {
-                        column: (Any::Advice, 0).into(),
+                        column: (Any::advice(), 0).into(),
                         location: FailureLocation::InRegion {
                             region: (0, "decompose").into(),
                             offset: 22,
                         },
                     },
                     VerifyFailure::Permutation {
-                        column: (Any::Advice, 0).into(),
+                        column: (Any::advice(), 0).into(),
                         location: FailureLocation::InRegion {
                             region: (0, "decompose").into(),
                             offset: 45,

--- a/halo2_proofs/examples/shuffle.rs
+++ b/halo2_proofs/examples/shuffle.rs
@@ -1,0 +1,361 @@
+use ff::BatchInvert;
+use halo2_proofs::{
+    arithmetic::{CurveAffine, FieldExt},
+    circuit::{floor_planner::V1, Layouter, Value},
+    dev::{metadata, FailureLocation, MockProver, VerifyFailure},
+    halo2curves::pasta::EqAffine,
+    plonk::*,
+    poly::{
+        commitment::ParamsProver,
+        ipa::{
+            commitment::{IPACommitmentScheme, ParamsIPA},
+            multiopen::{ProverIPA, VerifierIPA},
+            strategy::AccumulatorStrategy,
+        },
+        Rotation, VerificationStrategy,
+    },
+    transcript::{
+        Blake2bRead, Blake2bWrite, Challenge255, TranscriptReadBuffer, TranscriptWriterBuffer,
+    },
+};
+use rand_core::{OsRng, RngCore};
+use std::iter;
+
+fn rand_2d_array<F: FieldExt, R: RngCore, const W: usize, const H: usize>(
+    rng: &mut R,
+) -> [[F; H]; W] {
+    [(); W].map(|_| [(); H].map(|_| F::random(&mut *rng)))
+}
+
+fn shuffled<F: FieldExt, R: RngCore, const W: usize, const H: usize>(
+    original: [[F; H]; W],
+    rng: &mut R,
+) -> [[F; H]; W] {
+    let mut shuffled = original;
+
+    for row in (1..H).rev() {
+        let rand_row = (rng.next_u32() as usize) % row;
+        for column in shuffled.iter_mut() {
+            column.swap(row, rand_row);
+        }
+    }
+
+    shuffled
+}
+
+#[derive(Clone)]
+struct MyConfig<const W: usize> {
+    q_shuffle: Selector,
+    q_first: Selector,
+    q_last: Selector,
+    original: [Column<Advice>; W],
+    shuffled: [Column<Advice>; W],
+    theta: Challenge,
+    gamma: Challenge,
+    z: Column<Advice>,
+}
+
+impl<const W: usize> MyConfig<W> {
+    fn configure<F: FieldExt>(meta: &mut ConstraintSystem<F>) -> Self {
+        let [q_shuffle, q_first, q_last] = [(); 3].map(|_| meta.selector());
+        // First phase
+        let original = [(); W].map(|_| meta.advice_column_in(FirstPhase));
+        let shuffled = [(); W].map(|_| meta.advice_column_in(FirstPhase));
+        let [theta, gamma] = [(); 2].map(|_| meta.challenge_usable_after(FirstPhase));
+        // Second phase
+        let z = meta.advice_column_in(SecondPhase);
+
+        meta.create_gate("z should start with 1", |meta| {
+            let q_first = meta.query_selector(q_first);
+            let z = meta.query_advice(z, Rotation::cur());
+            let one = Expression::Constant(F::one());
+
+            vec![q_first * (one - z)]
+        });
+
+        meta.create_gate("z should end with 1", |meta| {
+            let q_last = meta.query_selector(q_last);
+            let z = meta.query_advice(z, Rotation::cur());
+            let one = Expression::Constant(F::one());
+
+            vec![q_last * (one - z)]
+        });
+
+        meta.create_gate("z should have valid transition", |meta| {
+            let q_shuffle = meta.query_selector(q_shuffle);
+            let original = original.map(|advice| meta.query_advice(advice, Rotation::cur()));
+            let shuffled = shuffled.map(|advice| meta.query_advice(advice, Rotation::cur()));
+            let [theta, gamma] = [theta, gamma].map(|challenge| meta.query_challenge(challenge));
+            let [z, z_w] =
+                [Rotation::cur(), Rotation::next()].map(|rotation| meta.query_advice(z, rotation));
+
+            // Compress
+            let original = original
+                .iter()
+                .cloned()
+                .reduce(|acc, a| acc * theta.clone() + a)
+                .unwrap();
+            let shuffled = shuffled
+                .iter()
+                .cloned()
+                .reduce(|acc, a| acc * theta.clone() + a)
+                .unwrap();
+
+            vec![q_shuffle * (z * (original + gamma.clone()) - z_w * (shuffled + gamma))]
+        });
+
+        Self {
+            q_shuffle,
+            q_first,
+            q_last,
+            original,
+            shuffled,
+            theta,
+            gamma,
+            z,
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+struct MyCircuit<F: FieldExt, const W: usize, const H: usize> {
+    original: Value<[[F; H]; W]>,
+    shuffled: Value<[[F; H]; W]>,
+}
+
+impl<F: FieldExt, const W: usize, const H: usize> MyCircuit<F, W, H> {
+    fn rand<R: RngCore>(rng: &mut R) -> Self {
+        let original = rand_2d_array::<F, _, W, H>(rng);
+        let shuffled = shuffled(original, rng);
+
+        Self {
+            original: Value::known(original),
+            shuffled: Value::known(shuffled),
+        }
+    }
+}
+
+impl<F: FieldExt, const W: usize, const H: usize> Circuit<F> for MyCircuit<F, W, H> {
+    type Config = MyConfig<W>;
+    type FloorPlanner = V1;
+
+    fn without_witnesses(&self) -> Self {
+        Self::default()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        MyConfig::configure(meta)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        let theta = layouter.get_challenge(config.theta);
+        let gamma = layouter.get_challenge(config.gamma);
+
+        layouter.assign_region(
+            || "Shuffle original into shuffled",
+            |mut region| {
+                // Keygen
+                config.q_first.enable(&mut region, 0)?;
+                config.q_last.enable(&mut region, H)?;
+                for offset in 0..H {
+                    config.q_shuffle.enable(&mut region, offset)?;
+                }
+
+                // First phase
+                for (idx, (&column, values)) in config
+                    .original
+                    .iter()
+                    .zip(self.original.transpose_array().iter())
+                    .enumerate()
+                {
+                    for (offset, &value) in values.transpose_array().iter().enumerate() {
+                        region.assign_advice(
+                            || format!("original[{}][{}]", idx, offset),
+                            column,
+                            offset,
+                            || value,
+                        )?;
+                    }
+                }
+                for (idx, (&column, values)) in config
+                    .shuffled
+                    .iter()
+                    .zip(self.shuffled.transpose_array().iter())
+                    .enumerate()
+                {
+                    for (offset, &value) in values.transpose_array().iter().enumerate() {
+                        region.assign_advice(
+                            || format!("shuffled[{}][{}]", idx, offset),
+                            column,
+                            offset,
+                            || value,
+                        )?;
+                    }
+                }
+
+                // Second phase
+                let z = self.original.zip(self.shuffled).zip(theta).zip(gamma).map(
+                    |(((original, shuffled), theta), gamma)| {
+                        let mut product = vec![F::zero(); H];
+                        for (idx, product) in product.iter_mut().enumerate() {
+                            let mut compressed = F::zero();
+                            for value in shuffled.iter() {
+                                compressed *= theta;
+                                compressed += value[idx];
+                            }
+
+                            *product = compressed + gamma
+                        }
+
+                        product.iter_mut().batch_invert();
+
+                        for (idx, product) in product.iter_mut().enumerate() {
+                            let mut compressed = F::zero();
+                            for value in original.iter() {
+                                compressed *= theta;
+                                compressed += value[idx];
+                            }
+
+                            *product *= compressed + gamma
+                        }
+
+                        #[allow(clippy::let_and_return)]
+                        let z = iter::once(F::one())
+                            .chain(product)
+                            .scan(F::one(), |state, cur| {
+                                *state *= &cur;
+                                Some(*state)
+                            })
+                            .collect::<Vec<_>>();
+
+                        #[cfg(feature = "sanity-checks")]
+                        assert_eq!(F::one(), *z.last().unwrap());
+
+                        z
+                    },
+                );
+                for (offset, value) in z.transpose_vec(H + 1).into_iter().enumerate() {
+                    region.assign_advice(
+                        || format!("z[{}]", offset),
+                        config.z,
+                        offset,
+                        || value,
+                    )?;
+                }
+
+                Ok(())
+            },
+        )
+    }
+}
+
+fn test_mock_prover<F: FieldExt, const W: usize, const H: usize>(
+    k: u32,
+    circuit: MyCircuit<F, W, H>,
+    expected: Result<(), Vec<(metadata::Constraint, FailureLocation)>>,
+) {
+    let prover = MockProver::run::<_>(k, &circuit, vec![]).unwrap();
+    match (prover.verify(), expected) {
+        (Ok(_), Ok(_)) => {}
+        (Err(err), Err(expected)) => {
+            assert_eq!(
+                err.into_iter()
+                    .map(|failure| match failure {
+                        VerifyFailure::ConstraintNotSatisfied {
+                            constraint,
+                            location,
+                            ..
+                        } => (constraint, location),
+                        _ => panic!("MockProver::verify has result unmatching expected"),
+                    })
+                    .collect::<Vec<_>>(),
+                expected
+            )
+        }
+        (_, _) => panic!("MockProver::verify has result unmatching expected"),
+    };
+}
+
+fn test_prover<C: CurveAffine, const W: usize, const H: usize>(
+    k: u32,
+    circuit: MyCircuit<C::Scalar, W, H>,
+    expected: bool,
+) {
+    let params = ParamsIPA::<C>::new(k);
+    let vk = keygen_vk(&params, &circuit).unwrap();
+    let pk = keygen_pk(&params, vk, &circuit).unwrap();
+
+    let proof = {
+        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+
+        create_proof::<IPACommitmentScheme<C>, ProverIPA<C>, _, _, _, _>(
+            &params,
+            &pk,
+            &[circuit],
+            &[&[]],
+            OsRng,
+            &mut transcript,
+        )
+        .expect("proof generation should not fail");
+
+        transcript.finalize()
+    };
+
+    let accepted = {
+        let strategy = AccumulatorStrategy::new(&params);
+        let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+
+        verify_proof::<IPACommitmentScheme<C>, VerifierIPA<C>, _, _, _>(
+            &params,
+            pk.get_vk(),
+            strategy,
+            &[&[]],
+            &mut transcript,
+        )
+        .map(|strategy| strategy.finalize())
+        .unwrap_or_default()
+    };
+
+    assert_eq!(accepted, expected);
+}
+
+fn main() {
+    const W: usize = 4;
+    const H: usize = 32;
+    const K: u32 = 8;
+
+    let circuit = &MyCircuit::<_, W, H>::rand(&mut OsRng);
+
+    {
+        test_mock_prover(K, circuit.clone(), Ok(()));
+        test_prover::<EqAffine, W, H>(K, circuit.clone(), true);
+    }
+
+    #[cfg(not(feature = "sanity-checks"))]
+    {
+        use std::ops::IndexMut;
+
+        let mut circuit = circuit.clone();
+        circuit.shuffled = circuit.shuffled.map(|mut shuffled| {
+            shuffled.index_mut(0).swap(0, 1);
+            shuffled
+        });
+
+        test_mock_prover(
+            K,
+            circuit.clone(),
+            Err(vec![(
+                ((1, "z should end with 1").into(), 0, "").into(),
+                FailureLocation::InRegion {
+                    region: (0, "Shuffle original into shuffled").into(),
+                    offset: 32,
+                },
+            )]),
+        );
+        test_prover::<EqAffine, W, H>(K, circuit, false);
+    }
+}

--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -6,7 +6,9 @@ use ff::Field;
 
 use crate::{
     arithmetic::FieldExt,
-    plonk::{Advice, Any, Assigned, Column, Error, Fixed, Instance, Selector, TableColumn},
+    plonk::{
+        Advice, Any, Assigned, Challenge, Column, Error, Fixed, Instance, Selector, TableColumn,
+    },
 };
 
 mod value;
@@ -441,6 +443,11 @@ pub trait Layouter<F: Field> {
         row: usize,
     ) -> Result<(), Error>;
 
+    /// Queries the value of the given challenge.
+    ///
+    /// Returns `Value::unknown()` if the current synthesis phase is before the challenge can be queried.
+    fn get_challenge(&self, challenge: Challenge) -> Value<F>;
+
     /// Gets the "root" of this assignment, bypassing the namespacing.
     ///
     /// Not intended for downstream consumption; use [`Layouter::namespace`] instead.
@@ -504,6 +511,10 @@ impl<'a, F: Field, L: Layouter<F> + 'a> Layouter<F> for NamespacedLayouter<'a, F
         row: usize,
     ) -> Result<(), Error> {
         self.0.constrain_instance(cell, column, row)
+    }
+
+    fn get_challenge(&self, challenge: Challenge) -> Value<F> {
+        self.0.get_challenge(challenge)
     }
 
     fn get_root(&mut self) -> &mut Self::Root {

--- a/halo2_proofs/src/circuit/floor_planner/single_pass.rs
+++ b/halo2_proofs/src/circuit/floor_planner/single_pass.rs
@@ -11,8 +11,8 @@ use crate::{
         Cell, Layouter, Region, RegionIndex, RegionStart, Table, Value,
     },
     plonk::{
-        Advice, Any, Assigned, Assignment, Circuit, Column, Error, Fixed, FloorPlanner, Instance,
-        Selector, TableColumn,
+        Advice, Any, Assigned, Assignment, Challenge, Circuit, Column, Error, Fixed, FloorPlanner,
+        Instance, Selector, TableColumn,
     },
 };
 
@@ -212,6 +212,10 @@ impl<'a, F: Field, CS: Assignment<F> + 'a> Layouter<F> for SingleChipLayouter<'a
             instance.into(),
             row,
         )
+    }
+
+    fn get_challenge(&self, challenge: Challenge) -> Value<F> {
+        self.cs.get_challenge(challenge)
     }
 
     fn get_root(&mut self) -> &mut Self::Root {

--- a/halo2_proofs/src/circuit/floor_planner/v1.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1.rs
@@ -9,8 +9,8 @@ use crate::{
         Cell, Layouter, Region, RegionIndex, RegionStart, Table, Value,
     },
     plonk::{
-        Advice, Any, Assigned, Assignment, Circuit, Column, Error, Fixed, FloorPlanner, Instance,
-        Selector, TableColumn,
+        Advice, Any, Assigned, Assignment, Challenge, Circuit, Column, Error, Fixed, FloorPlanner,
+        Instance, Selector, TableColumn,
     },
 };
 
@@ -196,6 +196,13 @@ impl<'p, 'a, F: Field, CS: Assignment<F> + 'a> Layouter<F> for V1Pass<'p, 'a, F,
         match &mut self.0 {
             Pass::Measurement(_) => Ok(()),
             Pass::Assignment(pass) => pass.constrain_instance(cell, instance, row),
+        }
+    }
+
+    fn get_challenge(&self, challenge: Challenge) -> Value<F> {
+        match &self.0 {
+            Pass::Measurement(_) => Value::unknown(),
+            Pass::Assignment(pass) => pass.plan.cs.get_challenge(challenge),
         }
     }
 

--- a/halo2_proofs/src/circuit/floor_planner/v1/strategy.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1/strategy.rs
@@ -205,7 +205,7 @@ pub fn slot_in_biggest_advice_first(
             .columns()
             .iter()
             .filter(|c| match c {
-                RegionColumn::Column(c) => matches!(c.column_type(), Any::Advice),
+                RegionColumn::Column(c) => matches!(c.column_type(), Any::Advice(_)),
                 _ => false,
             })
             .count();
@@ -231,7 +231,7 @@ fn test_slot_in() {
     let regions = vec![
         RegionShape {
             region_index: 0.into(),
-            columns: vec![Column::new(0, Any::Advice), Column::new(1, Any::Advice)]
+            columns: vec![Column::new(0, Any::advice()), Column::new(1, Any::advice())]
                 .into_iter()
                 .map(|a| a.into())
                 .collect(),
@@ -239,7 +239,7 @@ fn test_slot_in() {
         },
         RegionShape {
             region_index: 1.into(),
-            columns: vec![Column::new(2, Any::Advice)]
+            columns: vec![Column::new(2, Any::advice())]
                 .into_iter()
                 .map(|a| a.into())
                 .collect(),
@@ -247,7 +247,7 @@ fn test_slot_in() {
         },
         RegionShape {
             region_index: 2.into(),
-            columns: vec![Column::new(2, Any::Advice), Column::new(0, Any::Advice)]
+            columns: vec![Column::new(2, Any::advice()), Column::new(0, Any::advice())]
                 .into_iter()
                 .map(|a| a.into())
                 .collect(),

--- a/halo2_proofs/src/dev/cost.rs
+++ b/halo2_proofs/src/dev/cost.rs
@@ -13,8 +13,8 @@ use group::prime::PrimeGroup;
 use crate::{
     circuit::Value,
     plonk::{
-        Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
-        FloorPlanner, Instance, Selector,
+        Advice, Any, Assigned, Assignment, Challenge, Circuit, Column, ConstraintSystem, Error,
+        Fixed, FloorPlanner, Instance, Selector,
     },
     poly::Rotation,
 };
@@ -116,6 +116,10 @@ impl<F: Field> Assignment<F> for Assembly {
         _: Value<Assigned<F>>,
     ) -> Result<(), Error> {
         Ok(())
+    }
+
+    fn get_challenge(&self, _: Challenge) -> Value<F> {
+        Value::unknown()
     }
 
     fn push_namespace<NR, N>(&mut self, _: N)

--- a/halo2_proofs/src/dev/failure/emitter.rs
+++ b/halo2_proofs/src/dev/failure/emitter.rs
@@ -6,7 +6,7 @@ use group::ff::Field;
 use super::FailureLocation;
 use crate::{
     dev::{metadata, util},
-    plonk::{Any, Expression},
+    plonk::{Advice, Any, Expression},
 };
 
 fn padded(p: char, width: usize, text: &str) -> String {
@@ -59,7 +59,7 @@ pub(super) fn render_cell_layout(
                 &format!(
                     "{}{}",
                     match column.column_type {
-                        Any::Advice => "A",
+                        Any::Advice(_) => "A",
                         Any::Fixed => "F",
                         Any::Instance => "I",
                     },
@@ -121,7 +121,13 @@ pub(super) fn expression_to_string<F: Field>(
             layout
                 .get(&query.rotation.0)
                 .unwrap()
-                .get(&(Any::Advice, query.column_index).into())
+                .get(
+                    &(
+                        Any::Advice(Advice { phase: query.phase }),
+                        query.column_index,
+                    )
+                        .into(),
+                )
                 .unwrap()
                 .clone()
         },
@@ -133,6 +139,7 @@ pub(super) fn expression_to_string<F: Field>(
                 .unwrap()
                 .clone()
         },
+        &|challenge| format!("C{}({})", challenge.index(), challenge.phase()),
         &|a| {
             if a.contains(' ') {
                 format!("-({})", a)

--- a/halo2_proofs/src/dev/graph.rs
+++ b/halo2_proofs/src/dev/graph.rs
@@ -4,8 +4,8 @@ use tabbycat::{AttrList, Edge, GraphBuilder, GraphType, Identity, StmtList};
 use crate::{
     circuit::Value,
     plonk::{
-        Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
-        FloorPlanner, Instance, Selector,
+        Advice, Any, Assigned, Assignment, Challenge, Circuit, Column, ConstraintSystem, Error,
+        Fixed, FloorPlanner, Instance, Selector,
     },
 };
 
@@ -155,6 +155,10 @@ impl<F: Field> Assignment<F> for Graph {
         _: Value<Assigned<F>>,
     ) -> Result<(), Error> {
         Ok(())
+    }
+
+    fn get_challenge(&self, _: Challenge) -> Value<F> {
+        Value::unknown()
     }
 
     fn push_namespace<NR, N>(&mut self, name_fn: N)

--- a/halo2_proofs/src/dev/graph/layout.rs
+++ b/halo2_proofs/src/dev/graph/layout.rs
@@ -10,8 +10,8 @@ use std::ops::Range;
 use crate::{
     circuit::{layouter::RegionColumn, Value},
     plonk::{
-        Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
-        FloorPlanner, Instance, Selector,
+        Advice, Any, Assigned, Assignment, Challenge, Circuit, Column, ConstraintSystem, Error,
+        Fixed, FloorPlanner, Instance, Selector,
     },
 };
 
@@ -120,7 +120,7 @@ impl CircuitLayout {
             column.index()
                 + match column.column_type() {
                     Any::Instance => 0,
-                    Any::Advice => cs.num_instance_columns,
+                    Any::Advice(_) => cs.num_instance_columns,
                     Any::Fixed => cs.num_instance_columns + cs.num_advice_columns,
                 }
         };
@@ -488,6 +488,10 @@ impl<F: Field> Assignment<F> for Layout {
         _: Value<Assigned<F>>,
     ) -> Result<(), Error> {
         Ok(())
+    }
+
+    fn get_challenge(&self, _: Challenge) -> Value<F> {
+        Value::unknown()
     }
 
     fn push_namespace<NR, N>(&mut self, _: N)

--- a/halo2_proofs/src/dev/util.rs
+++ b/halo2_proofs/src/dev/util.rs
@@ -6,7 +6,7 @@ use halo2curves::FieldExt;
 use super::{metadata, CellValue, Value};
 use crate::{
     plonk::{
-        AdviceQuery, Any, Column, ColumnType, Expression, FixedQuery, Gate, InstanceQuery,
+        Advice, AdviceQuery, Any, Column, ColumnType, Expression, FixedQuery, Gate, InstanceQuery,
         VirtualCell,
     },
     poly::Rotation,
@@ -38,7 +38,7 @@ impl From<AdviceQuery> for AnyQuery {
     fn from(query: AdviceQuery) -> Self {
         Self {
             index: query.index,
-            column_type: Any::Advice,
+            column_type: Any::Advice(Advice { phase: query.phase }),
             column_index: query.column_index,
             rotation: query.rotation,
         }
@@ -146,6 +146,7 @@ pub(super) fn cell_values<'a, F: FieldExt>(
         &cell_value(virtual_cells, load_fixed),
         &cell_value(virtual_cells, load_advice),
         &cell_value(virtual_cells, load_instance),
+        &|_| BTreeMap::default(),
         &|a| a,
         &|mut a, mut b| {
             a.append(&mut b);

--- a/halo2_proofs/src/plonk/circuit/compress_selectors.rs
+++ b/halo2_proofs/src/plonk/circuit/compress_selectors.rs
@@ -325,6 +325,7 @@ mod tests {
                         },
                         &|_| panic!("should not occur in returned expressions"),
                         &|_| panic!("should not occur in returned expressions"),
+                        &|_| panic!("should not occur in returned expressions"),
                         &|a| -a,
                         &|a, b| a + b,
                         &|a, b| a * b,

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -11,7 +11,8 @@ use super::{
         Selector,
     },
     evaluation::Evaluator,
-    permutation, Assigned, Error, Expression, LagrangeCoeff, Polynomial, ProvingKey, VerifyingKey,
+    permutation, Assigned, Challenge, Error, Expression, LagrangeCoeff, Polynomial, ProvingKey,
+    VerifyingKey,
 };
 use crate::{
     arithmetic::{parallelize, CurveAffine},
@@ -171,6 +172,10 @@ impl<F: Field> Assignment<F> for Assembly<F> {
         }
 
         Ok(())
+    }
+
+    fn get_challenge(&self, _: Challenge) -> Value<F> {
+        Value::unknown()
     }
 
     fn push_namespace<NR, N>(&mut self, _: N)

--- a/halo2_proofs/src/plonk/lookup/prover.rs
+++ b/halo2_proofs/src/plonk/lookup/prover.rs
@@ -78,6 +78,7 @@ impl<F: FieldExt> Argument<F> {
         advice_values: &'a [Polynomial<C::Scalar, LagrangeCoeff>],
         fixed_values: &'a [Polynomial<C::Scalar, LagrangeCoeff>],
         instance_values: &'a [Polynomial<C::Scalar, LagrangeCoeff>],
+        challenges: &'a [C::Scalar],
         mut rng: R,
         transcript: &mut T,
     ) -> Result<Permuted<C>, Error>
@@ -97,6 +98,7 @@ impl<F: FieldExt> Argument<F> {
                         fixed_values,
                         advice_values,
                         instance_values,
+                        challenges,
                     ))
                 })
                 .fold(domain.empty_lagrange(), |acc, expression| {

--- a/halo2_proofs/src/plonk/lookup/verifier.rs
+++ b/halo2_proofs/src/plonk/lookup/verifier.rs
@@ -102,6 +102,7 @@ impl<C: CurveAffine> Evaluated<C> {
         advice_evals: &[C::Scalar],
         fixed_evals: &[C::Scalar],
         instance_evals: &[C::Scalar],
+        challenges: &[C::Scalar],
     ) -> impl Iterator<Item = C::Scalar> + 'a {
         let active_rows = C::Scalar::one() - (l_last + l_blind);
 
@@ -122,6 +123,7 @@ impl<C: CurveAffine> Evaluated<C> {
                             &|query| fixed_evals[query.index],
                             &|query| advice_evals[query.index],
                             &|query| instance_evals[query.index],
+                            &|challenge| challenges[challenge.index()],
                             &|a| -a,
                             &|a, b| a + &b,
                             &|a, b| a * &b,

--- a/halo2_proofs/src/plonk/permutation/prover.rs
+++ b/halo2_proofs/src/plonk/permutation/prover.rs
@@ -98,7 +98,7 @@ impl Argument {
             // Iterate over each column of the permutation
             for (&column, permuted_column_values) in columns.iter().zip(permutations.iter()) {
                 let values = match column.column_type() {
-                    Any::Advice => advice,
+                    Any::Advice(_) => advice,
                     Any::Fixed => fixed,
                     Any::Instance => instance,
                 };
@@ -121,7 +121,7 @@ impl Argument {
             for &column in columns.iter() {
                 let omega = domain.get_omega();
                 let values = match column.column_type() {
-                    Any::Advice => advice,
+                    Any::Advice(_) => advice,
                     Any::Fixed => fixed,
                     Any::Instance => instance,
                 };

--- a/halo2_proofs/src/plonk/permutation/verifier.rs
+++ b/halo2_proofs/src/plonk/permutation/verifier.rs
@@ -160,7 +160,7 @@ impl<C: CurveAffine> Evaluated<C> {
                         for (eval, permutation_eval) in columns
                             .iter()
                             .map(|&column| match column.column_type() {
-                                Any::Advice => {
+                                Any::Advice(_) => {
                                     advice_evals[vk.cs.get_any_query_index(column, Rotation::cur())]
                                 }
                                 Any::Fixed => {
@@ -180,7 +180,7 @@ impl<C: CurveAffine> Evaluated<C> {
                         let mut current_delta = (*beta * &*x)
                             * &(C::Scalar::DELTA.pow_vartime(&[(chunk_index * chunk_len) as u64]));
                         for eval in columns.iter().map(|&column| match column.column_type() {
-                            Any::Advice => {
+                            Any::Advice(_) => {
                                 advice_evals[vk.cs.get_any_query_index(column, Rotation::cur())]
                             }
                             Any::Fixed => {


### PR DESCRIPTION
Resolves #90.

## Major changes

- Add an enum `Phase`, which has 3 variant `First`, `Second` and `Third` (3 phases should be enough for most cases in my imagination).
- Add a field `phase` to struct `Advice`, variant `Any::Advice` and variant `Expression::Advice`.
- Add a struct `Challenge` and can be allocated by `ConstraintSystem::challenge_usable_after(phase)`, and it's also
    1. Used in `VirtualCells::query_challenge(challenge)` to get `Expression::Challenge`.
    2. Used in `Layouter::get_challenge(challenge)` to get `Value<F>` (`Value::unknown` if current phase is earlier than requested `challenge`).
- In `create_proof`, `ConcreteCircuit::FloorPlanner::synthesize` will be call as many time as the phases used in the circuit, and `WitnessCollection` will ignore the advice column assignment if phase doesn't match.
- Add a new example [`shuffle.rs`](https://github.com/han0110/halo2/blob/feature%2Fchallenge-api/halo2_proofs/examples/shuffle.rs) to show how to use multi-phase to roll our own vector shuffle argument.
