### PR TITLE
Add support for Column annotations for MockProver debugging

### DIFF
--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -206,6 +206,17 @@ impl<'r, F: Field> Region<'r, F> {
             .enable_selector(&|| annotation().into(), selector, offset)
     }
 
+    /// Annotates a column.
+    pub(crate) fn name_column<A, AR, T>(&mut self, annotation: A, column: T)
+    where
+        A: Fn() -> AR,
+        AR: Into<String>,
+        T: Into<Column<Any>>,
+    {
+        self.region
+            .name_column(&|| annotation().into(), column.into());
+    }
+
     /// Assign an advice column value (witness).
     ///
     /// Even though `to` has `FnMut` bounds, it is guaranteed to be called at most once.

--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -207,7 +207,7 @@ impl<'r, F: Field> Region<'r, F> {
     }
 
     /// Annotates a column.
-    pub(crate) fn name_column<A, AR, T>(&mut self, annotation: A, column: T)
+    pub fn name_column<A, AR, T>(&mut self, annotation: A, column: T)
     where
         A: Fn() -> AR,
         AR: Into<String>,

--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -206,7 +206,10 @@ impl<'r, F: Field> Region<'r, F> {
             .enable_selector(&|| annotation().into(), selector, offset)
     }
 
-    /// Annotates a column.
+    /// Allows the circuit implementor to name/annotate a Column within a Region context.
+    ///
+    /// This is useful in order to improve the amount of information that `prover.verify()`
+    /// and `prover.assert_satisfied()` can provide.
     pub fn name_column<A, AR, T>(&mut self, annotation: A, column: T)
     where
         A: Fn() -> AR,

--- a/halo2_proofs/src/circuit/floor_planner/single_pass.rs
+++ b/halo2_proofs/src/circuit/floor_planner/single_pass.rs
@@ -279,6 +279,14 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F>
         )
     }
 
+    fn name_column<'v>(
+        &'v mut self,
+        annotation: &'v (dyn Fn() -> String + 'v),
+        column: Column<Any>,
+    ) {
+        self.layouter.cs.annotate_column(annotation, column);
+    }
+
     fn assign_advice<'v>(
         &'v mut self,
         annotation: &'v (dyn Fn() -> String + 'v),

--- a/halo2_proofs/src/circuit/floor_planner/v1.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1.rs
@@ -481,6 +481,14 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F> for V1Region<'r
         Ok(())
     }
 
+    fn name_column<'v>(
+        &'v mut self,
+        annotation: &'v (dyn Fn() -> String + 'v),
+        column: Column<Any>,
+    ) {
+        unimplemented!()
+    }
+
     fn constrain_equal(&mut self, left: Cell, right: Cell) -> Result<(), Error> {
         self.plan.cs.copy(
             left.column,

--- a/halo2_proofs/src/circuit/floor_planner/v1.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1.rs
@@ -483,10 +483,10 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F> for V1Region<'r
 
     fn name_column<'v>(
         &'v mut self,
-        annotation: &'v (dyn Fn() -> String + 'v),
-        column: Column<Any>,
+        _annotation: &'v (dyn Fn() -> String + 'v),
+        _column: Column<Any>,
     ) {
-        unimplemented!()
+        // Do nothing
     }
 
     fn constrain_equal(&mut self, left: Cell, right: Cell) -> Result<(), Error> {

--- a/halo2_proofs/src/circuit/floor_planner/v1.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1.rs
@@ -483,10 +483,10 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F> for V1Region<'r
 
     fn name_column<'v>(
         &'v mut self,
-        _annotation: &'v (dyn Fn() -> String + 'v),
-        _column: Column<Any>,
+        annotation: &'v (dyn Fn() -> String + 'v),
+        column: Column<Any>,
     ) {
-        // Do nothing
+        self.plan.cs.annotate_column(annotation, column)
     }
 
     fn constrain_equal(&mut self, left: Cell, right: Cell) -> Result<(), Error> {

--- a/halo2_proofs/src/circuit/layouter.rs
+++ b/halo2_proofs/src/circuit/layouter.rs
@@ -48,6 +48,13 @@ pub trait RegionLayouter<F: Field>: fmt::Debug {
         offset: usize,
     ) -> Result<(), Error>;
 
+    /// Annotate a Column within a Region context.
+    fn name_column<'v>(
+        &'v mut self,
+        annotation: &'v (dyn Fn() -> String + 'v),
+        column: Column<Any>,
+    );
+
     /// Assign an advice column value (witness)
     fn assign_advice<'v>(
         &'v mut self,
@@ -273,6 +280,14 @@ impl<F: Field> RegionLayouter<F> for RegionShape {
             row_offset: offset,
             column: column.into(),
         })
+    }
+
+    fn name_column<'v>(
+        &'v mut self,
+        annotation: &'v (dyn Fn() -> String + 'v),
+        column: Column<Any>,
+    ) {
+        // Do nothing
     }
 
     fn constrain_constant(&mut self, _cell: Cell, _constant: Assigned<F>) -> Result<(), Error> {

--- a/halo2_proofs/src/circuit/layouter.rs
+++ b/halo2_proofs/src/circuit/layouter.rs
@@ -48,7 +48,10 @@ pub trait RegionLayouter<F: Field>: fmt::Debug {
         offset: usize,
     ) -> Result<(), Error>;
 
-    /// Annotate a Column within a Region context.
+    /// Allows the circuit implementor to name/annotate a Column within a Region context.
+    ///
+    /// This is useful in order to improve the amount of information that `prover.verify()`
+    /// and `prover.assert_satisfied()` can provide.
     fn name_column<'v>(
         &'v mut self,
         annotation: &'v (dyn Fn() -> String + 'v),

--- a/halo2_proofs/src/circuit/layouter.rs
+++ b/halo2_proofs/src/circuit/layouter.rs
@@ -284,8 +284,8 @@ impl<F: Field> RegionLayouter<F> for RegionShape {
 
     fn name_column<'v>(
         &'v mut self,
-        annotation: &'v (dyn Fn() -> String + 'v),
-        column: Column<Any>,
+        _annotation: &'v (dyn Fn() -> String + 'v),
+        _column: Column<Any>,
     ) {
         // Do nothing
     }

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -1436,23 +1436,21 @@ mod tests {
         }
 
         let prover = MockProver::run(K, &FaultyCircuit {}, vec![]).unwrap();
-        //print!("{:?}", prover.verify());
-        prover.assert_satisfied();
-        // assert_eq!(
-        //     prover.verify(),
-        //     Err(vec![VerifyFailure::CellNotAssigned {
-        //         gate: (0, "Equality check").into(),
-        //         region: (0, "Faulty synthesis".to_owned()).into(),
-        //         gate_offset: 1,
-        //         column: Column::new(
-        //             1,
-        //             Any::Advice(Advice {
-        //                 phase: FirstPhase.to_sealed()
-        //             })
-        //         ),
-        //         offset: 1,
-        //     }])
-        // );
+        assert_eq!(
+            prover.verify(),
+            Err(vec![VerifyFailure::CellNotAssigned {
+                gate: (0, "Equality check").into(),
+                region: (0, "Faulty synthesis".to_owned()).into(),
+                gate_offset: 1,
+                column: Column::new(
+                    1,
+                    Any::Advice(Advice {
+                        phase: FirstPhase.to_sealed()
+                    })
+                ),
+                offset: 1,
+            }])
+        );
     }
 
     #[test]
@@ -1574,19 +1572,17 @@ mod tests {
         }
 
         let prover = MockProver::run(K, &FaultyCircuit {}, vec![]).unwrap();
-        //print!("{:?}", prover.verify());
-        prover.assert_satisfied();
-        // assert_eq!(
-        //     prover.verify(),
-        //     Err(vec![VerifyFailure::Lookup {
-        //         name: "lookup",
-        //         lookup_index: 0,
-        //         location: FailureLocation::InRegion {
-        //             region: (2, "Faulty synthesis").into(),
-        //             offset: 1,
-        //         }
-        //     }])
-        // );
+        assert_eq!(
+            prover.verify(),
+            Err(vec![VerifyFailure::Lookup {
+                name: "lookup",
+                lookup_index: 0,
+                location: FailureLocation::InRegion {
+                    region: (2, "Faulty synthesis").into(),
+                    offset: 1,
+                }
+            }])
+        );
     }
 
     #[test]
@@ -1713,62 +1709,60 @@ mod tests {
         }
 
         let prover = MockProver::run(K, &FaultyCircuit {}, vec![]).unwrap();
-        //print!("{:?}", prover.verify());
-        prover.assert_satisfied();
-        // assert_eq!(
-        //     prover.verify(),
-        //     Err(vec![VerifyFailure::ConstraintNotSatisfied {
-        //         constraint: ((0, "Equality check").into(), 0, "").into(),
-        //         location: FailureLocation::InRegion {
-        //             region: (1, "Wrong synthesis").into(),
-        //             offset: 0,
-        //         },
-        //         cell_values: vec![
-        //             (
-        //                 (
-        //                     (
-        //                         Any::Advice(Advice {
-        //                             phase: FirstPhase.to_sealed()
-        //                         }),
-        //                         0
-        //                     )
-        //                         .into(),
-        //                     0
-        //                 )
-        //                     .into(),
-        //                 "1".to_string()
-        //             ),
-        //             (
-        //                 (
-        //                     (
-        //                         Any::Advice(Advice {
-        //                             phase: FirstPhase.to_sealed()
-        //                         }),
-        //                         1
-        //                     )
-        //                         .into(),
-        //                     0
-        //                 )
-        //                     .into(),
-        //                 "0".to_string()
-        //             ),
-        //             (
-        //                 (
-        //                     (
-        //                         Any::Advice(Advice {
-        //                             phase: FirstPhase.to_sealed()
-        //                         }),
-        //                         2
-        //                     )
-        //                         .into(),
-        //                     0
-        //                 )
-        //                     .into(),
-        //                 "0x5".to_string()
-        //             ),
-        //             (((Any::Fixed, 0).into(), 0).into(), "0x7".to_string()),
-        //         ],
-        //     },])
-        // )
+        assert_eq!(
+            prover.verify(),
+            Err(vec![VerifyFailure::ConstraintNotSatisfied {
+                constraint: ((0, "Equality check").into(), 0, "").into(),
+                location: FailureLocation::InRegion {
+                    region: (1, "Wrong synthesis").into(),
+                    offset: 0,
+                },
+                cell_values: vec![
+                    (
+                        (
+                            (
+                                Any::Advice(Advice {
+                                    phase: FirstPhase.to_sealed()
+                                }),
+                                0
+                            )
+                                .into(),
+                            0
+                        )
+                            .into(),
+                        "1".to_string()
+                    ),
+                    (
+                        (
+                            (
+                                Any::Advice(Advice {
+                                    phase: FirstPhase.to_sealed()
+                                }),
+                                1
+                            )
+                                .into(),
+                            0
+                        )
+                            .into(),
+                        "0".to_string()
+                    ),
+                    (
+                        (
+                            (
+                                Any::Advice(Advice {
+                                    phase: FirstPhase.to_sealed()
+                                }),
+                                2
+                            )
+                                .into(),
+                            0
+                        )
+                            .into(),
+                        "0x5".to_string()
+                    ),
+                    (((Any::Fixed, 0).into(), 0).into(), "0x7".to_string()),
+                ],
+            },])
+        )
     }
 }

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -1363,7 +1363,7 @@ mod tests {
         circuit::{Layouter, SimpleFloorPlanner, Value},
         plonk::{
             sealed::SealedPhase, Advice, Any, Circuit, Column, ConstraintSystem, Error, Expression,
-            FirstPhase, Fixed, Selector, TableColumn,
+            FirstPhase, Fixed, Instance, Selector, TableColumn,
         },
         poly::Rotation,
     };
