### PR TITLE
Add verifying key and proving key serialization

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -52,6 +52,10 @@ halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curv
 rand_core = { version = "0.6", default-features = false }
 tracing = "0.1"
 blake2b_simd = "1"
+serde = { version = "1.0", features = ["derive"] }
+serde_bytes = { version = "0.11.7" }
+serde_with = { version = "2.0.1" }
+bincode = { version = "1.3.3" }
 
 # Developer tooling dependencies
 plotters = { version = "0.3.0", optional = true }

--- a/halo2_proofs/src/helpers.rs
+++ b/halo2_proofs/src/helpers.rs
@@ -25,7 +25,10 @@ impl<F: PrimeField> serde_with::SerializeAs<F> for SerdePrimeField<F> {
     where
         S: serde::Serializer,
     {
-        serde_bytes::serialize(source.to_repr().as_ref(), serializer)
+        Serialize::serialize(
+            serde_bytes::Bytes::new(source.to_repr().as_ref()),
+            serializer,
+        )
     }
 }
 
@@ -35,8 +38,8 @@ impl<'de, F: PrimeField> serde_with::DeserializeAs<'de, F> for SerdePrimeField<F
         D: serde::Deserializer<'de>,
     {
         let mut compressed = F::Repr::default();
-        let bytes: &'_ serde_bytes::Bytes = Deserialize::deserialize(deserializer)?;
-        compressed.as_mut().copy_from_slice(bytes);
+        let bytes: serde_bytes::ByteBuf = Deserialize::deserialize(deserializer)?;
+        compressed.as_mut().copy_from_slice(&bytes);
         Ok(Option::from(F::from_repr(compressed)).unwrap())
         //.ok_or(D::Error::custom("invalid prime field point encoding"))
     }

--- a/halo2_proofs/src/helpers.rs
+++ b/halo2_proofs/src/helpers.rs
@@ -1,6 +1,8 @@
 use std::io;
 
+use ff::PrimeField;
 use halo2curves::CurveAffine;
