### PR TITLE
Feature to serialize/deserialize KZG params, verifying key, and proving key into uncompressed Montgomery form

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -68,13 +68,11 @@ rand_core = { version = "0.6", default-features = false, features = ["getrandom"
 getrandom = { version = "0.2", features = ["js"] }
 
 [features]
-default = ["batch", "serde-raw"]
+default = ["batch"]
 dev-graph = ["plotters", "tabbycat"]
 gadget-traces = ["backtrace"]
 sanity-checks = []
 batch = ["rand_core/getrandom"]
-serde-raw = []
-raw-unchecked = ["serde-raw"]
 
 [lib]
 bench = false

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -48,7 +48,7 @@ backtrace = { version = "0.3", optional = true }
 rayon = "1.5.1"
 ff = "0.12"
 group = "0.12"
-halo2curves = { git = 'https://github.com/jonathanpwang/halo2curves', branch = 'feat/serde-field' }
+halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves.git', tag = "0.3.1" }
 rand_core = { version = "0.6", default-features = false }
 tracing = "0.1"
 blake2b_simd = "1"

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -48,7 +48,7 @@ backtrace = { version = "0.3", optional = true }
 rayon = "1.5.1"
 ff = "0.12"
 group = "0.12"
-halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves', tag = '0.3.0' }
+halo2curves = { git = 'https://github.com/jonathanpwang/halo2curves', branch = 'feat/serde-field' }
 rand_core = { version = "0.6", default-features = false }
 tracing = "0.1"
 blake2b_simd = "1"
@@ -68,11 +68,13 @@ rand_core = { version = "0.6", default-features = false, features = ["getrandom"
 getrandom = { version = "0.2", features = ["js"] }
 
 [features]
-default = ["batch"]
+default = ["batch", "serde-raw"]
 dev-graph = ["plotters", "tabbycat"]
 gadget-traces = ["backtrace"]
 sanity-checks = []
 batch = ["rand_core/getrandom"]
+serde-raw = []
+raw-unchecked = ["serde-raw"]
 
 [lib]
 bench = false

--- a/halo2_proofs/examples/serialization.rs
+++ b/halo2_proofs/examples/serialization.rs
@@ -139,7 +139,7 @@ fn main() {
 
     let f = File::open("serialization-test.pk").unwrap();
     let mut reader = BufReader::new(f);
-    let pk = ProvingKey::<G1Affine>::read::<_, StandardPlonk>(&mut reader, &params).unwrap();
+    let pk = ProvingKey::<G1Affine>::read::<_, StandardPlonk>(&mut reader).unwrap();
 
     std::fs::remove_file("serialization-test.pk").unwrap();
 

--- a/halo2_proofs/examples/serialization.rs
+++ b/halo2_proofs/examples/serialization.rs
@@ -21,6 +21,7 @@ use halo2_proofs::{
     transcript::{
         Blake2bRead, Blake2bWrite, Challenge255, TranscriptReadBuffer, TranscriptWriterBuffer,
     },
+    SerdeFormat,
 };
 use halo2curves::bn256::{Bn256, Fr, G1Affine};
 use rand_core::OsRng;
@@ -134,12 +135,13 @@ fn main() {
 
     let f = File::create("serialization-test.pk").unwrap();
     let mut writer = BufWriter::new(f);
-    pk.write(&mut writer).unwrap();
+    pk.write(&mut writer, SerdeFormat::RawBytes).unwrap();
     writer.flush().unwrap();
 
     let f = File::open("serialization-test.pk").unwrap();
     let mut reader = BufReader::new(f);
-    let pk = ProvingKey::<G1Affine>::read::<_, StandardPlonk>(&mut reader).unwrap();
+    let pk = ProvingKey::<G1Affine>::read::<_, StandardPlonk>(&mut reader, SerdeFormat::RawBytes)
+        .unwrap();
 
     std::fs::remove_file("serialization-test.pk").unwrap();
 

--- a/halo2_proofs/src/helpers.rs
+++ b/halo2_proofs/src/helpers.rs
@@ -1,9 +1,12 @@
 use crate::poly::Polynomial;
 use ff::PrimeField;
+#[cfg(feature = "serde-raw")]
+use halo2curves::serde::SerdeObject;
 use halo2curves::CurveAffine;
 use std::io;
 
-pub(crate) trait CurveRead: CurveAffine {
+#[cfg(not(feature = "serde-raw"))]
+pub(crate) trait SerdeCurveAffine: CurveAffine {
     /// Reads a compressed element from the buffer and attempts to parse it
     /// using `from_bytes`.
     fn read<R: io::Read>(reader: &mut R) -> io::Result<Self> {
@@ -12,10 +15,45 @@ pub(crate) trait CurveRead: CurveAffine {
         Option::from(Self::from_bytes(&compressed))
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Invalid point encoding in proof"))
     }
+    /// Writes a curve element as a compressed affine point in bytes.
+    fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        writer.write_all(self.to_bytes().as_ref())
+    }
 }
+#[cfg(not(feature = "serde-raw"))]
+impl<C: CurveAffine> SerdeCurveAffine for C {}
 
-impl<C: CurveAffine> CurveRead for C {}
+#[cfg(feature = "serde-raw")]
+pub(crate) trait SerdeCurveAffine: CurveAffine + SerdeObject {
+    /// Reads a curve element from raw bytes.
+    /// The curve element is stored exactly as it is in memory (two field elements in Montgomery representation).
+    fn read<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        #[cfg(feature = "raw-unchecked")]
+        {
+            Ok(Self::read_raw_unchecked(reader))
+        }
+        #[cfg(not(feature = "raw-unchecked"))]
+        {
+            Self::read_raw(reader)
+        }
+    }
+    /// Writes a curve element into raw bytes.
+    /// The curve element is stored exactly as it is in memory (two field elements in Montgomery representation).
+    fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        #[cfg(feature = "raw-unchecked")]
+        {
+            Ok(self.write_raw_unchecked(writer))
+        }
+        #[cfg(not(feature = "raw-unchecked"))]
+        {
+            self.write_raw(writer)
+        }
+    }
+}
+#[cfg(feature = "serde-raw")]
+impl<C: CurveAffine + SerdeObject> SerdeCurveAffine for C {}
 
+#[cfg(not(feature = "serde-raw"))]
 pub(crate) trait SerdePrimeField: PrimeField {
     /// Reads a field element as bytes from the buffer using `from_repr`.
     /// Endianness is specified by `PrimeField` implementation.
@@ -33,8 +71,37 @@ pub(crate) trait SerdePrimeField: PrimeField {
         writer.write_all(self.to_repr().as_ref())
     }
 }
-
+#[cfg(not(feature = "serde-raw"))]
 impl<F: PrimeField> SerdePrimeField for F {}
+
+#[cfg(feature = "serde-raw")]
+pub(crate) trait SerdePrimeField: PrimeField + SerdeObject {
+    /// Reads a field element from raw bytes in its internal Montgomery representation.
+    fn read<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        #[cfg(feature = "raw-unchecked")]
+        {
+            Ok(Self::read_raw_unchecked(reader))
+        }
+        #[cfg(not(feature = "raw-unchecked"))]
+        {
+            Self::read_raw(reader)
+        }
+    }
+    /// Writes a field element into raw bytes in its internal Montgomery representation,
+    /// WITHOUT performing the expensive Montgomery reduction.
+    fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        #[cfg(feature = "raw-unchecked")]
+        {
+            Ok(self.write_raw_unchecked(writer))
+        }
+        #[cfg(not(feature = "raw-unchecked"))]
+        {
+            self.write_raw(writer)
+        }
+    }
+}
+#[cfg(feature = "serde-raw")]
+impl<F: PrimeField + SerdeObject> SerdePrimeField for F {}
 
 /// Convert a slice of `bool` into a `u8`.
 ///
@@ -56,12 +123,12 @@ pub fn unpack(byte: u8, bits: &mut [bool]) {
 }
 
 /// Reads a vector of polynomials from buffer
-pub(crate) fn read_polynomial_vec<R: io::Read, F: PrimeField, B>(
+pub(crate) fn read_polynomial_vec<R: io::Read, F: SerdePrimeField, B>(
     reader: &mut R,
 ) -> io::Result<Vec<Polynomial<F, B>>> {
-    let mut len_be_bytes = [0u8; 4];
-    reader.read_exact(&mut len_be_bytes)?;
-    let len = u32::from_be_bytes(len_be_bytes);
+    let mut len = [0u8; 4];
+    reader.read_exact(&mut len)?;
+    let len = u32::from_be_bytes(len);
 
     (0..len)
         .map(|_| Polynomial::<F, B>::read(reader))
@@ -69,7 +136,7 @@ pub(crate) fn read_polynomial_vec<R: io::Read, F: PrimeField, B>(
 }
 
 /// Writes a slice of polynomials to buffer
-pub(crate) fn write_polynomial_slice<W: io::Write, F: PrimeField, B>(
+pub(crate) fn write_polynomial_slice<W: io::Write, F: SerdePrimeField, B>(
     slice: &[Polynomial<F, B>],
     writer: &mut W,
 ) -> io::Result<()> {

--- a/halo2_proofs/src/lib.rs
+++ b/halo2_proofs/src/lib.rs
@@ -35,3 +35,4 @@ pub mod transcript;
 
 pub mod dev;
 mod helpers;
+pub use helpers::SerdeFormat;

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -19,6 +19,7 @@ use crate::poly::{
     PinnedEvaluationDomain, Polynomial,
 };
 use crate::transcript::{ChallengeScalar, EncodedChallenge, Transcript};
+use crate::SerdeFormat;
 
 mod assigned;
 mod circuit;
@@ -62,13 +63,21 @@ where
     C::Scalar: SerdePrimeField,
 {
     /// Writes a verifying key to a buffer.
-    pub fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+    ///
+    /// Writes a curve element according to `format`:
+    /// - `Processed`: Writes a compressed curve element with coordinates in standard form.
+    /// Writes a field element in standard form, with endianness specified by the
+    /// `PrimeField` implementation.
+    /// - Otherwise: Writes an uncompressed curve element with coordinates in Montgomery form
+    /// Writes a field element into raw bytes in its internal Montgomery representation,
+    /// WITHOUT performing the expensive Montgomery reduction.
+    pub fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
         writer.write_all(&self.domain.k().to_be_bytes())?;
         writer.write_all(&(self.fixed_commitments.len() as u32).to_be_bytes())?;
         for commitment in &self.fixed_commitments {
-            commitment.write(writer)?;
+            commitment.write(writer, format)?;
         }
-        self.permutation.write(writer)?;
+        self.permutation.write(writer, format)?;
 
         // write self.selectors
         for selector in &self.selectors {
@@ -81,8 +90,18 @@ where
     }
 
     /// Reads a verification key from a buffer.
+    ///
+    /// Reads a curve element from the buffer and parses it according to the `format`:
+    /// - `Processed`: Reads a compressed curve element and decompresses it.
+    /// Reads a field element in standard form, with endianness specified by the
+    /// `PrimeField` implementation, and checks that the element is less than the modulus.
+    /// - `RawBytes`: Reads an uncompressed curve element with coordinates in Montgomery form.
+    /// Checks that field elements are less than modulus, and then checks that the point is on the curve.
+    /// - `RawBytesUnchecked`: Reads an uncompressed curve element with coordinates in Montgomery form;
+    /// does not perform any checks
     pub fn read<R: io::Read, ConcreteCircuit: Circuit<C::Scalar>>(
         reader: &mut R,
+        format: SerdeFormat,
     ) -> io::Result<Self> {
         let mut k = [0u8; 4];
         reader.read_exact(&mut k)?;
@@ -93,10 +112,10 @@ where
         let num_fixed_columns = u32::from_be_bytes(num_fixed_columns);
 
         let fixed_commitments: Vec<_> = (0..num_fixed_columns)
-            .map(|_| C::read(reader))
+            .map(|_| C::read(reader, format))
             .collect::<Result<_, _>>()?;
 
-        let permutation = permutation::VerifyingKey::read(reader, &cs.permutation)?;
+        let permutation = permutation::VerifyingKey::read(reader, &cs.permutation, format)?;
 
         // read selectors
         let selectors: Vec<Vec<bool>> = vec![vec![false; 1 << k]; cs.num_selectors]
@@ -121,16 +140,19 @@ where
         ))
     }
 
-    /// Writes a verifying key to a vector of bytes.
-    pub fn to_bytes(&self) -> Vec<u8> {
+    /// Writes a verifying key to a vector of bytes using [`Self::write`].
+    pub fn to_bytes(&self, format: SerdeFormat) -> Vec<u8> {
         let mut bytes = Vec::<u8>::with_capacity(self.bytes_length());
-        Self::write(self, &mut bytes).expect("Writing to vector should not fail");
+        Self::write(self, &mut bytes, format).expect("Writing to vector should not fail");
         bytes
     }
 
-    /// Reads a verification key from a slice of bytes.
-    pub fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(mut bytes: &[u8]) -> io::Result<Self> {
-        Self::read::<_, ConcreteCircuit>(&mut bytes)
+    /// Reads a verification key from a slice of bytes using [`Self::read`].
+    pub fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(
+        mut bytes: &[u8],
+        format: SerdeFormat,
+    ) -> io::Result<Self> {
+        Self::read::<_, ConcreteCircuit>(&mut bytes, format)
     }
 }
 
@@ -273,32 +295,50 @@ where
     C::Scalar: SerdePrimeField,
 {
     /// Writes a proving key to a buffer.
+    ///
+    /// Writes a curve element according to `format`:
+    /// - `Processed`: Writes a compressed curve element with coordinates in standard form.
+    /// Writes a field element in standard form, with endianness specified by the
+    /// `PrimeField` implementation.
+    /// - Otherwise: Writes an uncompressed curve element with coordinates in Montgomery form
+    /// Writes a field element into raw bytes in its internal Montgomery representation,
+    /// WITHOUT performing the expensive Montgomery reduction.
     /// Does so by first writing the verifying key and then serializing the rest of the data (in the form of field polynomials)
-    pub fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
-        self.vk.write(writer)?;
-        self.l0.write(writer)?;
-        self.l_last.write(writer)?;
-        self.l_active_row.write(writer)?;
-        write_polynomial_slice(&self.fixed_values, writer)?;
-        write_polynomial_slice(&self.fixed_polys, writer)?;
-        write_polynomial_slice(&self.fixed_cosets, writer)?;
-        self.permutation.write(writer)?;
+    pub fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
+        self.vk.write(writer, format)?;
+        self.l0.write(writer, format)?;
+        self.l_last.write(writer, format)?;
+        self.l_active_row.write(writer, format)?;
+        write_polynomial_slice(&self.fixed_values, writer, format)?;
+        write_polynomial_slice(&self.fixed_polys, writer, format)?;
+        write_polynomial_slice(&self.fixed_cosets, writer, format)?;
+        self.permutation.write(writer, format)?;
         Ok(())
     }
 
     /// Reads a proving key from a buffer.
     /// Does so by reading verification key first, and then deserializing the rest of the file into the remaining proving key data.
+    ///
+    /// Reads a curve element from the buffer and parses it according to the `format`:
+    /// - `Processed`: Reads a compressed curve element and decompresses it.
+    /// Reads a field element in standard form, with endianness specified by the
+    /// `PrimeField` implementation, and checks that the element is less than the modulus.
+    /// - `RawBytes`: Reads an uncompressed curve element with coordinates in Montgomery form.
+    /// Checks that field elements are less than modulus, and then checks that the point is on the curve.
+    /// - `RawBytesUnchecked`: Reads an uncompressed curve element with coordinates in Montgomery form;
+    /// does not perform any checks
     pub fn read<R: io::Read, ConcreteCircuit: Circuit<C::Scalar>>(
         reader: &mut R,
+        format: SerdeFormat,
     ) -> io::Result<Self> {
-        let vk = VerifyingKey::<C>::read::<R, ConcreteCircuit>(reader)?;
-        let l0 = Polynomial::read(reader)?;
-        let l_last = Polynomial::read(reader)?;
-        let l_active_row = Polynomial::read(reader)?;
-        let fixed_values = read_polynomial_vec(reader)?;
-        let fixed_polys = read_polynomial_vec(reader)?;
-        let fixed_cosets = read_polynomial_vec(reader)?;
-        let permutation = permutation::ProvingKey::read(reader)?;
+        let vk = VerifyingKey::<C>::read::<R, ConcreteCircuit>(reader, format)?;
+        let l0 = Polynomial::read(reader, format)?;
+        let l_last = Polynomial::read(reader, format)?;
+        let l_active_row = Polynomial::read(reader, format)?;
+        let fixed_values = read_polynomial_vec(reader, format)?;
+        let fixed_polys = read_polynomial_vec(reader, format)?;
+        let fixed_cosets = read_polynomial_vec(reader, format)?;
+        let permutation = permutation::ProvingKey::read(reader, format)?;
         let ev = Evaluator::new(vk.cs());
         Ok(Self {
             vk,
@@ -313,16 +353,19 @@ where
         })
     }
 
-    /// Writes a proving key to a vector of bytes.
-    pub fn to_bytes(&self) -> Vec<u8> {
+    /// Writes a proving key to a vector of bytes using [`Self::write`].
+    pub fn to_bytes(&self, format: SerdeFormat) -> Vec<u8> {
         let mut bytes = Vec::<u8>::with_capacity(self.bytes_length());
-        Self::write(self, &mut bytes).expect("Writing to vector should not fail");
+        Self::write(self, &mut bytes, format).expect("Writing to vector should not fail");
         bytes
     }
 
-    /// Reads a proving key from a slice of bytes.
-    pub fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(mut bytes: &[u8]) -> io::Result<Self> {
-        Self::read::<_, ConcreteCircuit>(&mut bytes)
+    /// Reads a proving key from a slice of bytes using [`Self::read`].
+    pub fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(
+        mut bytes: &[u8],
+        format: SerdeFormat,
+    ) -> io::Result<Self> {
+        Self::read::<_, ConcreteCircuit>(&mut bytes, format)
     }
 }
 

--- a/halo2_proofs/src/plonk/permutation.rs
+++ b/halo2_proofs/src/plonk/permutation.rs
@@ -6,6 +6,7 @@ use crate::{
         SerdeCurveAffine, SerdePrimeField,
     },
     poly::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial},
+    SerdeFormat,
 };
 use ff::PrimeField;
 
@@ -88,22 +89,26 @@ impl<C: CurveAffine> VerifyingKey<C> {
         &self.commitments
     }
 
-    pub(crate) fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()>
+    pub(crate) fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()>
     where
         C: SerdeCurveAffine,
     {
         for commitment in &self.commitments {
-            commitment.write(writer)?;
+            commitment.write(writer, format)?;
         }
         Ok(())
     }
 
-    pub(crate) fn read<R: io::Read>(reader: &mut R, argument: &Argument) -> io::Result<Self>
+    pub(crate) fn read<R: io::Read>(
+        reader: &mut R,
+        argument: &Argument,
+        format: SerdeFormat,
+    ) -> io::Result<Self>
     where
         C: SerdeCurveAffine,
     {
         let commitments = (0..argument.columns.len())
-            .map(|_| C::read(reader))
+            .map(|_| C::read(reader, format))
             .collect::<Result<Vec<_>, _>>()?;
         Ok(VerifyingKey { commitments })
     }
@@ -126,10 +131,10 @@ where
     C::Scalar: SerdePrimeField,
 {
     /// Reads proving key for a single permutation argument from buffer using `Polynomial::read`.  
-    pub(super) fn read<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-        let permutations = read_polynomial_vec(reader)?;
-        let polys = read_polynomial_vec(reader)?;
-        let cosets = read_polynomial_vec(reader)?;
+    pub(super) fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self> {
+        let permutations = read_polynomial_vec(reader, format)?;
+        let polys = read_polynomial_vec(reader, format)?;
+        let cosets = read_polynomial_vec(reader, format)?;
         Ok(ProvingKey {
             permutations,
             polys,
@@ -138,10 +143,14 @@ where
     }
 
     /// Writes proving key for a single permutation argument to buffer using `Polynomial::write`.  
-    pub(super) fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
-        write_polynomial_slice(&self.permutations, writer)?;
-        write_polynomial_slice(&self.polys, writer)?;
-        write_polynomial_slice(&self.cosets, writer)?;
+    pub(super) fn write<W: io::Write>(
+        &self,
+        writer: &mut W,
+        format: SerdeFormat,
+    ) -> io::Result<()> {
+        write_polynomial_slice(&self.permutations, writer, format)?;
+        write_polynomial_slice(&self.polys, writer, format)?;
+        write_polynomial_slice(&self.cosets, writer, format)?;
         Ok(())
     }
 }

--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -5,6 +5,7 @@
 use crate::arithmetic::parallelize;
 use crate::helpers::SerdePrimeField;
 use crate::plonk::Assigned;
+use crate::SerdeFormat;
 
 use ff::PrimeField;
 use group::ff::{BatchInvert, Field};
@@ -148,13 +149,13 @@ impl<F, B> Polynomial<F, B> {
 
 impl<F: SerdePrimeField, B> Polynomial<F, B> {
     /// Reads polynomial from buffer using `SerdePrimeField::read`.  
-    pub(crate) fn read<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+    pub(crate) fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self> {
         let mut poly_len = [0u8; 4];
         reader.read_exact(&mut poly_len)?;
         let poly_len = u32::from_be_bytes(poly_len);
 
         (0..poly_len)
-            .map(|_| F::read(reader))
+            .map(|_| F::read(reader, format))
             .collect::<io::Result<Vec<_>>>()
             .map(|values| Self {
                 values,
@@ -163,10 +164,14 @@ impl<F: SerdePrimeField, B> Polynomial<F, B> {
     }
 
     /// Writes polynomial to buffer using `SerdePrimeField::write`.  
-    pub(crate) fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+    pub(crate) fn write<W: io::Write>(
+        &self,
+        writer: &mut W,
+        format: SerdeFormat,
+    ) -> io::Result<()> {
         writer.write_all(&(self.values.len() as u32).to_be_bytes())?;
         for value in self.values.iter() {
-            value.write(writer)?;
+            value.write(writer, format)?;
         }
         Ok(())
     }

--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -146,12 +146,12 @@ impl<F, B> Polynomial<F, B> {
     }
 }
 
-impl<F: PrimeField, B> Polynomial<F, B> {
+impl<F: SerdePrimeField, B> Polynomial<F, B> {
     /// Reads polynomial from buffer using `SerdePrimeField::read`.  
     pub(crate) fn read<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-        let mut poly_len_be_bytes = [0u8; 4];
-        reader.read_exact(&mut poly_len_be_bytes)?;
-        let poly_len = u32::from_be_bytes(poly_len_be_bytes);
+        let mut poly_len = [0u8; 4];
+        reader.read_exact(&mut poly_len)?;
+        let poly_len = u32::from_be_bytes(poly_len);
 
         (0..poly_len)
             .map(|_| F::read(reader))

--- a/halo2_proofs/src/poly/kzg/commitment.rs
+++ b/halo2_proofs/src/poly/kzg/commitment.rs
@@ -4,6 +4,7 @@ use crate::arithmetic::{
 use crate::helpers::SerdeCurveAffine;
 use crate::poly::commitment::{Blind, CommitmentScheme, Params, ParamsProver, ParamsVerifier, MSM};
 use crate::poly::{Coeff, LagrangeCoeff, Polynomial};
+use crate::SerdeFormat;
 
 use ff::{Field, PrimeField};
 use group::{prime::PrimeCurveAffine, Curve, Group as _};
@@ -136,6 +137,111 @@ impl<E: Engine + Debug> ParamsKZG<E> {
     pub fn s_g2(&self) -> E::G2Affine {
         self.s_g2
     }
+
+    /// Writes parameters to buffer
+    pub fn write_custom<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()>
+    where
+        E::G1Affine: SerdeCurveAffine,
+        E::G2Affine: SerdeCurveAffine,
+    {
+        writer.write_all(&self.k.to_le_bytes())?;
+        for el in self.g.iter() {
+            el.write(writer, format)?;
+        }
+        for el in self.g_lagrange.iter() {
+            el.write(writer, format)?;
+        }
+        self.g2.write(writer, format)?;
+        self.s_g2.write(writer, format)?;
+        Ok(())
+    }
+
+    /// Reads params from a buffer.
+    pub fn read_custom<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self>
+    where
+        E::G1Affine: SerdeCurveAffine,
+        E::G2Affine: SerdeCurveAffine,
+    {
+        let mut k = [0u8; 4];
+        reader.read_exact(&mut k[..])?;
+        let k = u32::from_le_bytes(k);
+        let n = 1 << k;
+
+        let (g, g_lagrange) = match format {
+            SerdeFormat::Processed => {
+                use group::GroupEncoding;
+                let load_points_from_file_parallelly =
+                    |reader: &mut R| -> io::Result<Vec<Option<E::G1Affine>>> {
+                        let mut points_compressed =
+                            vec![<<E as Engine>::G1Affine as GroupEncoding>::Repr::default(); n];
+                        for points_compressed in points_compressed.iter_mut() {
+                            reader.read_exact((*points_compressed).as_mut())?;
+                        }
+
+                        let mut points = vec![Option::<E::G1Affine>::None; n];
+                        parallelize(&mut points, |points, chunks| {
+                            for (i, point) in points.iter_mut().enumerate() {
+                                *point = Option::from(E::G1Affine::from_bytes(
+                                    &points_compressed[chunks + i],
+                                ));
+                            }
+                        });
+                        Ok(points)
+                    };
+
+                let g = load_points_from_file_parallelly(reader)?;
+                let g: Vec<<E as Engine>::G1Affine> = g
+                    .iter()
+                    .map(|point| {
+                        point.ok_or_else(|| {
+                            io::Error::new(io::ErrorKind::Other, "invalid point encoding")
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
+                let g_lagrange = load_points_from_file_parallelly(reader)?;
+                let g_lagrange: Vec<<E as Engine>::G1Affine> = g_lagrange
+                    .iter()
+                    .map(|point| {
+                        point.ok_or_else(|| {
+                            io::Error::new(io::ErrorKind::Other, "invalid point encoding")
+                        })
+                    })
+                    .collect::<Result<_, _>>()?;
+                (g, g_lagrange)
+            }
+            SerdeFormat::RawBytes => {
+                let g = (0..n)
+                    .map(|_| <E::G1Affine as SerdeCurveAffine>::read(reader, format))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let g_lagrange = (0..n)
+                    .map(|_| <E::G1Affine as SerdeCurveAffine>::read(reader, format))
+                    .collect::<Result<Vec<_>, _>>()?;
+                (g, g_lagrange)
+            }
+            SerdeFormat::RawBytesUnchecked => {
+                // avoid try branching for performance
+                let g = (0..n)
+                    .map(|_| <E::G1Affine as SerdeCurveAffine>::read(reader, format).unwrap())
+                    .collect::<Vec<_>>();
+                let g_lagrange = (0..n)
+                    .map(|_| <E::G1Affine as SerdeCurveAffine>::read(reader, format).unwrap())
+                    .collect::<Vec<_>>();
+                (g, g_lagrange)
+            }
+        };
+
+        let g2 = E::G2Affine::read(reader, format)?;
+        let s_g2 = E::G2Affine::read(reader, format)?;
+
+        Ok(Self {
+            k,
+            n: n as u64,
+            g,
+            g_lagrange,
+            g2,
+            s_g2,
+        })
+    }
 }
 
 // TODO: see the issue at https://github.com/appliedzkp/halo2/issues/45
@@ -187,100 +293,12 @@ where
 
     /// Writes params to a buffer.
     fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
-        writer.write_all(&self.k.to_le_bytes())?;
-        for el in self.g.iter() {
-            el.write(writer)?;
-        }
-        for el in self.g_lagrange.iter() {
-            el.write(writer)?;
-        }
-        self.g2.write(writer)?;
-        self.s_g2.write(writer)?;
-        Ok(())
+        self.write_custom(writer, SerdeFormat::RawBytes)
     }
 
     /// Reads params from a buffer.
     fn read<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-        let mut k = [0u8; 4];
-        reader.read_exact(&mut k[..])?;
-        let k = u32::from_le_bytes(k);
-        let n = 1 << k;
-
-        #[cfg(not(feature = "serde-raw"))]
-        let (g, g_lagrange) = {
-            use group::GroupEncoding;
-            let load_points_from_file_parallelly =
-                |reader: &mut R| -> io::Result<Vec<Option<E::G1Affine>>> {
-                    let mut points_compressed =
-                        vec![<<E as Engine>::G1Affine as GroupEncoding>::Repr::default(); n];
-                    for points_compressed in points_compressed.iter_mut() {
-                        reader.read_exact((*points_compressed).as_mut())?;
-                    }
-
-                    let mut points = vec![Option::<E::G1Affine>::None; n];
-                    parallelize(&mut points, |points, chunks| {
-                        for (i, point) in points.iter_mut().enumerate() {
-                            *point = Option::from(E::G1Affine::from_bytes(
-                                &points_compressed[chunks + i],
-                            ));
-                        }
-                    });
-                    Ok(points)
-                };
-
-            let g = load_points_from_file_parallelly(reader)?;
-            let g: Vec<<E as Engine>::G1Affine> = g
-                .iter()
-                .map(|point| {
-                    point.ok_or_else(|| {
-                        io::Error::new(io::ErrorKind::Other, "invalid point encoding")
-                    })
-                })
-                .collect::<Result<_, _>>()?;
-            let g_lagrange = load_points_from_file_parallelly(reader)?;
-            let g_lagrange: Vec<<E as Engine>::G1Affine> = g_lagrange
-                .iter()
-                .map(|point| {
-                    point.ok_or_else(|| {
-                        io::Error::new(io::ErrorKind::Other, "invalid point encoding")
-                    })
-                })
-                .collect::<Result<_, _>>()?;
-            (g, g_lagrange)
-        };
-        #[cfg(all(feature = "serde-raw", not(feature = "raw-unchecked")))]
-        let (g, g_lagrange) = {
-            let g = (0..n)
-                .map(|_| <E::G1Affine as SerdeCurveAffine>::read(reader))
-                .collect::<Result<Vec<_>, _>>()?;
-            let g_lagrange = (0..n)
-                .map(|_| <E::G1Affine as SerdeCurveAffine>::read(reader))
-                .collect::<Result<Vec<_>, _>>()?;
-            (g, g_lagrange)
-        };
-        #[cfg(all(feature = "serde-raw", feature = "raw-unchecked"))]
-        let (g, g_lagrange) = {
-            // avoid try branching for performance
-            let g = (0..n)
-                .map(|_| <E::G1Affine as SerdeCurveAffine>::read(reader).unwrap())
-                .collect::<Vec<_>>();
-            let g_lagrange = (0..n)
-                .map(|_| <E::G1Affine as SerdeCurveAffine>::read(reader).unwrap())
-                .collect::<Vec<_>>();
-            (g, g_lagrange)
-        };
-
-        let g2 = E::G2Affine::read(reader)?;
-        let s_g2 = E::G2Affine::read(reader)?;
-
-        Ok(Self {
-            k,
-            n: n as u64,
-            g,
-            g_lagrange,
-            g2,
-            s_g2,
-        })
+        Self::read_custom(reader, SerdeFormat::RawBytes)
     }
 }
 

--- a/halo2_proofs/src/poly/kzg/multiopen/gwc/prover.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/gwc/prover.rs
@@ -1,6 +1,6 @@
 use super::{construct_intermediate_sets, ChallengeV, Query};
 use crate::arithmetic::{eval_polynomial, kate_division, powers, CurveAffine, FieldExt};
-
+use crate::helpers::SerdeCurveAffine;
 use crate::poly::commitment::ParamsProver;
 use crate::poly::commitment::Prover;
 use crate::poly::kzg::commitment::{KZGCommitmentScheme, ParamsKZG};
@@ -27,7 +27,11 @@ pub struct ProverGWC<'params, E: Engine> {
 }
 
 /// Create a multi-opening proof
-impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>> for ProverGWC<'params, E> {
+impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>> for ProverGWC<'params, E>
+where
+    E::G1Affine: SerdeCurveAffine,
+    E::G2Affine: SerdeCurveAffine,
+{
     const QUERY_INSTANCE: bool = false;
 
     fn new(params: &'params ParamsKZG<E>) -> Self {

--- a/halo2_proofs/src/poly/kzg/multiopen/gwc/verifier.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/gwc/verifier.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use super::{construct_intermediate_sets, ChallengeU, ChallengeV};
 use crate::arithmetic::{eval_polynomial, lagrange_interpolate, powers, CurveAffine, FieldExt};
-
+use crate::helpers::SerdeCurveAffine;
 use crate::poly::commitment::Verifier;
 use crate::poly::commitment::MSM;
 use crate::poly::kzg::commitment::{KZGCommitmentScheme, ParamsKZG};
@@ -30,8 +30,11 @@ pub struct VerifierGWC<'params, E: Engine> {
     params: &'params ParamsKZG<E>,
 }
 
-impl<'params, E: MultiMillerLoop + Debug> Verifier<'params, KZGCommitmentScheme<E>>
-    for VerifierGWC<'params, E>
+impl<'params, E> Verifier<'params, KZGCommitmentScheme<E>> for VerifierGWC<'params, E>
+where
+    E: MultiMillerLoop + Debug,
+    E::G1Affine: SerdeCurveAffine,
+    E::G2Affine: SerdeCurveAffine,
 {
     type Guard = GuardKZG<'params, E>;
     type MSMAccumulator = DualMSM<'params, E>;

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs
@@ -5,7 +5,7 @@ use crate::arithmetic::{
     eval_polynomial, evaluate_vanishing_polynomial, kate_division, lagrange_interpolate,
     parallelize, powers, CurveAffine, FieldExt,
 };
-
+use crate::helpers::SerdeCurveAffine;
 use crate::poly::commitment::{Blind, ParamsProver, Prover};
 use crate::poly::kzg::commitment::{KZGCommitmentScheme, ParamsKZG};
 use crate::poly::query::{PolynomialPointer, ProverQuery};
@@ -103,6 +103,9 @@ impl<'a, E: Engine> ProverSHPLONK<'a, E> {
 /// Create a multi-opening proof
 impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>>
     for ProverSHPLONK<'params, E>
+where
+    E::G1Affine: SerdeCurveAffine,
+    E::G2Affine: SerdeCurveAffine,
 {
     const QUERY_INSTANCE: bool = false;
 

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk/verifier.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk/verifier.rs
@@ -7,6 +7,7 @@ use crate::arithmetic::{
     eval_polynomial, evaluate_vanishing_polynomial, lagrange_interpolate, powers, CurveAffine,
     FieldExt,
 };
+use crate::helpers::SerdeCurveAffine;
 use crate::poly::commitment::Verifier;
 use crate::poly::commitment::MSM;
 use crate::poly::kzg::commitment::{KZGCommitmentScheme, ParamsKZG};
@@ -33,8 +34,11 @@ pub struct VerifierSHPLONK<'params, E: Engine> {
     params: &'params ParamsKZG<E>,
 }
 
-impl<'params, E: MultiMillerLoop + Debug> Verifier<'params, KZGCommitmentScheme<E>>
-    for VerifierSHPLONK<'params, E>
+impl<'params, E> Verifier<'params, KZGCommitmentScheme<E>> for VerifierSHPLONK<'params, E>
+where
+    E: MultiMillerLoop + Debug,
+    E::G1Affine: SerdeCurveAffine,
+    E::G2Affine: SerdeCurveAffine,
 {
     type Guard = GuardKZG<'params, E>;
     type MSMAccumulator = DualMSM<'params, E>;

--- a/halo2_proofs/src/poly/kzg/strategy.rs
+++ b/halo2_proofs/src/poly/kzg/strategy.rs
@@ -6,6 +6,7 @@ use super::{
     multiopen::VerifierGWC,
 };
 use crate::{
+    helpers::SerdeCurveAffine,
     plonk::Error,
     poly::{
         commitment::{Verifier, MSM},
@@ -29,7 +30,12 @@ pub struct GuardKZG<'params, E: MultiMillerLoop + Debug> {
 }
 
 /// Define accumulator type as `DualMSM`
-impl<'params, E: MultiMillerLoop + Debug> Guard<KZGCommitmentScheme<E>> for GuardKZG<'params, E> {
+impl<'params, E> Guard<KZGCommitmentScheme<E>> for GuardKZG<'params, E>
+where
+    E: MultiMillerLoop + Debug,
+    E::G1Affine: SerdeCurveAffine,
+    E::G2Affine: SerdeCurveAffine,
+{
     type MSMAccumulator = DualMSM<'params, E>;
 }
 
@@ -85,6 +91,9 @@ impl<
             Guard = GuardKZG<'params, E>,
         >,
     > VerificationStrategy<'params, KZGCommitmentScheme<E>, V> for AccumulatorStrategy<'params, E>
+where
+    E::G1Affine: SerdeCurveAffine,
+    E::G2Affine: SerdeCurveAffine,
 {
     type Output = Self;
 
@@ -120,6 +129,9 @@ impl<
             Guard = GuardKZG<'params, E>,
         >,
     > VerificationStrategy<'params, KZGCommitmentScheme<E>, V> for SingleStrategy<'params, E>
+where
+    E::G1Affine: SerdeCurveAffine,
+    E::G2Affine: SerdeCurveAffine,
 {
     type Output = ();
 


### PR DESCRIPTION
This resolves the discussion in https://github.com/privacy-scaling-explorations/halo2/pull/103#issuecomment-1338184504

- With feature "serde-raw", field elements are serialized into `[u8; 32]` in Montgomery form `a * R (mod p)` without reduction. Elements are deserialized to `[u64; 4]` and then checked to see that they are less than the modulus `< p`. 
- With feature "raw-unchecked", same as "serde-raw" but the less than modulus check is skipped. Also when possible I favor unwrapping instead of try-branch / try-collect since this feature is optimized for speed.
- With no feature selected it goes back to the previous serialization where Montgomery reduction is done, and curves are stored in affine compressed form.

Should be merged after https://github.com/privacy-scaling-explorations/halo2curves/pull/10 but can be reviewed concurrently. 

Changes are overall isolated to the helper traits in `helpers.rs` but there is some cosmetic annoyance in that to implement traits like `Params` or `Prover` I had to add extra `where` clauses. I didn't see a way around this, and in any case the helper traits are automatically implemented so it should have no effect on external users of the API.