### PR TITLE
Fix MockProver `assert_verify` panic errors

### DIFF
--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -1315,6 +1315,27 @@ impl<F: FieldExt> MockProver<F> {
             panic!("circuit was not satisfied");
         }
     }
+
+    /// Panics if the circuit being checked by this `MockProver` is not satisfied.
+    ///
+    /// Any verification failures will be pretty-printed to stderr before the function
+    /// panics.
+    ///
+    /// Internally, this function uses a parallel aproach in order to verify the `MockProver` contents.
+    ///
+    /// Apart from the stderr output, this method is equivalent to:
+    /// ```ignore
+    /// assert_eq!(prover.verify_par(), Ok(()));
+    /// ```
+    pub fn assert_satisfied_par(&self) {
+        if let Err(errs) = self.verify_par() {
+            for err in errs {
+                err.emit(self);
+                eprintln!();
+            }
+            panic!("circuit was not satisfied");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1392,16 +1413,17 @@ mod tests {
         }
 
         let prover = MockProver::run(K, &FaultyCircuit {}, vec![]).unwrap();
-        assert_eq!(
-            prover.verify(),
-            Err(vec![VerifyFailure::CellNotAssigned {
-                gate: (0, "Equality check").into(),
-                region: (0, "Faulty synthesis".to_owned()).into(),
-                gate_offset: 1,
-                column: Column::new(1, Any::advice()),
-                offset: 1,
-            }])
-        );
+        prover.assert_satisfied();
+        // assert_eq!(
+        //     prover.verify(),
+        //     Err(vec![VerifyFailure::CellNotAssigned {
+        //         gate: (0, "Equality check").into(),
+        //         region: (0, "Faulty synthesis".to_owned()).into(),
+        //         gate_offset: 1,
+        //         column: Column::new(1, Any::advice()),
+        //         offset: 1,
+        //     }])
+        // );
     }
 
     #[test]

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -1413,17 +1413,16 @@ mod tests {
         }
 
         let prover = MockProver::run(K, &FaultyCircuit {}, vec![]).unwrap();
-        prover.assert_satisfied();
-        // assert_eq!(
-        //     prover.verify(),
-        //     Err(vec![VerifyFailure::CellNotAssigned {
-        //         gate: (0, "Equality check").into(),
-        //         region: (0, "Faulty synthesis".to_owned()).into(),
-        //         gate_offset: 1,
-        //         column: Column::new(1, Any::advice()),
-        //         offset: 1,
-        //     }])
-        // );
+        assert_eq!(
+            prover.verify(),
+            Err(vec![VerifyFailure::CellNotAssigned {
+                gate: (0, "Equality check").into(),
+                region: (0, "Faulty synthesis".to_owned()).into(),
+                gate_offset: 1,
+                column: Column::new(1, Any::advice()),
+                offset: 1,
+            }])
+        );
     }
 
     #[test]

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -398,18 +398,18 @@ fn render_lookup<F: FieldExt>(
 
     // Recover the fixed columns from the table expressions. We don't allow composite
     // expressions for the table side of lookups.
-    let table_columns = lookup.table_expressions.iter().map(|expr| {
+    let lookup_columns = lookup.table_expressions.iter().map(|expr| {
         expr.evaluate(
             &|_| panic!("no constants in table expressions"),
             &|_| panic!("no selectors in table expressions"),
             &|query| format!("F{}", query.column_index),
-            &|_| panic!("no advice columns in table expressions"),
-            &|_| panic!("no instance columns in table expressions"),
-            &|_| panic!("no challenges in table expressions"),
-            &|_| panic!("no negations in table expressions"),
-            &|_, _| panic!("no sums in table expressions"),
-            &|_, _| panic!("no products in table expressions"),
-            &|_, _| panic!("no scaling in table expressions"),
+            &|query| format! {"A{}", query.column_index},
+            &|query| format! {"I{}", query.column_index},
+            &|challenge| format! {"C{}", challenge.index()},
+            &|query| format! {"-{}", query},
+            &|a, b| format! {"{} + {}", a,b},
+            &|a, b| format! {"{} * {}", a,b},
+            &|a, b| format! {"{} * {:?}", a, b},
         )
     });
 
@@ -441,7 +441,7 @@ fn render_lookup<F: FieldExt>(
         eprint!("{}L{}", if i == 0 { "" } else { ", " }, i);
     }
     eprint!(") ∉ (");
-    for (i, column) in table_columns.enumerate() {
+    for (i, column) in lookup_columns.enumerate() {
         eprint!("{}{}", if i == 0 { "" } else { ", " }, column);
     }
     eprintln!(")");

--- a/halo2_proofs/src/dev/failure/emitter.rs
+++ b/halo2_proofs/src/dev/failure/emitter.rs
@@ -130,8 +130,7 @@ pub(super) fn expression_to_string<F: Field>(
                     )
                 })
                 .cloned()
-                .unwrap_or_else(|| String::new())
-                .clone()
+                .unwrap_or_default()
         },
         &|query| {
             layout

--- a/halo2_proofs/src/dev/failure/emitter.rs
+++ b/halo2_proofs/src/dev/failure/emitter.rs
@@ -120,7 +120,7 @@ pub(super) fn expression_to_string<F: Field>(
         &|query| {
             layout
                 .get(&query.rotation.0)
-                .map(|map| {
+                .and_then(|map| {
                     map.get(
                         &(
                             Any::Advice(Advice { phase: query.phase }),
@@ -129,7 +129,6 @@ pub(super) fn expression_to_string<F: Field>(
                             .into(),
                     )
                 })
-                .flatten()
                 .cloned()
                 .unwrap_or_else(|| String::new())
                 .clone()

--- a/halo2_proofs/src/dev/failure/emitter.rs
+++ b/halo2_proofs/src/dev/failure/emitter.rs
@@ -120,15 +120,18 @@ pub(super) fn expression_to_string<F: Field>(
         &|query| {
             layout
                 .get(&query.rotation.0)
-                .unwrap()
-                .get(
-                    &(
-                        Any::Advice(Advice { phase: query.phase }),
-                        query.column_index,
+                .map(|map| {
+                    map.get(
+                        &(
+                            Any::Advice(Advice { phase: query.phase }),
+                            query.column_index,
+                        )
+                            .into(),
                     )
-                        .into(),
-                )
-                .unwrap()
+                })
+                .flatten()
+                .cloned()
+                .unwrap_or_else(|| String::new())
                 .clone()
         },
         &|query| {


### PR DESCRIPTION
Since lookups can only be `Fixed` in Halo2-upstream, we need to add custom suport for the error rendering of dynamic lookups which doesn't come by default when we rebase to upstream.

This means that now we have to print not only `AdviceQuery` results to render the `Expression` that is being looked up. But also support `Instance`, `Advice`, `Challenge` or any other expression types that are avaliable. Therefore, enabling dynamic lookups for `MockProver`.

This addresses the rendering issue, renaming also the `table_columns` variable for `lookup_columns` as the columns do not have the type `TableColumn` by default as opposite to what happens upstream.

`MockProver::assert_satisfied_par` is also included with this PR.

Resolves: #116 