### PR TITLE
Parallelize SHPLONK multi-open prover

### DIFF
--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -99,7 +99,7 @@ pub trait ParamsProver<'params, C: CurveAffine>: Params<'params, C> {
 pub trait ParamsVerifier<'params, C: CurveAffine>: Params<'params, C> {}
 
 /// Multi scalar multiplication engine
-pub trait MSM<C: CurveAffine>: Clone + Debug {
+pub trait MSM<C: CurveAffine>: Clone + Debug + Send + Sync {
     /// Add arbitrary term (the scalar and the point)
     fn append_term(&mut self, scalar: C::Scalar, point: C::CurveExt);
 

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk.rs
@@ -11,8 +11,9 @@ use crate::{
 };
 
 use std::{
-    collections::{btree_map::Entry, BTreeMap, BTreeSet},
+    collections::{btree_map::Entry, BTreeMap, BTreeSet, HashMap, HashSet},
     marker::PhantomData,
+    sync::Arc,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -69,18 +70,8 @@ where
             .get_eval()
     };
 
-    // Order points according to their rotation
-    let mut rotation_point_map = BTreeMap::new();
-    for query in queries.clone() {
-        let point = rotation_point_map
-            .entry(query.get_point())
-            .or_insert_with(|| query.get_point());
-
-        // Assert rotation point matching consistency
-        assert_eq!(*point, query.get_point());
-    }
-    // All points appear in queries
-    let super_point_set: Vec<F> = rotation_point_map.values().copied().collect();
+    // All points that appear in queries
+    let mut super_point_set = BTreeSet::new();
 
     // Collect rotation sets for each commitment
     // Example elements in the vector:
@@ -89,19 +80,21 @@ where
     // (C_2, {r_2, r_3, r_4}),
     // (C_3, {r_2, r_3, r_4}),
     // ...
-    let mut commitment_rotation_set_map: Vec<(Q::Commitment, Vec<F>)> = vec![];
+    let mut commitment_rotation_set_map: Vec<(Q::Commitment, BTreeSet<F>)> = vec![];
     for query in queries.iter() {
         let rotation = query.get_point();
-        if let Some(pos) = commitment_rotation_set_map
-            .iter()
-            .position(|(commitment, _)| *commitment == query.get_commitment())
+        super_point_set.insert(rotation);
+        if let Some(commitment_rotation_set) = commitment_rotation_set_map
+            .iter_mut()
+            .find(|(commitment, _)| *commitment == query.get_commitment())
         {
-            let (_, rotation_set) = &mut commitment_rotation_set_map[pos];
-            if !rotation_set.contains(&rotation) {
-                rotation_set.push(rotation);
-            }
+            let (_, rotation_set) = commitment_rotation_set;
+            rotation_set.insert(rotation);
         } else {
-            commitment_rotation_set_map.push((query.get_commitment(), vec![rotation]));
+            commitment_rotation_set_map.push((
+                query.get_commitment(),
+                BTreeSet::from_iter(std::iter::once(rotation)),
+            ));
         };
     }
 
@@ -111,18 +104,12 @@ where
     // {r_1, r_2, r_3} : [C_1]
     // {r_2, r_3, r_4} : [C_2, C_3],
     // ...
-    let mut rotation_set_commitment_map = Vec::<(Vec<_>, Vec<Q::Commitment>)>::new();
-    for (commitment, rotation_set) in commitment_rotation_set_map.iter() {
-        if let Some(pos) = rotation_set_commitment_map.iter().position(|(set, _)| {
-            BTreeSet::<&F>::from_iter(set.iter()) == BTreeSet::<&F>::from_iter(rotation_set.iter())
-        }) {
-            let (_, commitments) = &mut rotation_set_commitment_map[pos];
-            if !commitments.contains(commitment) {
-                commitments.push(*commitment);
-            }
-        } else {
-            rotation_set_commitment_map.push((rotation_set.clone(), vec![*commitment]))
-        }
+    let mut rotation_set_commitment_map = BTreeMap::<BTreeSet<F>, Vec<Q::Commitment>>::new();
+    for (commitment, rotation_set) in commitment_rotation_set_map.into_iter() {
+        rotation_set_commitment_map
+            .entry(rotation_set)
+            .and_modify(|commitments| commitments.push(commitment))
+            .or_insert_with(|| vec![commitment]);
     }
 
     // TODO: parallelize
@@ -130,29 +117,26 @@ where
         .into_iter()
         .map(|(rotations, commitments)| {
             let commitments: Vec<Commitment<F, Q::Commitment>> = commitments
-                .iter()
+                .into_iter()
                 .map(|commitment| {
                     let evals: Vec<F> = rotations
                         .iter()
-                        .map(|rotation| get_eval(*commitment, *rotation))
+                        .map(|rotation| get_eval(commitment, *rotation))
                         .collect();
-                    Commitment((*commitment, evals))
+                    Commitment((commitment, evals))
                 })
                 .collect();
 
             RotationSet {
                 commitments,
-                points: rotations
-                    .iter()
-                    .map(|rotation| *rotation_point_map.get(rotation).unwrap())
-                    .collect(),
+                points: rotations.into_iter().collect(),
             }
         })
         .collect::<Vec<RotationSet<_, _>>>();
 
     IntermediateSets {
         rotation_sets,
-        super_point_set,
+        super_point_set: super_point_set.into_iter().collect(),
     }
 }
 

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk.rs
@@ -80,7 +80,7 @@ where
         assert_eq!(*point, query.get_point());
     }
     // All points appear in queries
-    let super_point_set: Vec<F> = rotation_point_map.values().cloned().collect();
+    let super_point_set: Vec<F> = rotation_point_map.values().copied().collect();
 
     // Collect rotation sets for each commitment
     // Example elements in the vector:
@@ -90,7 +90,7 @@ where
     // (C_3, {r_2, r_3, r_4}),
     // ...
     let mut commitment_rotation_set_map: Vec<(Q::Commitment, Vec<F>)> = vec![];
-    for query in queries.clone() {
+    for query in queries.iter() {
         let rotation = query.get_point();
         if let Some(pos) = commitment_rotation_set_map
             .iter()
@@ -114,8 +114,7 @@ where
     let mut rotation_set_commitment_map = Vec::<(Vec<_>, Vec<Q::Commitment>)>::new();
     for (commitment, rotation_set) in commitment_rotation_set_map.iter() {
         if let Some(pos) = rotation_set_commitment_map.iter().position(|(set, _)| {
-            BTreeSet::<F>::from_iter(set.iter().cloned())
-                == BTreeSet::<F>::from_iter(rotation_set.iter().cloned())
+            BTreeSet::<&F>::from_iter(set.iter()) == BTreeSet::<&F>::from_iter(rotation_set.iter())
         }) {
             let (_, commitments) = &mut rotation_set_commitment_map[pos];
             if !commitments.contains(commitment) {
@@ -126,6 +125,7 @@ where
         }
     }
 
+    // TODO: parallelize
     let rotation_sets = rotation_set_commitment_map
         .into_iter()
         .map(|(rotations, commitments)| {

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs
@@ -17,6 +17,8 @@ use ff::Field;
 use group::Curve;
 use halo2curves::pairing::Engine;
 use rand_core::RngCore;
+use rayon::iter::ParallelIterator;
+use rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator};
 use std::fmt::Debug;
 use std::io::{self, Write};
 use std::marker::PhantomData;
@@ -171,11 +173,11 @@ impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>>
         );
 
         let rotation_sets: Vec<RotationSetExtension<E::G1Affine>> = rotation_sets
-            .iter()
+            .par_iter()
             .map(|rotation_set| {
                 let commitments: Vec<CommitmentExtension<E::G1Affine>> = rotation_set
                     .commitments
-                    .iter()
+                    .par_iter()
                     .map(|commitment_data| commitment_data.extend(rotation_set.points.clone()))
                     .collect();
                 rotation_set.extend(commitments)
@@ -184,9 +186,13 @@ impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>>
 
         let v: ChallengeV<_> = transcript.squeeze_challenge_scalar();
 
-        let quotient_polynomials = rotation_sets.iter().map(quotient_contribution);
+        let quotient_polynomials = rotation_sets
+            .par_iter()
+            .map(quotient_contribution)
+            .collect::<Vec<_>>();
 
         let h_x: Polynomial<E::Scalar, Coeff> = quotient_polynomials
+            .into_iter()
             .zip(powers(*v))
             .map(|(poly, power_of_v)| poly * power_of_v)
             .reduce(|acc, poly| acc + &poly)
@@ -235,7 +241,7 @@ impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>>
             Vec<Polynomial<E::Scalar, Coeff>>,
             Vec<E::Scalar>,
         ) = rotation_sets
-            .into_iter()
+            .into_par_iter()
             .map(linearisation_contribution)
             .unzip();
 
@@ -249,6 +255,7 @@ impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>>
         let l_x = l_x - &(h_x * zt_eval);
 
         // sanity check
+        #[cfg(debug_assertions)]
         {
             let must_be_zero = eval_polynomial(&l_x.values[..], *u);
             assert_eq!(must_be_zero, E::Scalar::zero());

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs
@@ -17,8 +17,7 @@ use ff::Field;
 use group::Curve;
 use halo2curves::pairing::Engine;
 use rand_core::RngCore;
-use rayon::iter::ParallelIterator;
-use rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator};
+use rayon::prelude::*;
 use std::fmt::Debug;
 use std::io::{self, Write};
 use std::marker::PhantomData;
@@ -38,8 +37,8 @@ struct CommitmentExtension<'a, C: CurveAffine> {
 }
 
 impl<'a, C: CurveAffine> Commitment<C::Scalar, PolynomialPointer<'a, C>> {
-    fn extend(&self, points: Vec<C::Scalar>) -> CommitmentExtension<'a, C> {
-        let poly = lagrange_interpolate(&points[..], &self.evals()[..]);
+    fn extend(&self, points: &[C::Scalar]) -> CommitmentExtension<'a, C> {
+        let poly = lagrange_interpolate(points, &self.evals()[..]);
 
         let low_degree_equivalent = Polynomial {
             values: poly,
@@ -81,10 +80,10 @@ struct RotationSetExtension<'a, C: CurveAffine> {
 }
 
 impl<'a, C: CurveAffine> RotationSet<C::Scalar, PolynomialPointer<'a, C>> {
-    fn extend(&self, commitments: Vec<CommitmentExtension<'a, C>>) -> RotationSetExtension<'a, C> {
+    fn extend(self, commitments: Vec<CommitmentExtension<'a, C>>) -> RotationSetExtension<'a, C> {
         RotationSetExtension {
             commitments,
-            points: self.points.clone(),
+            points: self.points,
         }
     }
 }
@@ -138,8 +137,9 @@ impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>>
                 // [P_i_0(X) - R_i_0(X), P_i_1(X) - R_i_1(X), ... ]
                 let numerators = rotation_set
                     .commitments
-                    .iter()
-                    .map(|commitment| commitment.quotient_contribution());
+                    .par_iter()
+                    .map(|commitment| commitment.quotient_contribution())
+                    .collect::<Vec<_>>();
 
                 // define numerator polynomial as
                 // N_i_j(X) = (P_i_j(X) - R_i_j(X))
@@ -147,6 +147,7 @@ impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>>
                 // N_i(X) = linear_combinination(y, N_i_j(X))
                 // where y is random scalar to combine numerator polynomials
                 let n_x = numerators
+                    .into_iter()
                     .zip(powers(*y))
                     .map(|(numerator, power_of_y)| numerator * power_of_y)
                     .reduce(|acc, numerator| acc + &numerator)
@@ -173,12 +174,12 @@ impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>>
         );
 
         let rotation_sets: Vec<RotationSetExtension<E::G1Affine>> = rotation_sets
-            .par_iter()
+            .into_par_iter()
             .map(|rotation_set| {
                 let commitments: Vec<CommitmentExtension<E::G1Affine>> = rotation_set
                     .commitments
                     .par_iter()
-                    .map(|commitment_data| commitment_data.extend(rotation_set.points.clone()))
+                    .map(|commitment_data| commitment_data.extend(&rotation_set.points))
                     .collect();
                 rotation_set.extend(commitments)
             })
@@ -202,18 +203,15 @@ impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>>
         transcript.write_point(h)?;
         let u: ChallengeU<_> = transcript.squeeze_challenge_scalar();
 
-        let zt_eval = evaluate_vanishing_polynomial(&super_point_set[..], *u);
-
         let linearisation_contribution =
             |rotation_set: RotationSetExtension<E::G1Affine>| -> (Polynomial<E::Scalar, Coeff>, E::Scalar) {
-                let diffs: Vec<E::Scalar> = super_point_set
-                    .iter()
-                    .filter(|point| !rotation_set.points.contains(point))
-                    .copied()
-                    .collect();
+                let mut diffs = super_point_set.clone();
+                for point in rotation_set.points.iter() {
+                    diffs.remove(point);
+                }
+                let diffs = diffs.into_iter().collect::<Vec<_>>();
 
                 // calculate difference vanishing polynomial evaluation
-
                 let z_i = evaluate_vanishing_polynomial(&diffs[..], *u);
 
                 // inner linearisation contibutions are
@@ -222,15 +220,15 @@ impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>>
                 // where u is random evaluation point
                 let inner_contributions = rotation_set
                     .commitments
-                    .iter()
-                    .map(|commitment| commitment.linearisation_contribution(*u));
+                    .par_iter()
+                    .map(|commitment| commitment.linearisation_contribution(*u)).collect::<Vec<_>>();
 
                 // define inner contributor polynomial as
                 // L_i_j(X) = (P_i_j(X) - r_i_j)
                 // and combine polynomials with same evaluation point set
                 // L_i(X) = linear_combinination(y, L_i_j(X))
                 // where y is random scalar to combine inner contibutors
-                let l_x: Polynomial<E::Scalar, Coeff> = inner_contributions.zip(powers(*y)).map(|(poly, power_of_y)| poly * power_of_y).reduce(|acc, poly| acc + &poly).unwrap();
+                let l_x: Polynomial<E::Scalar, Coeff> = inner_contributions.into_iter().zip(powers(*y)).map(|(poly, power_of_y)| poly * power_of_y).reduce(|acc, poly| acc + &poly).unwrap();
 
                 // finally scale l_x by difference vanishing polynomial evaluation z_i
                 (l_x * z_i, z_i)
@@ -252,6 +250,8 @@ impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>>
             .reduce(|acc, poly| acc + &poly)
             .unwrap();
 
+        let super_point_set = super_point_set.into_iter().collect::<Vec<_>>();
+        let zt_eval = evaluate_vanishing_polynomial(&super_point_set[..], *u);
         let l_x = l_x - &(h_x * zt_eval);
 
         // sanity check

--- a/halo2_proofs/src/poly/query.rs
+++ b/halo2_proofs/src/poly/query.rs
@@ -8,8 +8,8 @@ use crate::{
 use ff::Field;
 use halo2curves::CurveAffine;
 
-pub trait Query<F>: Sized + Clone {
-    type Commitment: PartialEq + Copy;
+pub trait Query<F>: Sized + Clone + Send + Sync {
+    type Commitment: PartialEq + Copy + Send + Sync;
     type Eval: Clone + Default + Debug;
 
     fn get_point(&self) -> F;


### PR DESCRIPTION
The main commit d6f562a basically just changes two iterators to `par_iter`. On some circuit I tested this sped up the SHPLONK multi-open proving time at the end of `create_proof` from `12s` to `4s`. 

The other commits are optional and only give minor performance improvements. I used `BTreeSet` for a slightly more efficient/cleaner implementation of getting the distinct rotation sets. Then the last commit (which can be reverted if necessary) adds `Send + Sync` to some traits for further parallelization. 