+use serde::{de::Error, Deserialize, Serialize};
 
 pub(crate) trait CurveRead: CurveAffine {
     /// Reads a compressed element from the buffer and attempts to parse it
@@ -14,3 +16,28 @@ pub(crate) trait CurveRead: CurveAffine {
 }
 
 impl<C: CurveAffine> CurveRead for C {}
+
+#[derive(Clone, Debug)]
+pub struct SerdePrimeField<F: PrimeField>(F);
+
+impl<F: PrimeField> serde_with::SerializeAs<F> for SerdePrimeField<F> {
+    fn serialize_as<S>(source: &F, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serde_bytes::serialize(source.to_repr().as_ref(), serializer)
+    }
+}
+
+impl<'de, F: PrimeField> serde_with::DeserializeAs<'de, F> for SerdePrimeField<F> {
+    fn deserialize_as<D>(deserializer: D) -> Result<F, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut compressed = F::Repr::default();
+        let bytes: &'_ serde_bytes::Bytes = Deserialize::deserialize(deserializer)?;
+        compressed.as_mut().copy_from_slice(bytes);
+        Ok(Option::from(F::from_repr(compressed)).unwrap())
+        //.ok_or(D::Error::custom("invalid prime field point encoding"))
+    }
+}

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -50,14 +50,78 @@ pub struct VerifyingKey<C: CurveAffine> {
     cs_degree: usize,
     /// The representative of this `VerifyingKey` in transcripts.
     transcript_repr: C::Scalar,
+    selectors: Vec<Vec<bool>>,
 }
 
 impl<C: CurveAffine> VerifyingKey<C> {
+    /// Writes a verifying key to a buffer.
+    pub fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        for commitment in &self.fixed_commitments {
+            writer.write_all(commitment.to_bytes().as_ref())?;
+        }
+        self.permutation.write(writer)?;
+
+        // write self.selectors
+        for selector in &self.selectors {
+            let mut selector_bytes = vec![0u8; selector.len() / 8 + 1];
+            for i in 0..selector.len() {
+                let byte_index = i / 8;
+                let bit_index = i % 8;
+                selector_bytes[byte_index] |= (selector[i] as u8) << bit_index;
+            }
+            writer.write_all(&selector_bytes)?;
+        }
+
+        Ok(())
+    }
+
+    /// Reads a verification key from a buffer.
+    pub fn read<'params, R: io::Read, ConcreteCircuit: Circuit<C::Scalar>>(
+        reader: &mut R,
+        params: &impl Params<'params, C>,
+    ) -> io::Result<Self> {
+        let (domain, cs, _) = keygen::create_domain::<C, ConcreteCircuit>(params.k());
+
+        let fixed_commitments: Vec<_> = (0..cs.num_fixed_columns)
+            .map(|_| C::read(reader))
+            .collect::<Result<_, _>>()?;
+
+        let permutation = permutation::VerifyingKey::read(reader, &cs.permutation)?;
+
+        // read selectors
+        let selectors: Vec<Vec<bool>> = vec![vec![false; params.n() as usize]; cs.num_selectors]
+            .into_iter()
+            .map(|mut selector| {
+                let mut selector_bytes = vec![0u8; selector.len() / 8 + 1];
+                reader
+                    .read_exact(&mut selector_bytes)
+                    .expect("unable to read selector bytes");
+                for i in 0..selector.len() {
+                    let byte_index = i / 8;
+                    let bit_index = i % 8;
+                    selector[i] = (selector_bytes[byte_index] >> bit_index) & 1 == 1;
+                }
+                Ok(selector)
+            })
+            .collect::<Result<Vec<Vec<bool>>, &str>>()
+            .unwrap();
+        let (cs, _) = cs.compress_selectors(selectors.clone());
+
+        Ok(Self::from_parts(
+            domain,
+            fixed_commitments,
+            permutation,
+            cs,
+            selectors,
+        ))
+    }
+
     fn from_parts(
         domain: EvaluationDomain<C::Scalar>,
         fixed_commitments: Vec<C>,
         permutation: permutation::VerifyingKey<C>,
         cs: ConstraintSystem<C::Scalar>,
+        selectors: Vec<Vec<bool>>,
     ) -> Self {
         // Compute cached values.
         let cs_degree = cs.degree();
@@ -70,6 +134,7 @@ impl<C: CurveAffine> VerifyingKey<C> {
             cs_degree,
             // Temporary, this is not pinned.
             transcript_repr: C::Scalar::zero(),
+            selectors,
         };
 
         let mut hasher = Blake2bParams::new()

--- a/halo2_proofs/src/plonk/evaluation.rs
+++ b/halo2_proofs/src/plonk/evaluation.rs
@@ -1,3 +1,4 @@
+use crate::helpers::SerdePrimeField;
 use crate::multicore;
 use crate::plonk::lookup::prover::Committed;
 use crate::plonk::permutation::Argument;
@@ -16,6 +17,7 @@ use group::{
     ff::{BatchInvert, Field},
     Curve,
 };
+use serde::{Deserialize, Serialize};
 use std::any::TypeId;
 use std::convert::TryInto;
 use std::num::ParseIntError;
@@ -34,7 +36,7 @@ fn get_rotation_idx(idx: usize, rot: i32, rot_scale: i32, isize: i32) -> usize {
 }
 
 /// Value used in a calculation
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Serialize, Deserialize)]
 pub enum ValueSource {
     /// This is a constant value
     Constant(usize),
@@ -106,7 +108,7 @@ impl ValueSource {
 }
 
 /// Calculation
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Calculation {
     /// This is an addition
     Add(ValueSource, ValueSource),
@@ -180,7 +182,8 @@ impl Calculation {
 }
 
 /// Evaluator
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
+#[serde(bound = "C: CurveAffine")]
 pub struct Evaluator<C: CurveAffine> {
     ///  Custom gates evalution
     pub custom_gates: GraphEvaluator<C>,
@@ -189,9 +192,11 @@ pub struct Evaluator<C: CurveAffine> {
 }
 
 /// GraphEvaluator
-#[derive(Clone, Debug)]
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GraphEvaluator<C: CurveAffine> {
     /// Constants
+    #[serde_as(as = "Vec<SerdePrimeField<C::ScalarExt>>")]
     pub constants: Vec<C::ScalarExt>,
     /// Rotations
     pub rotations: Vec<i32>,
@@ -211,7 +216,7 @@ pub struct EvaluationData<C: CurveAffine> {
 }
 
 /// CaluclationInfo
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CalculationInfo {
     /// Calculation
     pub calculation: Calculation,

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -225,7 +225,7 @@ where
     )?;
 
     let mut fixed = batch_invert_assigned(assembly.fixed);
-    let (cs, selector_polys) = cs.compress_selectors(assembly.selectors);
+    let (cs, selector_polys) = cs.compress_selectors(assembly.selectors.clone());
     fixed.extend(
         selector_polys
             .into_iter()
@@ -246,6 +246,7 @@ where
         fixed_commitments,
         permutation_vk,
         cs,
+        assembly.selectors,
     ))
 }
 

--- a/halo2_proofs/src/plonk/permutation.rs
+++ b/halo2_proofs/src/plonk/permutation.rs
@@ -83,6 +83,21 @@ impl<C: CurveAffine> VerifyingKey<C> {
     pub fn commitments(&self) -> &Vec<C> {
         &self.commitments
     }
+
+    pub(crate) fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        for commitment in &self.commitments {
+            writer.write_all(commitment.to_bytes().as_ref())?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn read<R: io::Read>(reader: &mut R, argument: &Argument) -> io::Result<Self> {
+        let commitments = (0..argument.columns.len())
+            .map(|_| C::read(reader))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(VerifyingKey { commitments })
+    }
 }
 
 /// The proving key for a single permutation argument.

--- a/halo2_proofs/src/plonk/permutation.rs
+++ b/halo2_proofs/src/plonk/permutation.rs
@@ -101,7 +101,7 @@ impl<C: CurveAffine> VerifyingKey<C> {
 }
 
 /// The proving key for a single permutation argument.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ProvingKey<C: CurveAffine> {
     permutations: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
     polys: Vec<Polynomial<C::Scalar, Coeff>>,

--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -5,8 +5,11 @@
 use crate::arithmetic::parallelize;
 use crate::plonk::Assigned;
 
+use ff::PrimeField;
 use group::ff::{BatchInvert, Field};
 use halo2curves::FieldExt;
+use serde::ser::SerializeSeq;
+use serde::{de::Error as DeError, Deserialize, Serialize};
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ops::{Add, Deref, DerefMut, Index, IndexMut, Mul, RangeFrom, RangeFull, Sub};
@@ -61,8 +64,11 @@ impl Basis for ExtendedLagrangeCoeff {}
 
 /// Represents a univariate polynomial defined over a field and a particular
 /// basis.
-#[derive(Clone, Debug)]
+#[serde_with::serde_as]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(bound = "F: PrimeField")]
 pub struct Polynomial<F, B> {
+    #[serde_as(as = "Vec<crate::helpers::SerdePrimeField<F>>")]
     values: Vec<F>,
     _marker: PhantomData<B>,
 }


### PR DESCRIPTION
This PR adds features for reading and writing the verifying key and proving key of any circuit from/to file. 

For verifying key, this uses https://github.com/zcash/halo2/pull/661 which fixes the issue with vkey write not working after selector compression. 

For proving key, this uses serde derive macros and `bincode`. 

Both vkey and pkey serializations have been tested on very large circuits (up to `K = 23`), including circuits created from `plonk-verifier`. There have been no problems even up to pkey of sizes `> 100GB`. 