### PR TITLE
fix: FailureLocation::find empty-region handling

### DIFF
--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -90,6 +90,9 @@ impl FailureLocation {
             .iter()
             .enumerate()
             .find(|(_, r)| {
+                if r.rows.is_none() {
+                    return false;
+                }
                 let (start, end) = r.rows.unwrap();
                 // We match the region if any input columns overlap, rather than all of
                 // them, because matching complex selector columns is hard. As long as


### PR DESCRIPTION
After working on fixing
privacy-scaling-explorations/zkevm-circuits#1024, a bug was found in the verification fn of the MockProver which implies that while finding a FailureLocation, if a Region doesn't contain any rows.

This is fixed by introducing a 2-line solution suggested by @lispc.

Resolves: #117