@@ -1454,7 +1454,177 @@ mod tests {
     }
 
     #[test]
-    fn bad_lookup() {
+    fn bad_lookup_any() {
+        const K: u32 = 4;
+
+        #[derive(Clone)]
+        struct FaultyCircuitConfig {
+            a: Column<Advice>,
+            table: Column<Instance>,
+            advice_table: Column<Advice>,
+            q: Selector,
+        }
+
+        struct FaultyCircuit {}
+
+        impl Circuit<Fp> for FaultyCircuit {
+            type Config = FaultyCircuitConfig;
+            type FloorPlanner = SimpleFloorPlanner;
+
+            fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+                let a = meta.advice_column();
+                let q = meta.complex_selector();
+                let table = meta.instance_column();
+                let advice_table = meta.advice_column();
+
+                meta.annotate_lookup_any_column(table, || "Inst-Table");
+                meta.enable_equality(table);
+                meta.annotate_lookup_any_column(advice_table, || "Adv-Table");
+                meta.enable_equality(advice_table);
+
+                meta.lookup_any("lookup", |cells| {
+                    let a = cells.query_advice(a, Rotation::cur());
+                    let q = cells.query_selector(q);
+                    let advice_table = cells.query_advice(advice_table, Rotation::cur());
+                    let table = cells.query_instance(table, Rotation::cur());
+
+                    // If q is enabled, a must be in the table.
+                    // When q is not enabled, lookup the default value instead.
+                    let not_q = Expression::Constant(Fp::one()) - q.clone();
+                    let default = Expression::Constant(Fp::from(2));
+                    vec![
+                        (
+                            q.clone() * a.clone() + not_q.clone() * default.clone(),
+                            table,
+                        ),
+                        (q * a + not_q * default, advice_table),
+                    ]
+                });
+
+                FaultyCircuitConfig {
+                    a,
+                    q,
+                    table,
+                    advice_table,
+                }
+            }
+
+            fn without_witnesses(&self) -> Self {
+                Self {}
+            }
+
+            fn synthesize(
+                &self,
+                config: Self::Config,
+                mut layouter: impl Layouter<Fp>,
+            ) -> Result<(), Error> {
+                // No assignment needed for the table as is an Instance Column.
+
+                layouter.assign_region(
+                    || "Good synthesis",
+                    |mut region| {
+                        // Enable the lookup on rows 0 and 1.
+                        config.q.enable(&mut region, 0)?;
+                        config.q.enable(&mut region, 1)?;
+
+                        for i in 0..4 {
+                            // Load Advice lookup table with Instance lookup table values.
+                            region.assign_advice_from_instance(
+                                || "Advice from instance tables",
+                                config.table,
+                                i,
+                                config.advice_table,
+                                i,
+                            )?;
+                        }
+
+                        // Assign a = 2 and a = 6.
+                        region.assign_advice(
+                            || "a = 2",
+                            config.a,
+                            0,
+                            || Value::known(Fp::from(2)),
+                        )?;
+                        region.assign_advice(
+                            || "a = 6",
+                            config.a,
+                            1,
+                            || Value::known(Fp::from(6)),
+                        )?;
+
+                        Ok(())
+                    },
+                )?;
+
+                layouter.assign_region(
+                    || "Faulty synthesis",
+                    |mut region| {
+                        // Enable the lookup on rows 0 and 1.
+                        config.q.enable(&mut region, 0)?;
+                        config.q.enable(&mut region, 1)?;
+
+                        for i in 0..4 {
+                            // Load Advice lookup table with Instance lookup table values.
+                            region.assign_advice_from_instance(
+                                || "Advice from instance tables",
+                                config.table,
+                                i,
+                                config.advice_table,
+                                i,
+                            )?;
+                        }
+
+                        // Assign a = 4.
+                        region.assign_advice(
+                            || "a = 4",
+                            config.a,
+                            0,
+                            || Value::known(Fp::from(4)),
+                        )?;
+
+                        // BUG: Assign a = 5, which doesn't exist in the table!
+                        region.assign_advice(
+                            || "a = 5",
+                            config.a,
+                            1,
+                            || Value::known(Fp::from(5)),
+                        )?;
+
+                        region.name_column(|| "Witness example", config.a);
+
+                        Ok(())
+                    },
+                )
+            }
+        }
+
+        let prover = MockProver::run(
+            K,
+            &FaultyCircuit {},
+            // This is our "lookup table".
+            vec![vec![
+                Fp::from(1u64),
+                Fp::from(2u64),
+                Fp::from(4u64),
+                Fp::from(6u64),
+            ]],
+        )
+        .unwrap();
+        assert_eq!(
+            prover.verify(),
+            Err(vec![VerifyFailure::Lookup {
+                name: "lookup",
+                lookup_index: 0,
+                location: FailureLocation::InRegion {
+                    region: (1, "Faulty synthesis").into(),
+                    offset: 1,
+                }
+            }])
+        );
+    }
+
+    #[test]
+    fn bad_fixed_lookup() {
         const K: u32 = 4;
 
         #[derive(Clone)]

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -898,7 +898,6 @@ impl<F: FieldExt> MockProver<F> {
                                         *input_row,
                                         lookup.input_expressions.iter(),
                                     ),
-                                    //annotations: Some(&self.cs.lookup_annotations),
                                 })
                             } else {
                                 None
@@ -1459,17 +1458,16 @@ mod tests {
         }
 
         let prover = MockProver::run(K, &FaultyCircuit {}, vec![]).unwrap();
-        prover.assert_satisfied();
-        // assert_eq!(
-        //     prover.verify(),
-        //     Err(vec![VerifyFailure::CellNotAssigned {
-        //         gate: (0, "Equality check").into(),
-        //         region: (0, "Faulty synthesis".to_owned()).into(),
-        //         gate_offset: 1,
-        //         column: Column::new(1, Any::Advice),
-        //         offset: 1,
-        //     }])
-        // );
+        assert_eq!(
+            prover.verify(),
+            Err(vec![VerifyFailure::CellNotAssigned {
+                gate: (0, "Equality check").into(),
+                region: (0, "Faulty synthesis".to_owned()).into(),
+                gate_offset: 1,
+                column: Column::new(1, Any::Advice),
+                offset: 1,
+            }])
+        );
     }
 
     #[test]
@@ -1493,7 +1491,7 @@ mod tests {
                 let a = meta.advice_column();
                 let q = meta.complex_selector();
                 let table = meta.lookup_table_column();
-                meta.annotate_lookup_column(table, || "Table Lookup");
+                meta.annotate_lookup_column(table, || "Table1");
 
                 meta.lookup("lookup", |cells| {
                     let a = cells.query_advice(a, Rotation::cur());
@@ -1591,17 +1589,16 @@ mod tests {
         }
 
         let prover = MockProver::run(K, &FaultyCircuit {}, vec![]).unwrap();
-        prover.assert_satisfied();
-        // assert_eq!(
-        //     prover.verify(),
-        //     Err(vec![VerifyFailure::Lookup {
-        //         lookup_index: 0,
-        //         location: FailureLocation::InRegion {
-        //             region: (2, "Faulty synthesis").into(),
-        //             offset: 1,
-        //         }
-        //     }])
-        // );
+        assert_eq!(
+            prover.verify(),
+            Err(vec![VerifyFailure::Lookup {
+                lookup_index: 0,
+                location: FailureLocation::InRegion {
+                    region: (2, "Faulty synthesis").into(),
+                    offset: 1,
+                }
+            }])
+        );
     }
 
     #[test]
@@ -1728,16 +1725,15 @@ mod tests {
         }
 
         let prover = MockProver::run(K, &FaultyCircuit {}, vec![]).unwrap();
-        prover.assert_satisfied();
-        // assert_eq!(
-        //     prover.verify(),
-        //     Err(vec![VerifyFailure::CellNotAssigned {
-        //         gate: (0, "Equality check").into(),
-        //         region: (0, "Faulty synthesis".to_owned()).into(),
-        //         gate_offset: 1,
-        //         column: Column::new(1, Any::Advice),
-        //         offset: 1,
-        //     }])
-        // );
+        assert_eq!(
+            prover.verify(),
+            Err(vec![VerifyFailure::CellNotAssigned {
+                gate: (0, "Equality check").into(),
+                region: (0, "Faulty synthesis".to_owned()).into(),
+                gate_offset: 1,
+                column: Column::new(1, Any::Advice),
+                offset: 1,
+            }])
+        );
     }
 }

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -1727,13 +1727,19 @@ mod tests {
         let prover = MockProver::run(K, &FaultyCircuit {}, vec![]).unwrap();
         assert_eq!(
             prover.verify(),
-            Err(vec![VerifyFailure::CellNotAssigned {
-                gate: (0, "Equality check").into(),
-                region: (0, "Faulty synthesis".to_owned()).into(),
-                gate_offset: 1,
-                column: Column::new(1, Any::Advice),
-                offset: 1,
-            }])
-        );
+            Err(vec![VerifyFailure::ConstraintNotSatisfied {
+                constraint: ((0, "Equality check").into(), 0, "").into(),
+                location: FailureLocation::InRegion {
+                    region: (1, "Wrong synthesis").into(),
+                    offset: 0,
+                },
+                cell_values: vec![
+                    (((Any::Advice, 0).into(), 0).into(), "1".to_string()),
+                    (((Any::Advice, 1).into(), 0).into(), "0".to_string()),
+                    (((Any::Advice, 2).into(), 0).into(), "0x5".to_string()),
+                    (((Any::Fixed, 0).into(), 0).into(), "0x7".to_string()),
+                ],
+            },])
+        )
     }
 }

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -58,7 +58,7 @@ struct Region {
     /// The selectors that have been enabled in this region. All other selectors are by
     /// construction not enabled.
     enabled_selectors: HashMap<Selector, Vec<usize>>,
-    /// Annotations of the columns.
+    /// Annotations given to Advice, Fixed or Instance columns within a region context.
     annotations: HashMap<ColumnMetadata, String>,
     /// The cells assigned in this region. We store this as a `Vec` so that if any cells
     /// are double-assigned, they will be visibly darker.

--- a/halo2_proofs/src/dev/cost.rs
+++ b/halo2_proofs/src/dev/cost.rs
@@ -122,12 +122,12 @@ impl<F: Field> Assignment<F> for Assembly {
         Value::unknown()
     }
 
-    fn annotate_column<A, AR>(&mut self, annotation: A, column: Column<Any>)
+    fn annotate_column<A, AR>(&mut self, _annotation: A, _column: Column<Any>)
     where
         A: FnOnce() -> AR,
         AR: Into<String>,
     {
-        unimplemented!()
+        // Do nothing
     }
 
     fn push_namespace<NR, N>(&mut self, _: N)

--- a/halo2_proofs/src/dev/cost.rs
+++ b/halo2_proofs/src/dev/cost.rs
@@ -122,6 +122,14 @@ impl<F: Field> Assignment<F> for Assembly {
         Value::unknown()
     }
 
+    fn annotate_column<A, AR>(&mut self, annotation: A, column: Column<Any>)
+    where
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
+        unimplemented!()
+    }
+
     fn push_namespace<NR, N>(&mut self, _: N)
     where
         NR: Into<String>,

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -217,7 +217,7 @@ impl<'a> fmt::Display for VerifyFailure<'a> {
 
                     (DebugVirtualCell::from((vc, ann_map)), string)
                 }) {
-                    let _ = writeln!(f, "- {} = {}", dvc, value)?;
+                    writeln!(f, "- {} = {}", dvc, value)?;
                 }
                 Ok(())
             }

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -457,8 +457,8 @@ fn render_lookup<F: FieldExt>(
     // expressions for the table side of lookups.
     let lookup_columns = lookup.table_expressions.iter().map(|expr| {
         expr.evaluate(
-            &|_| panic!("no constants in table expressions"),
-            &|_| panic!("no selectors in table expressions"),
+            &|f| format! {"Const: {:#?}", f},
+            &|s| format! {"S{}", s.0},
             &|query| {
                 format!(
                     "{:?}",
@@ -478,7 +478,7 @@ fn render_lookup<F: FieldExt>(
                         .general_column_annotations
                         .get(&metadata::Column::from((Any::advice(), query.column_index)))
                         .cloned()
-                        .unwrap_or_else(|| format!("I{}", query.column_index()))
+                        .unwrap_or_else(|| format!("A{}", query.column_index()))
                 )
             },
             &|query| {

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::dev::metadata::Constraint;
 use crate::{
-    dev::Value,
+    dev::{Instance, Value},
     plonk::{Any, Column, ConstraintSystem, Expression, Gate},
     poly::Rotation,
 };
@@ -104,6 +104,7 @@ impl<'a> FailureLocation<'a> {
                 region: (r_i, r.name.clone(), &r.annotations).into(),
                 offset: failure_row - r.rows.unwrap().0,
             })
+            .unwrap_or_else(|| FailureLocation::OutsideRegion { row: failure_row })
     }
 }
 
@@ -125,20 +126,6 @@ pub enum VerifyFailure<'a> {
         /// assigned. This may be negative (for example, if a selector enables a gate at
         /// offset 0, but the gate uses `Rotation::prev()`).
         offset: isize,
-    },
-    /// An instance cell used in an active gate was not assigned to.
-    InstanceCellNotAssigned {
-        /// The index of the active gate.
-        gate: metadata::Gate,
-        /// The region in which this gate was activated.
-        region: metadata::Region<'a>,
-        /// The offset (relative to the start of the region) at which the active gate
-        /// queries this cell.
-        gate_offset: usize,
-        /// The column in which this cell should be assigned.
-        column: Column<Instance>,
-        /// The absolute row at which this cell should be assigned.
-        row: usize,
     },
     /// A constraint was not satisfied for a particular row.
     ConstraintNotSatisfied {

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -60,18 +60,6 @@ impl<'a> FailureLocation<'a> {
         }
     }
 
-    /// Fetch the annotation of a `Column` within a `FailureLocation` providing it's associated metadata.
-    ///
-    /// This function will return `None` if:
-    /// - `self` matches to `Self::OutsideRegion`.
-    /// - There's no annotation map generated for the `Region` inside `self`.
-    /// - There's no entry on the annotation map corresponding to the metadata provided.
-    pub(super) fn get_column_annotation(&self, metadata: metadata::Column) -> Option<String> {
-        match self {
-            Self::InRegion { region, .. } => region.get_column_annotation(metadata),
-            _ => None,
-        }
-    }
     pub(super) fn find_expressions<F: Field>(
         cs: &ConstraintSystem<F>,
         regions: &'a [Region],
@@ -219,7 +207,6 @@ impl<'a> fmt::Display for VerifyFailure<'a> {
                 cell_values,
             } => {
                 writeln!(f, "{} is not satisfied {}", constraint, location)?;
-                println!("All OK");
                 for (dvc, value) in cell_values.iter().map(|(vc, string)| {
                     let ann_map = match location {
                         FailureLocation::InRegion { region, offset: _ } => {
@@ -272,6 +259,7 @@ impl<'a> Debug for VerifyFailure<'a> {
                 location,
                 cell_values,
             } => {
+                #[allow(dead_code)]
                 #[derive(Debug)]
                 struct ConstraintCaseDebug<'a> {
                     constraint: Constraint,

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -1,15 +1,16 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::fmt;
-use std::iter;
+use std::fmt::{self, Debug};
 
 use group::ff::Field;
 use halo2curves::FieldExt;
 
+use super::metadata::DebugVirtualCell;
 use super::{
     metadata,
     util::{self, AnyQuery},
     MockProver, Region,
 };
+use crate::dev::metadata::Constraint;
 use crate::{
     dev::Value,
     plonk::{Any, Column, ConstraintSystem, Expression, Gate},
@@ -19,7 +20,7 @@ use crate::{
 mod emitter;
 
 /// The location within the circuit at which a particular [`VerifyFailure`] occurred.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum FailureLocation<'a> {
     /// A location inside a region.
     InRegion {
@@ -106,7 +107,7 @@ impl<'a> FailureLocation<'a> {
 }
 
 /// The reasons why a particular circuit is not satisfied.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 pub enum VerifyFailure<'a> {
     /// A cell used in an active gate was not assigned to.
     CellNotAssigned {
@@ -210,9 +211,17 @@ impl<'a> fmt::Display for VerifyFailure<'a> {
                 cell_values,
             } => {
                 writeln!(f, "{} is not satisfied {}", constraint, location)?;
-                for (name, value) in cell_values {
-                    writeln!(f, "- {} = {}", name, value)?;
+                for (dvc, value) in cell_values.iter().map(|(vc, string)| {
+                    let ann_map = match location {
+                        FailureLocation::InRegion { region, offset } => region.column_annotations,
+                        _ => None,
+                    };
+
+                    (DebugVirtualCell::from((vc, ann_map)), string)
+                }) {
+                    writeln!(f, "- {} = {}", dvc, value);
                 }
+
                 Ok(())
             }
             Self::ConstraintPoisoned { constraint } => {
@@ -240,6 +249,43 @@ impl<'a> fmt::Display for VerifyFailure<'a> {
                     column, location
                 )
             }
+        }
+    }
+}
+
+impl<'a> Debug for VerifyFailure<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VerifyFailure::ConstraintNotSatisfied {
+                constraint,
+                location,
+                cell_values,
+            } => {
+                let constraint: Constraint = constraint.clone();
+                #[derive(Debug)]
+                struct ConstraintCaseDebug<'a> {
+                    constraint: Constraint,
+                    location: FailureLocation<'a>,
+                    cell_values: Vec<(DebugVirtualCell, String)>,
+                }
+
+                let ann_map = match location {
+                    FailureLocation::InRegion { region, offset } => region.column_annotations,
+                    _ => None,
+                };
+
+                let debug = ConstraintCaseDebug {
+                    constraint: constraint.clone(),
+                    location: location.clone(),
+                    cell_values: cell_values
+                        .iter()
+                        .map(|(vc, value)| (DebugVirtualCell::from((vc, ann_map)), value.clone()))
+                        .collect(),
+                };
+
+                write!(f, "{:#?}", debug)
+            }
+            _ => write!(f, "{:#?}", self),
         }
     }
 }

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -459,9 +459,39 @@ fn render_lookup<F: FieldExt>(
         expr.evaluate(
             &|_| panic!("no constants in table expressions"),
             &|_| panic!("no selectors in table expressions"),
-            &|query| format!("F{}", query.column_index),
-            &|query| format! {"A{}", query.column_index},
-            &|query| format! {"I{}", query.column_index},
+            &|query| {
+                format!(
+                    "{:?}",
+                    prover
+                        .cs
+                        .general_column_annotations
+                        .get(&metadata::Column::from((Any::Fixed, query.column_index)))
+                        .cloned()
+                        .unwrap_or_else(|| format!("F{}", query.column_index()))
+                )
+            },
+            &|query| {
+                format!(
+                    "{:?}",
+                    prover
+                        .cs
+                        .general_column_annotations
+                        .get(&metadata::Column::from((Any::advice(), query.column_index)))
+                        .cloned()
+                        .unwrap_or_else(|| format!("I{}", query.column_index()))
+                )
+            },
+            &|query| {
+                format!(
+                    "{:?}",
+                    prover
+                        .cs
+                        .general_column_annotations
+                        .get(&metadata::Column::from((Any::Instance, query.column_index)))
+                        .cloned()
+                        .unwrap_or_else(|| format!("I{}", query.column_index()))
+                )
+            },
             &|challenge| format! {"C{}", challenge.index()},
             &|query| format! {"-{}", query},
             &|a, b| format! {"{} + {}", a,b},
@@ -499,17 +529,8 @@ fn render_lookup<F: FieldExt>(
     }
 
     eprint!(") ∉ (");
-    for (i, column) in table_columns.enumerate() {
-        eprint!(
-            "{}{}",
-            if i == 0 { "" } else { ", " },
-            prover
-                .cs
-                .general_column_annotations
-                .get(&column)
-                .cloned()
-                .unwrap_or_else(|| format!("{}", column))
-        );
+    for (i, column) in lookup_columns.enumerate() {
+        eprint!("{}{}", if i == 0 { "" } else { ", " }, column);
     }
     eprintln!(")");
 

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -217,7 +217,7 @@ impl<'a> fmt::Display for VerifyFailure<'a> {
 
                     (DebugVirtualCell::from((vc, ann_map)), string)
                 }) {
-                    let _ = writeln!(f, "- {} = {}", dvc, value);
+                    let _ = writeln!(f, "- {} = {}", dvc, value)?;
                 }
                 Ok(())
             }

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -346,8 +346,6 @@ fn render_constraint_not_satisfied<F: Field>(
             .or_insert(format!("x{}", i));
     }
 
-    dbg!(location);
-
     eprintln!("error: constraint not satisfied");
     emitter::render_cell_layout("  ", location, &columns, &layout, |_, rotation| {
         if rotation == 0 {
@@ -455,9 +453,19 @@ fn render_lookup<F: FieldExt>(
     for i in 0..lookup.input_expressions.len() {
         eprint!("{}L{}", if i == 0 { "" } else { ", " }, i);
     }
+
     eprint!(") ∉ (");
-    for (i, column) in lookup_columns.enumerate() {
-        eprint!("{}{}", if i == 0 { "" } else { ", " }, column);
+    for (i, column) in table_columns.enumerate() {
+        eprint!(
+            "{}{}",
+            if i == 0 { "" } else { ", " },
+            prover
+                .cs
+                .lookup_annotations
+                .get(&column)
+                .cloned()
+                .unwrap_or_else(|| format!("{}", column))
+        );
     }
     eprintln!(")");
 
@@ -513,24 +521,6 @@ fn render_lookup<F: FieldExt>(
             emitter::expression_to_string(input, &layout)
         );
         eprintln!("    ^");
-        // // Include into the FailureLocation the TableColumns that we want to be annotated when displayed.
-        // let mut location_extended = location.clone();
-        // match location_extended {
-        //     FailureLocation::InRegion { mut region, offset } => {
-        //         if region.column_annotations.is_none() {
-        //             ()
-        //         } else if let Some(annotation) = prover.cs.lookup_annotations.get(&lookup_index) {
-        //             region
-        //                 .column_annotations
-        //                 .as_mut()
-        //                 .unwrap()
-        //                 .insert(lookup_index, annotation.clone());
-        //         } else {
-        //             ()
-        //         }
-        //     }
-        //     _ => (),
-        // };
 
         emitter::render_cell_layout("    | ", location, &columns, &layout, |_, rotation| {
             if rotation == 0 {

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -178,8 +178,6 @@ pub enum VerifyFailure<'a> {
         /// - The input expressions use a column queried at a non-zero `Rotation`, and the
         ///   lookup is active on a row adjacent to an unrelated region.
         location: FailureLocation<'a>,
-        // Maps lookup columns to their annotations from an outside-region perspective.
-        //annotations: Option<&'a HashMap<usize, String>>,
     },
     /// A permutation did not preserve the original value of a cell.
     Permutation {

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -1,14 +1,15 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::{self, Debug};
 
 use group::ff::Field;
 use halo2curves::FieldExt;
 
 use super::metadata::DebugVirtualCell;
+use super::MockProver;
 use super::{
     metadata,
     util::{self, AnyQuery},
-    MockProver, Region,
+    Region,
 };
 use crate::dev::metadata::Constraint;
 use crate::{
@@ -213,13 +214,15 @@ impl<'a> fmt::Display for VerifyFailure<'a> {
                 writeln!(f, "{} is not satisfied {}", constraint, location)?;
                 for (dvc, value) in cell_values.iter().map(|(vc, string)| {
                     let ann_map = match location {
-                        FailureLocation::InRegion { region, offset } => region.column_annotations,
+                        FailureLocation::InRegion { region, offset: _ } => {
+                            region.column_annotations
+                        }
                         _ => None,
                     };
 
                     (DebugVirtualCell::from((vc, ann_map)), string)
                 }) {
-                    writeln!(f, "- {} = {}", dvc, value);
+                    let _ = writeln!(f, "- {} = {}", dvc, value);
                 }
 
                 Ok(())
@@ -261,7 +264,6 @@ impl<'a> Debug for VerifyFailure<'a> {
                 location,
                 cell_values,
             } => {
-                let constraint: Constraint = constraint.clone();
                 #[derive(Debug)]
                 struct ConstraintCaseDebug<'a> {
                     constraint: Constraint,
@@ -270,12 +272,12 @@ impl<'a> Debug for VerifyFailure<'a> {
                 }
 
                 let ann_map = match location {
-                    FailureLocation::InRegion { region, offset } => region.column_annotations,
+                    FailureLocation::InRegion { region, offset: _ } => region.column_annotations,
                     _ => None,
                 };
 
                 let debug = ConstraintCaseDebug {
-                    constraint: constraint.clone(),
+                    constraint: *constraint,
                     location: location.clone(),
                     cell_values: cell_values
                         .iter()

--- a/halo2_proofs/src/dev/failure/emitter.rs
+++ b/halo2_proofs/src/dev/failure/emitter.rs
@@ -5,7 +5,7 @@ use group::ff::Field;
 
 use super::FailureLocation;
 use crate::{
-    dev::{metadata, util, MockProver},
+    dev::{metadata, util},
     plonk::{Any, Expression},
 };
 
@@ -68,9 +68,9 @@ pub(super) fn render_cell_layout(
         .iter()
         .map(|(col, _)| {
             let size = match location {
-                FailureLocation::InRegion { region, offset } => {
+                FailureLocation::InRegion { region, offset: _ } => {
                     if let Some(column_ann) = region.column_annotations {
-                        if let Some(ann) = column_ann.get(&col) {
+                        if let Some(ann) = column_ann.get(col) {
                             ann.len()
                         } else {
                             col_width(column_type_and_idx(col).as_str().len())
@@ -79,7 +79,7 @@ pub(super) fn render_cell_layout(
                         col_width(column_type_and_idx(col).as_str().len())
                     }
                 }
-                FailureLocation::OutsideRegion { row } => {
+                FailureLocation::OutsideRegion { row: _ } => {
                     col_width(column_type_and_idx(col).as_str().len())
                 }
             };
@@ -88,35 +88,33 @@ pub(super) fn render_cell_layout(
         .collect();
 
     // Print the assigned cells, and their region offset or rotation + the column name at which they're assigned to.
-    for ((column, cells), &width) in columns.iter().zip(widths.iter()) {
+    for ((column, _), &width) in columns.iter().zip(widths.iter()) {
         //let width = col_width(*cells);
         eprint!(
             "{}|",
             padded(
                 ' ',
                 width,
-                &format!(
-                    "{}",
-                    match location {
-                        FailureLocation::InRegion { region, offset } => {
-                            region
-                                .column_annotations
-                                .map(|column_ann| column_ann.get(&column).cloned())
-                                .flatten()
-                                .unwrap_or_else(|| column_type_and_idx(column))
-                        }
-                        FailureLocation::OutsideRegion { row } => {
-                            column_type_and_idx(column)
-                        }
+                &match location {
+                    FailureLocation::InRegion { region, offset: _ } => {
+                        region
+                            .column_annotations
+                            .map(|column_ann| column_ann.get(column).cloned())
+                            .flatten()
+                            .unwrap_or_else(|| column_type_and_idx(column))
                     }
-                )
+                    FailureLocation::OutsideRegion { row: _ } => {
+                        column_type_and_idx(column)
+                    }
+                }
+                .to_string()
             )
         );
     }
 
     eprintln!();
     eprint!("{}  +--------+", prefix);
-    for (cells, &width) in columns.values().zip(widths.iter()) {
+    for &width in widths.iter() {
         eprint!("{}+", padded('-', width, ""));
     }
     eprintln!();
@@ -126,7 +124,7 @@ pub(super) fn render_cell_layout(
             prefix,
             padded(' ', 8, &(offset.unwrap_or(0) + rotation).to_string())
         );
-        for ((col, cells), &width) in columns.iter().zip(widths.iter()) {
+        for ((col, _), &width) in columns.iter().zip(widths.iter()) {
             //let width = col_width(*cells);
             eprint!(
                 "{}|",

--- a/halo2_proofs/src/dev/failure/emitter.rs
+++ b/halo2_proofs/src/dev/failure/emitter.rs
@@ -98,8 +98,7 @@ pub(super) fn render_cell_layout(
                     FailureLocation::InRegion { region, offset: _ } => {
                         region
                             .column_annotations
-                            .map(|column_ann| column_ann.get(column).cloned())
-                            .flatten()
+                            .and_then(|column_ann| column_ann.get(column).cloned())
                             .unwrap_or_else(|| column_type_and_idx(column))
                     }
                     FailureLocation::OutsideRegion { row: _ } => {

--- a/halo2_proofs/src/dev/failure/emitter.rs
+++ b/halo2_proofs/src/dev/failure/emitter.rs
@@ -89,7 +89,6 @@ pub(super) fn render_cell_layout(
 
     // Print the assigned cells, and their region offset or rotation + the column name at which they're assigned to.
     for ((column, _), &width) in columns.iter().zip(widths.iter()) {
-        //let width = col_width(*cells);
         eprint!(
             "{}|",
             padded(
@@ -125,7 +124,6 @@ pub(super) fn render_cell_layout(
             padded(' ', 8, &(offset.unwrap_or(0) + rotation).to_string())
         );
         for ((col, _), &width) in columns.iter().zip(widths.iter()) {
-            //let width = col_width(*cells);
             eprint!(
                 "{}|",
                 padded(

--- a/halo2_proofs/src/dev/failure/emitter.rs
+++ b/halo2_proofs/src/dev/failure/emitter.rs
@@ -6,7 +6,7 @@ use group::ff::Field;
 use super::FailureLocation;
 use crate::{
     dev::{metadata, util},
-    plonk::{Any, Expression},
+    plonk::{Advice, Any, Expression},
 };
 
 fn padded(p: char, width: usize, text: &str) -> String {
@@ -24,7 +24,7 @@ fn column_type_and_idx(column: &metadata::Column) -> String {
     format!(
         "{}{}",
         match column.column_type {
-            Any::Advice => "A",
+            Any::Advice(_) => "A",
             Any::Fixed => "F",
             Any::Instance => "I",
         },

--- a/halo2_proofs/src/dev/failure/emitter.rs
+++ b/halo2_proofs/src/dev/failure/emitter.rs
@@ -5,8 +5,8 @@ use group::ff::Field;
 
 use super::FailureLocation;
 use crate::{
-    dev::{metadata, util},
-    plonk::{Advice, Any, Expression},
+    dev::{metadata, util, MockProver},
+    plonk::{Any, Expression},
 };
 
 fn padded(p: char, width: usize, text: &str) -> String {
@@ -99,15 +99,11 @@ pub(super) fn render_cell_layout(
                     "{}",
                     match location {
                         FailureLocation::InRegion { region, offset } => {
-                            if let Some(column_ann) = region.column_annotations {
-                                if let Some(ann) = column_ann.get(&column) {
-                                    format!("{}{}", ann.as_str(), "".to_string())
-                                } else {
-                                    column_type_and_idx(column)
-                                }
-                            } else {
-                                column_type_and_idx(column)
-                            }
+                            region
+                                .column_annotations
+                                .map(|column_ann| column_ann.get(&column).cloned())
+                                .flatten()
+                                .unwrap_or_else(|| column_type_and_idx(column))
                         }
                         FailureLocation::OutsideRegion { row } => {
                             column_type_and_idx(column)

--- a/halo2_proofs/src/dev/failure/emitter.rs
+++ b/halo2_proofs/src/dev/failure/emitter.rs
@@ -11,11 +11,24 @@ use crate::{
 
 fn padded(p: char, width: usize, text: &str) -> String {
     let pad = width - text.len();
+
     format!(
         "{}{}{}",
         iter::repeat(p).take(pad - pad / 2).collect::<String>(),
         text,
         iter::repeat(p).take(pad / 2).collect::<String>(),
+    )
+}
+
+fn column_type_and_idx(column: &metadata::Column) -> String {
+    format!(
+        "{}{}",
+        match column.column_type {
+            Any::Advice => "A",
+            Any::Fixed => "F",
+            Any::Instance => "I",
+        },
+        column.index
     )
 }
 
@@ -32,46 +45,83 @@ pub(super) fn render_cell_layout(
     highlight_row: impl Fn(Option<i32>, i32),
 ) {
     let col_width = |cells: usize| cells.to_string().len() + 3;
+    let mut col_headers = String::new();
 
     // If we are in a region, show rows at offsets relative to it. Otherwise, just show
     // the rotations directly.
     let offset = match location {
         FailureLocation::InRegion { region, offset } => {
-            eprintln!("{}Cell layout in region '{}':", prefix, region.name);
-            eprint!("{}  | Offset |", prefix);
+            col_headers
+                .push_str(format!("{}Cell layout in region '{}':\n", prefix, region.name).as_str());
+            col_headers.push_str(format!("{}  | Offset |", prefix).as_str());
             Some(*offset as i32)
         }
         FailureLocation::OutsideRegion { row } => {
-            eprintln!("{}Cell layout at row {}:", prefix, row);
-            eprint!("{}  |Rotation|", prefix);
+            col_headers.push_str(format!("{}Cell layout at row {}:\n", prefix, row).as_str());
+            col_headers.push_str(format!("{}  |Rotation|", prefix).as_str());
             None
         }
     };
+    eprint!("\n{}", col_headers);
 
-    // Print the assigned cells, and their region offset or rotation.
-    for (column, cells) in columns {
-        let width = col_width(*cells);
+    let widths: Vec<usize> = columns
+        .iter()
+        .map(|(col, _)| {
+            let size = match location {
+                FailureLocation::InRegion { region, offset } => {
+                    if let Some(column_ann) = region.column_annotations {
+                        if let Some(ann) = column_ann.get(&col) {
+                            ann.len()
+                        } else {
+                            col_width(column_type_and_idx(col).as_str().len())
+                        }
+                    } else {
+                        col_width(column_type_and_idx(col).as_str().len())
+                    }
+                }
+                FailureLocation::OutsideRegion { row } => {
+                    col_width(column_type_and_idx(col).as_str().len())
+                }
+            };
+            size
+        })
+        .collect();
+
+    // Print the assigned cells, and their region offset or rotation + the column name at which they're assigned to.
+    for ((column, cells), &width) in columns.iter().zip(widths.iter()) {
+        //let width = col_width(*cells);
         eprint!(
             "{}|",
             padded(
                 ' ',
                 width,
                 &format!(
-                    "{}{}",
-                    match column.column_type {
-                        Any::Advice(_) => "A",
-                        Any::Fixed => "F",
-                        Any::Instance => "I",
-                    },
-                    column.index,
+                    "{}",
+                    match location {
+                        FailureLocation::InRegion { region, offset } => {
+                            if let Some(column_ann) = region.column_annotations {
+                                if let Some(ann) = column_ann.get(&column) {
+                                    format!("{}{}", ann.as_str(), "".to_string())
+                                } else {
+                                    column_type_and_idx(column)
+                                }
+                            } else {
+                                column_type_and_idx(column)
+                            }
+                        }
+                        FailureLocation::OutsideRegion { row } => {
+                            column_type_and_idx(column)
+                        }
+                    }
                 )
             )
         );
     }
+
     eprintln!();
     eprint!("{}  +--------+", prefix);
-    for cells in columns.values() {
-        eprint!("{}+", padded('-', col_width(*cells), ""));
+    for (cells, &width) in columns.values().zip(widths.iter()) {
+        eprint!("{}+", padded('-', width, ""));
     }
     eprintln!();
     for (rotation, row) in layout {
@@ -80,8 +130,8 @@ pub(super) fn render_cell_layout(
             prefix,
             padded(' ', 8, &(offset.unwrap_or(0) + rotation).to_string())
         );
-        for (col, cells) in columns {
-            let width = col_width(*cells);
+        for ((col, cells), &width) in columns.iter().zip(widths.iter()) {
+            //let width = col_width(*cells);
             eprint!(
                 "{}|",
                 padded(

--- a/halo2_proofs/src/dev/graph.rs
+++ b/halo2_proofs/src/dev/graph.rs
@@ -99,6 +99,14 @@ impl<F: Field> Assignment<F> for Graph {
         Ok(())
     }
 
+    fn annotate_column<A, AR>(&mut self, _annotation: A, _column: Column<Any>)
+    where
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
+        // Do nothing
+    }
+
     fn query_instance(&self, _: Column<Instance>, _: usize) -> Result<Value<F>, Error> {
         Ok(Value::unknown())
     }

--- a/halo2_proofs/src/dev/graph/layout.rs
+++ b/halo2_proofs/src/dev/graph/layout.rs
@@ -494,6 +494,14 @@ impl<F: Field> Assignment<F> for Layout {
         Value::unknown()
     }
 
+    fn annotate_column<A, AR>(&mut self, _annotation: A, _column: Column<Any>)
+    where
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
+        // Do nothing
+    }
+
     fn push_namespace<NR, N>(&mut self, _: N)
     where
         NR: Into<String>,

--- a/halo2_proofs/src/dev/metadata.rs
+++ b/halo2_proofs/src/dev/metadata.rs
@@ -160,11 +160,7 @@ pub struct Region<'a> {
 
 impl<'a> Debug for Region<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Region {} ('{}') with annotations: \n{:#?}",
-            self.index, self.name, self.column_annotations
-        )
+        write!(f, "Region {} ('{}')", self.index, self.name)
     }
 }
 

--- a/halo2_proofs/src/dev/metadata.rs
+++ b/halo2_proofs/src/dev/metadata.rs
@@ -36,6 +36,42 @@ impl From<plonk::Column<Any>> for Column {
     }
 }
 
+/// A helper structure that allows to print a Column with it's annotation as a single structure.
+#[derive(Debug, Clone)]
+struct DebugColumn {
+    /// The type of the column.
+    column_type: Any,
+    /// The index of the column.
+    index: usize,
+    /// Annotation of the column
+    annotation: String,
+}
+
+impl From<(Column, Option<&HashMap<Column, String>>)> for DebugColumn {
+    fn from(info: (Column, Option<&HashMap<Column, String>>)) -> Self {
+        DebugColumn {
+            column_type: info.0.column_type,
+            index: info.0.index,
+            annotation: info
+                .1
+                .map(|map| map.get(&info.0))
+                .flatten()
+                .cloned()
+                .unwrap_or_else(|| String::new()),
+        }
+    }
+}
+
+impl fmt::Display for DebugColumn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Column('{:?}', {} - {})",
+            self.column_type, self.index, self.annotation
+        )
+    }
+}
+
 /// A "virtual cell" is a PLONK cell that has been queried at a particular relative offset
 /// within a custom gate.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -85,8 +121,35 @@ impl fmt::Display for VirtualCell {
     }
 }
 
+#[derive(Clone, Debug)]
+pub(super) struct DebugVirtualCell {
+    name: &'static str,
+    column: DebugColumn,
+    rotation: i32,
+}
+
+impl From<(&VirtualCell, Option<&HashMap<Column, String>>)> for DebugVirtualCell {
+    fn from(info: (&VirtualCell, Option<&HashMap<Column, String>>)) -> Self {
+        DebugVirtualCell {
+            name: info.0.name,
+            column: DebugColumn::from((info.0.column, info.1)),
+            rotation: info.0.rotation,
+        }
+    }
+}
+
+impl fmt::Display for DebugVirtualCell {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}@{}", self.column, self.rotation)?;
+        if !self.name.is_empty() {
+            write!(f, "({})", self.name)?;
+        }
+        Ok(())
+    }
+}
+
 /// Metadata about a configured gate within a circuit.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Gate {
     /// The index of the active gate. These indices are assigned in the order in which
     /// `ConstraintSystem::create_gate` is called during `Circuit::configure`.
@@ -109,7 +172,7 @@ impl From<(usize, &'static str)> for Gate {
 }
 
 /// Metadata about a configured constraint within a circuit.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Constraint {
     /// The gate containing the constraint.
     pub(super) gate: Gate,

--- a/halo2_proofs/src/dev/metadata.rs
+++ b/halo2_proofs/src/dev/metadata.rs
@@ -38,7 +38,7 @@ impl From<plonk::Column<Any>> for Column {
 
 /// A helper structure that allows to print a Column with it's annotation as a single structure.
 #[derive(Debug, Clone)]
-struct DebugColumn {
+pub(super) struct DebugColumn {
     /// The type of the column.
     column_type: Any,
     /// The index of the column.
@@ -57,7 +57,7 @@ impl From<(Column, Option<&HashMap<Column, String>>)> for DebugColumn {
                 .map(|map| map.get(&info.0))
                 .flatten()
                 .cloned()
-                .unwrap_or_else(String::new),
+                .unwrap_or_default(),
         }
     }
 }

--- a/halo2_proofs/src/dev/metadata.rs
+++ b/halo2_proofs/src/dev/metadata.rs
@@ -57,7 +57,7 @@ impl From<(Column, Option<&HashMap<Column, String>>)> for DebugColumn {
                 .map(|map| map.get(&info.0))
                 .flatten()
                 .cloned()
-                .unwrap_or_else(|| String::new()),
+                .unwrap_or_else(String::new),
         }
     }
 }
@@ -223,11 +223,7 @@ pub struct Region<'a> {
 
 impl<'a> PartialEq for Region<'a> {
     fn eq(&self, other: &Self) -> bool {
-        if self.index == other.index && self.name == other.name {
-            true
-        } else {
-            false
-        }
+        self.index == other.index && self.name == other.name
     }
 }
 

--- a/halo2_proofs/src/dev/metadata.rs
+++ b/halo2_proofs/src/dev/metadata.rs
@@ -222,6 +222,18 @@ pub struct Region<'a> {
     pub(super) column_annotations: Option<&'a HashMap<ColumnMetadata, String>>,
 }
 
+impl<'a> Region<'a> {
+    /// Fetch the annotation of a `Column` within a `Region` providing it's associated metadata.
+    ///
+    /// This function will return `None` if:
+    /// - There's no annotation map generated for this `Region`.
+    /// - There's no entry on the annotation map corresponding to the metadata provided.
+    pub(crate) fn get_column_annotation(&self, metadata: ColumnMetadata) -> Option<String> {
+        self.column_annotations
+            .and_then(|map| map.get(&metadata).cloned())
+    }
+}
+
 impl<'a> PartialEq for Region<'a> {
     fn eq(&self, other: &Self) -> bool {
         self.index == other.index && self.name == other.name

--- a/halo2_proofs/src/dev/metadata.rs
+++ b/halo2_proofs/src/dev/metadata.rs
@@ -1,10 +1,13 @@
 //! Metadata about circuits.
 
+use super::metadata::Column as ColumnMetadata;
 use crate::plonk::{self, Any};
-use std::fmt;
-
+use std::{
+    collections::HashMap,
+    fmt::{self, Debug},
+};
 /// Metadata about a column within a circuit.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Column {
     /// The type of the column.
     pub(super) column_type: Any,
@@ -143,33 +146,74 @@ impl From<(Gate, usize, &'static str)> for Constraint {
 }
 
 /// Metadata about an assigned region within a circuit.
-#[derive(Clone, Debug, PartialEq)]
-pub struct Region {
+#[derive(Clone, PartialEq, Eq)]
+pub struct Region<'a> {
     /// The index of the region. These indices are assigned in the order in which
     /// `Layouter::assign_region` is called during `Circuit::synthesize`.
     pub(super) index: usize,
     /// The name of the region. This is specified by the region creator (such as a chip
     /// implementation), and is not enforced to be unique.
     pub(super) name: String,
+    /// A reference to the in-Region annotations
+    pub(super) column_annotations: Option<&'a HashMap<ColumnMetadata, String>>,
 }
 
-impl fmt::Display for Region {
+impl<'a> Debug for Region<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Region {} ('{}') with annotations: \n{:#?}",
+            self.index, self.name, self.column_annotations
+        )
+    }
+}
+
+impl<'a> fmt::Display for Region<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Region {} ('{}')", self.index, self.name)
     }
 }
 
-impl From<(usize, String)> for Region {
+impl<'a> From<(usize, String)> for Region<'a> {
     fn from((index, name): (usize, String)) -> Self {
-        Region { index, name }
+        Region {
+            index,
+            name,
+            column_annotations: None,
+        }
     }
 }
 
-impl From<(usize, &str)> for Region {
+impl<'a> From<(usize, &str)> for Region<'a> {
     fn from((index, name): (usize, &str)) -> Self {
         Region {
             index,
             name: name.to_owned(),
+            column_annotations: None,
+        }
+    }
+}
+
+impl<'a> From<(usize, String, &'a HashMap<ColumnMetadata, String>)> for Region<'a> {
+    fn from(
+        (index, name, annotations): (usize, String, &'a HashMap<ColumnMetadata, String>),
+    ) -> Self {
+        Region {
+            index,
+            name,
+            column_annotations: Some(annotations),
+        }
+    }
+}
+
+impl<'a> From<(usize, &str, &'a HashMap<ColumnMetadata, String>)> for Region<'a> {
+    fn from(
+        (index, name, annotations): (usize, &str, &'a HashMap<ColumnMetadata, String>),
+    ) -> Self {
+        Region {
+            index,
+            name: name.to_owned(),
+            column_annotations: Some(annotations),
         }
     }
 }

--- a/halo2_proofs/src/dev/metadata.rs
+++ b/halo2_proofs/src/dev/metadata.rs
@@ -146,7 +146,7 @@ impl From<(Gate, usize, &'static str)> for Constraint {
 }
 
 /// Metadata about an assigned region within a circuit.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct Region<'a> {
     /// The index of the region. These indices are assigned in the order in which
     /// `Layouter::assign_region` is called during `Circuit::synthesize`.
@@ -157,6 +157,18 @@ pub struct Region<'a> {
     /// A reference to the in-Region annotations
     pub(super) column_annotations: Option<&'a HashMap<ColumnMetadata, String>>,
 }
+
+impl<'a> PartialEq for Region<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.index == other.index && self.name == other.name {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<'a> Eq for Region<'a> {}
 
 impl<'a> Debug for Region<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/halo2_proofs/src/dev/metadata.rs
+++ b/halo2_proofs/src/dev/metadata.rs
@@ -121,6 +121,7 @@ impl fmt::Display for VirtualCell {
     }
 }
 
+/// Helper structure used to be able to inject Column annotations inside a `Display` or `Debug` call.
 #[derive(Clone, Debug)]
 pub(super) struct DebugVirtualCell {
     name: &'static str,
@@ -217,7 +218,7 @@ pub struct Region<'a> {
     /// The name of the region. This is specified by the region creator (such as a chip
     /// implementation), and is not enforced to be unique.
     pub(super) name: String,
-    /// A reference to the in-Region annotations
+    /// A reference to the annotations of the Columns that exist within this `Region`.
     pub(super) column_annotations: Option<&'a HashMap<ColumnMetadata, String>>,
 }
 

--- a/halo2_proofs/src/dev/metadata.rs
+++ b/halo2_proofs/src/dev/metadata.rs
@@ -54,8 +54,7 @@ impl From<(Column, Option<&HashMap<Column, String>>)> for DebugColumn {
             index: info.0.index,
             annotation: info
                 .1
-                .map(|map| map.get(&info.0))
-                .flatten()
+                .and_then(|map| map.get(&info.0))
                 .cloned()
                 .unwrap_or_default(),
         }

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -1,6 +1,7 @@
 use core::cmp::max;
 use core::ops::{Add, Mul};
 use ff::Field;
+use std::collections::HashMap;
 use std::{
     convert::TryFrom,
     ops::{Neg, Sub},
@@ -523,6 +524,12 @@ pub trait Assignment<F: Field> {
     where
         NR: Into<String>,
         N: FnOnce() -> NR;
+
+    /// TODO: Document
+    fn annotate_column<A, AR>(&mut self, annotation: A, column: Column<Any>)
+    where
+        A: FnOnce() -> AR,
+        AR: Into<String>;
 
     /// Exits the current region.
     ///
@@ -1373,6 +1380,9 @@ pub struct ConstraintSystem<F: Field> {
     // input expressions and a sequence of table expressions involved in the lookup.
     pub(crate) lookups: Vec<lookup::Argument<F>>,
 
+    // List of indexes of Fixed columns which are associated to a `TableColumn` tied to their annotation.
+    pub(crate) lookup_annotations: HashMap<usize, String>,
+
     // Vector of fixed columns, which can be used to store constant values
     // that are copied into advice columns.
     pub(crate) constants: Vec<Column<Fixed>>,
@@ -1456,6 +1466,7 @@ impl<F: Field> Default for ConstraintSystem<F> {
             instance_queries: Vec::new(),
             permutation: permutation::Argument::new(),
             lookups: Vec::new(),
+            lookup_annotations: HashMap::new(),
             constants: vec![],
             minimum_degree: None,
         }
@@ -1838,6 +1849,17 @@ impl<F: Field> ConstraintSystem<F> {
         TableColumn {
             inner: self.fixed_column(),
         }
+    }
+
+    /// Annotate a Lookup column.
+    pub fn annotate_lookup_column<A, AR>(&mut self, column: TableColumn, annotation: A)
+    where
+        A: Fn() -> AR,
+        AR: Into<String>,
+    {
+        // We don't care if the table has already an annotation. If it's the case we keep the original one.
+        self.lookup_annotations
+            .insert(column.inner().index, annotation().into());
     }
 
     /// Allocate a new fixed column

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use super::{lookup, permutation, Assigned, Error};
+use crate::dev::metadata;
 use crate::{
     circuit::{Layouter, Region, Value},
     poly::Rotation,
@@ -1381,7 +1382,7 @@ pub struct ConstraintSystem<F: Field> {
     pub(crate) lookups: Vec<lookup::Argument<F>>,
 
     // List of indexes of Fixed columns which are associated to a `TableColumn` tied to their annotation.
-    pub(crate) lookup_annotations: HashMap<usize, String>,
+    pub(crate) lookup_annotations: HashMap<metadata::Column, String>,
 
     // Vector of fixed columns, which can be used to store constant values
     // that are copied into advice columns.
@@ -1858,8 +1859,10 @@ impl<F: Field> ConstraintSystem<F> {
         AR: Into<String>,
     {
         // We don't care if the table has already an annotation. If it's the case we keep the original one.
-        self.lookup_annotations
-            .insert(column.inner().index, annotation().into());
+        self.lookup_annotations.insert(
+            metadata::Column::from((Any::Fixed, column.inner().index)),
+            annotation().into(),
+        );
     }
 
     /// Allocate a new fixed column

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -1382,7 +1382,7 @@ pub struct ConstraintSystem<F: Field> {
     pub(crate) lookups: Vec<lookup::Argument<F>>,
 
     // List of indexes of Fixed columns which are associated to a `TableColumn` tied to their annotation.
-    pub(crate) lookup_annotations: HashMap<metadata::Column, String>,
+    pub(crate) general_column_annotations: HashMap<metadata::Column, String>,
 
     // Vector of fixed columns, which can be used to store constant values
     // that are copied into advice columns.
@@ -1467,7 +1467,7 @@ impl<F: Field> Default for ConstraintSystem<F> {
             instance_queries: Vec::new(),
             permutation: permutation::Argument::new(),
             lookups: Vec::new(),
-            lookup_annotations: HashMap::new(),
+            general_column_annotations: HashMap::new(),
             constants: vec![],
             minimum_degree: None,
         }
@@ -1859,7 +1859,7 @@ impl<F: Field> ConstraintSystem<F> {
         AR: Into<String>,
     {
         // We don't care if the table has already an annotation. If it's the case we keep the original one.
-        self.lookup_annotations.insert(
+        self.general_column_annotations.insert(
             metadata::Column::from((Any::Fixed, column.inner().index)),
             annotation().into(),
         );

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -526,7 +526,9 @@ pub trait Assignment<F: Field> {
         NR: Into<String>,
         N: FnOnce() -> NR;
 
-    /// TODO: Document
+    /// Allows the developer to include an annotation for an specific column within a `Region`.
+    ///
+    /// This is usually useful for debugging circuit failures.
     fn annotate_column<A, AR>(&mut self, annotation: A, column: Column<Any>)
     where
         A: FnOnce() -> AR,
@@ -1381,7 +1383,7 @@ pub struct ConstraintSystem<F: Field> {
     // input expressions and a sequence of table expressions involved in the lookup.
     pub(crate) lookups: Vec<lookup::Argument<F>>,
 
-    // List of indexes of Fixed columns which are associated to a `TableColumn` tied to their annotation.
+    // List of indexes of Fixed columns which are associated to a circuit-general Column tied to their annotation.
     pub(crate) general_column_annotations: HashMap<metadata::Column, String>,
 
     // Vector of fixed columns, which can be used to store constant values
@@ -1858,7 +1860,7 @@ impl<F: Field> ConstraintSystem<F> {
         A: Fn() -> AR,
         AR: Into<String>,
     {
-        // We don't care if the table has already an annotation. If it's the case we keep the original one.
+        // We don't care if the table has already an annotation. If it's the case we keep the new one.
         self.general_column_annotations.insert(
             metadata::Column::from((Any::Fixed, column.inner().index)),
             annotation().into(),
@@ -1873,7 +1875,7 @@ impl<F: Field> ConstraintSystem<F> {
         T: Into<Column<Any>>,
     {
         let col_any = column.into();
-        // We don't care if the table has already an annotation. If it's the case we keep the original one.
+        // We don't care if the table has already an annotation. If it's the case we keep the new one.
         self.general_column_annotations.insert(
             metadata::Column::from((col_any.column_type, col_any.index)),
             annotation().into(),

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -1865,6 +1865,21 @@ impl<F: Field> ConstraintSystem<F> {
         );
     }
 
+    /// Annotate an Instance column.
+    pub fn annotate_lookup_any_column<A, AR, T>(&mut self, column: T, annotation: A)
+    where
+        A: Fn() -> AR,
+        AR: Into<String>,
+        T: Into<Column<Any>>,
+    {
+        let col_any = column.into();
+        // We don't care if the table has already an annotation. If it's the case we keep the original one.
+        self.general_column_annotations.insert(
+            metadata::Column::from((col_any.column_type, col_any.index)),
+            annotation().into(),
+        );
+    }
+
     /// Allocate a new fixed column
     pub fn fixed_column(&mut self) -> Column<Fixed> {
         let tmp = Column {

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -178,12 +178,12 @@ impl<F: Field> Assignment<F> for Assembly<F> {
         Value::unknown()
     }
 
-    fn annotate_column<A, AR>(&mut self, annotation: A, column: Column<Any>)
+    fn annotate_column<A, AR>(&mut self, _annotation: A, _column: Column<Any>)
     where
         A: FnOnce() -> AR,
         AR: Into<String>,
     {
-        unimplemented!()
+        // Do nothing
     }
 
     fn push_namespace<NR, N>(&mut self, _: N)

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -178,6 +178,14 @@ impl<F: Field> Assignment<F> for Assembly<F> {
         Value::unknown()
     }
 
+    fn annotate_column<A, AR>(&mut self, annotation: A, column: Column<Any>)
+    where
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
+        unimplemented!()
+    }
+
     fn push_namespace<NR, N>(&mut self, _: N)
     where
         NR: Into<String>,

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -182,22 +182,125 @@ pub fn create_proof<
                 .ok_or(Error::BoundsFailure)
         }
 
-        fn assign_advice<V, VR, A, AR>(
-            &mut self,
-            _: A,
-            column: Column<Advice>,
-            row: usize,
-            to: V,
-        ) -> Result<(), Error>
-        where
-            V: FnOnce() -> Value<VR>,
-            VR: Into<Assigned<F>>,
-            A: FnOnce() -> AR,
-            AR: Into<String>,
-        {
-            // Ignore assignment of advice column in different phase than current one.
-            if self.current_phase != column.column_type().phase {
-                return Ok(());
+                fn exit_region(&mut self) {
+                    // Do nothing; we don't care about regions in this context.
+                }
+
+                fn enable_selector<A, AR>(
+                    &mut self,
+                    _: A,
+                    _: &Selector,
+                    _: usize,
+                ) -> Result<(), Error>
+                where
+                    A: FnOnce() -> AR,
+                    AR: Into<String>,
+                {
+                    // We only care about advice columns here
+
+                    Ok(())
+                }
+
+                fn query_instance(
+                    &self,
+                    column: Column<Instance>,
+                    row: usize,
+                ) -> Result<Value<F>, Error> {
+                    if !self.usable_rows.contains(&row) {
+                        return Err(Error::not_enough_rows_available(self.k));
+                    }
+
+                    self.instances
+                        .get(column.index())
+                        .and_then(|column| column.get(row))
+                        .map(|v| Value::known(*v))
+                        .ok_or(Error::BoundsFailure)
+                }
+
+                fn assign_advice<V, VR, A, AR>(
+                    &mut self,
+                    _: A,
+                    column: Column<Advice>,
+                    row: usize,
+                    to: V,
+                ) -> Result<(), Error>
+                where
+                    V: FnOnce() -> Value<VR>,
+                    VR: Into<Assigned<F>>,
+                    A: FnOnce() -> AR,
+                    AR: Into<String>,
+                {
+                    if !self.usable_rows.contains(&row) {
+                        return Err(Error::not_enough_rows_available(self.k));
+                    }
+
+                    *self
+                        .advice
+                        .get_mut(column.index())
+                        .and_then(|v| v.get_mut(row))
+                        .ok_or(Error::BoundsFailure)? = to().into_field().assign()?;
+
+                    Ok(())
+                }
+
+                fn assign_fixed<V, VR, A, AR>(
+                    &mut self,
+                    _: A,
+                    _: Column<Fixed>,
+                    _: usize,
+                    _: V,
+                ) -> Result<(), Error>
+                where
+                    V: FnOnce() -> Value<VR>,
+                    VR: Into<Assigned<F>>,
+                    A: FnOnce() -> AR,
+                    AR: Into<String>,
+                {
+                    // We only care about advice columns here
+
+                    Ok(())
+                }
+
+                fn copy(
+                    &mut self,
+                    _: Column<Any>,
+                    _: usize,
+                    _: Column<Any>,
+                    _: usize,
+                ) -> Result<(), Error> {
+                    // We only care about advice columns here
+
+                    Ok(())
+                }
+
+                fn fill_from_row(
+                    &mut self,
+                    _: Column<Fixed>,
+                    _: usize,
+                    _: Value<Assigned<F>>,
+                ) -> Result<(), Error> {
+                    Ok(())
+                }
+
+                fn annotate_column<A, AR>(&mut self, annotation: A, column: Column<Any>)
+                where
+                    A: FnOnce() -> AR,
+                    AR: Into<String>,
+                {
+                    unimplemented!()
+                }
+
+                fn push_namespace<NR, N>(&mut self, _: N)
+                where
+                    NR: Into<String>,
+                    N: FnOnce() -> NR,
+                {
+                    // Do nothing; we don't care about namespaces in this context.
+                }
+
+                fn pop_namespace(&mut self, _: Option<String>) {
+                    // Do nothing; we don't care about namespaces in this context.
+                }
             }
 
             if !self.usable_rows.contains(&row) {

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -170,6 +170,14 @@ pub fn create_proof<
             Ok(())
         }
 
+        fn annotate_column<A, AR>(&mut self, annotation: A, column: Column<Any>)
+        where
+            A: FnOnce() -> AR,
+            AR: Into<String>,
+        {
+            // Do nothing
+        }
+
         fn query_instance(&self, column: Column<Instance>, row: usize) -> Result<Value<F>, Error> {
             if !self.usable_rows.contains(&row) {
                 return Err(Error::not_enough_rows_available(self.k));
@@ -182,125 +190,22 @@ pub fn create_proof<
                 .ok_or(Error::BoundsFailure)
         }
 
-                fn exit_region(&mut self) {
-                    // Do nothing; we don't care about regions in this context.
-                }
-
-                fn enable_selector<A, AR>(
-                    &mut self,
-                    _: A,
-                    _: &Selector,
-                    _: usize,
-                ) -> Result<(), Error>
-                where
-                    A: FnOnce() -> AR,
-                    AR: Into<String>,
-                {
-                    // We only care about advice columns here
-
-                    Ok(())
-                }
-
-                fn query_instance(
-                    &self,
-                    column: Column<Instance>,
-                    row: usize,
-                ) -> Result<Value<F>, Error> {
-                    if !self.usable_rows.contains(&row) {
-                        return Err(Error::not_enough_rows_available(self.k));
-                    }
-
-                    self.instances
-                        .get(column.index())
-                        .and_then(|column| column.get(row))
-                        .map(|v| Value::known(*v))
-                        .ok_or(Error::BoundsFailure)
-                }
-
-                fn assign_advice<V, VR, A, AR>(
-                    &mut self,
-                    _: A,
-                    column: Column<Advice>,
-                    row: usize,
-                    to: V,
-                ) -> Result<(), Error>
-                where
-                    V: FnOnce() -> Value<VR>,
-                    VR: Into<Assigned<F>>,
-                    A: FnOnce() -> AR,
-                    AR: Into<String>,
-                {
-                    if !self.usable_rows.contains(&row) {
-                        return Err(Error::not_enough_rows_available(self.k));
-                    }
-
-                    *self
-                        .advice
-                        .get_mut(column.index())
-                        .and_then(|v| v.get_mut(row))
-                        .ok_or(Error::BoundsFailure)? = to().into_field().assign()?;
-
-                    Ok(())
-                }
-
-                fn assign_fixed<V, VR, A, AR>(
-                    &mut self,
-                    _: A,
-                    _: Column<Fixed>,
-                    _: usize,
-                    _: V,
-                ) -> Result<(), Error>
-                where
-                    V: FnOnce() -> Value<VR>,
-                    VR: Into<Assigned<F>>,
-                    A: FnOnce() -> AR,
-                    AR: Into<String>,
-                {
-                    // We only care about advice columns here
-
-                    Ok(())
-                }
-
-                fn copy(
-                    &mut self,
-                    _: Column<Any>,
-                    _: usize,
-                    _: Column<Any>,
-                    _: usize,
-                ) -> Result<(), Error> {
-                    // We only care about advice columns here
-
-                    Ok(())
-                }
-
-                fn fill_from_row(
-                    &mut self,
-                    _: Column<Fixed>,
-                    _: usize,
-                    _: Value<Assigned<F>>,
-                ) -> Result<(), Error> {
-                    Ok(())
-                }
-
-                fn annotate_column<A, AR>(&mut self, _annotation: A, _column: Column<Any>)
-                where
-                    A: FnOnce() -> AR,
-                    AR: Into<String>,
-                {
-                    // Do nothing
-                }
-
-                fn push_namespace<NR, N>(&mut self, _: N)
-                where
-                    NR: Into<String>,
-                    N: FnOnce() -> NR,
-                {
-                    // Do nothing; we don't care about namespaces in this context.
-                }
-
-                fn pop_namespace(&mut self, _: Option<String>) {
-                    // Do nothing; we don't care about namespaces in this context.
-                }
+        fn assign_advice<V, VR, A, AR>(
+            &mut self,
+            _: A,
+            column: Column<Advice>,
+            row: usize,
+            to: V,
+        ) -> Result<(), Error>
+        where
+            V: FnOnce() -> Value<VR>,
+            VR: Into<Assigned<F>>,
+            A: FnOnce() -> AR,
+            AR: Into<String>,
+        {
+            // Ignore assignment of advice column in different phase than current one.
+            if self.current_phase != column.column_type().phase {
+                return Ok(());
             }
 
             if !self.usable_rows.contains(&row) {

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -170,7 +170,7 @@ pub fn create_proof<
             Ok(())
         }
 
-        fn annotate_column<A, AR>(&mut self, annotation: A, column: Column<Any>)
+        fn annotate_column<A, AR>(&mut self, _annotation: A, _column: Column<Any>)
         where
             A: FnOnce() -> AR,
             AR: Into<String>,

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -282,12 +282,12 @@ pub fn create_proof<
                     Ok(())
                 }
 
-                fn annotate_column<A, AR>(&mut self, annotation: A, column: Column<Any>)
+                fn annotate_column<A, AR>(&mut self, _annotation: A, _column: Column<Any>)
                 where
                     A: FnOnce() -> AR,
                     AR: Into<String>,
                 {
-                    unimplemented!()
+                    // Do nothing
                 }
 
                 fn push_namespace<NR, N>(&mut self, _: N)


### PR DESCRIPTION
This PR particularly includes:

- [x] Ability to annotate columns within a Region.
- [x] Ability to annotate lookup table columns.
- [x] Ability to print for both prover.verify() and prover.assert_verify() the annotations of the Columns that have been declared.
- [x] Ability to print the lookup column queried within a lookup expression that failed.
- [x] Ability to annotate dynamic-lookup columns (Advice Columns used for lookup)


Resolves: #57 

Here is a list of all of the prints that you can now get with the annotation support: 

**Assert_satisfied - Lookup_any**
<details>

```
error: lookup input does not exist in table
  (L0, L1) ∉ ("Inst-Table", "Adv-Table")

  Lookup 'lookup' inputs:
    L0 = x1 * x0 + (1 - x1) * 0x2
    ^

    | Cell layout in region 'Faulty synthesis':
    |   | Offset |Witness example| F0 |
    |   +--------+---------------+----+
    |   |    1   |       x0      | x1 | <--{ Lookup 'lookup' inputs queried here
    |
    | Assigned cell values:
    |   x0 = 0x5
    |   x1 = 1

    L1 = x1 * x0 + (1 - x1) * 0x2
    ^

    | Cell layout in region 'Faulty synthesis':
    |   | Offset |Witness example| F0 |
    |   +--------+---------------+----+
    |   |    1   |       x0      | x1 | <--{ Lookup 'lookup' inputs queried here
    |
    | Assigned cell values:
    |   x0 = 0x5
    |   x1 = 1
```

</details>


**Assert_satisfied - Lookup_fixed**
<details>

```
error: lookup input does not exist in table
  (L0) ∉ ("Table1")

  Lookup 'lookup' inputs:
    L0 = x1 * x0 + (1 - x1) * 0x2
    ^

    | Cell layout in region 'Faulty synthesis':
    |   | Offset |Witness example| F1 |
    |   +--------+---------------+----+
    |   |    1   |       x0      | x1 | <--{ Lookup 'lookup' inputs queried here
    |
    | Assigned cell values:
    |   x0 = 0x5
    |   x1 = 1
```

</details>

**Assert_satisfied - ConstraintNotSatisfied**
<details>

```
error: constraint not satisfied

  Cell layout in region 'Wrong synthesis':
    | Offset |This is Advice!|This is Advice too!|Another one!|This is a Fixed!|
    +--------+---------------+-------------------+------------+----------------+
    |    0   |       x0      |         x1        |     x2     |       x3       | <--{ Gate 'Equality check' applied here

  Constraint '':
    (S1 * (x0 - x1)) * (x2 - x3) = 0

  Assigned cell values:
    x0 = 1
    x1 = 0
    x2 = 0x5
    x3 = 0x7
```

</details>


**Assert_satisfied - CellNotAssigned**
<details>

```
error: cell not assigned

  Cell layout in region 'Faulty synthesis':
    | Offset |This is annotated!|This is also annotated!|
    +--------+------------------+-----------------------+
    |    0   |        x0        |                       |
    |    1   |                  |           X           | <--{ X marks the spot! 🦜

  Gate 'Equality check' (applied at offset 1) queries these cells.
```

</details>

**Prover.verify - ConstraintNotSatisfied (now includes annotations for VirtualCells)**
<details>

```
Err([ConstraintCaseDebug {
    constraint: Constraint {
        gate: Gate {
            index: 0,
            name: "Equality check",
        },
        index: 0,
        name: "",
    },
    location: InRegion {
        region: Region 1 ('Wrong synthesis'),
        offset: 0,
    },
    cell_values: [
        (
            DebugVirtualCell {
                name: "",
                column: DebugColumn {
                    column_type: Advice,
                    index: 0,
                    annotation: "This is Advice!",
                },
                rotation: 0,
            },
            "1",
        ),
        (
            DebugVirtualCell {
                name: "",
                column: DebugColumn {
                    column_type: Advice,
                    index: 1,
                    annotation: "This is Advice too!",
                },
                rotation: 0,
            },
            "0",
        ),
        (
            DebugVirtualCell {
                name: "",
                column: DebugColumn {
                    column_type: Advice,
                    index: 2,
                    annotation: "Another one!",
                },
                rotation: 0,
            },
            "0x5",
        ),
        (
            DebugVirtualCell {
                name: "",
                column: DebugColumn {
                    column_type: Fixed,
                    index: 0,
                    annotation: "This is a Fixed!",
                },
                rotation: 0,
            },
            "0x7",
        ),
    ],
}])
```

</details>