### PR TITLE
Feat/expose mock fixed

### DIFF
--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use blake2b_simd::blake2b;
 use ff::Field;
 
+use crate::plonk::permutation::keygen::Assembly;
 use crate::{
     arithmetic::{FieldExt, Group},
     circuit,
@@ -1340,6 +1341,11 @@ impl<F: FieldExt> MockProver<F> {
     /// Returns the list of Fixed Columns used within a MockProver instance and the associated values contained on each Cell.
     pub fn fixed(&self) -> &Vec<Vec<CellValue<F>>> {
         &self.fixed
+    }
+
+    /// TODO
+    pub fn permutation(&self) -> &Assembly {
+        &self.permutation
     }
 }
 

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -1343,7 +1343,7 @@ impl<F: FieldExt> MockProver<F> {
         &self.fixed
     }
 
-    /// TODO
+    /// Returns the permutation argument (`Assembly`) used within a MockProver instance.
     pub fn permutation(&self) -> &Assembly {
         &self.permutation
     }

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -82,12 +82,12 @@ impl Region {
 
 /// The value of a particular cell within the circuit.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum CellValue<F: Group + Field> {
-    // An unassigned cell.
+pub enum CellValue<F: Group + Field> {
+    /// An unassigned cell.
     Unassigned,
-    // A cell that has been assigned a value.
+    /// A cell that has been assigned a value.
     Assigned(F),
-    // A unique poisoned cell.
+    /// A unique poisoned cell.
     Poison(usize),
 }
 
@@ -1335,6 +1335,11 @@ impl<F: FieldExt> MockProver<F> {
             }
             panic!("circuit was not satisfied");
         }
+    }
+
+    /// Returns the list of Fixed Columns used within a MockProver instance and the associated values contained on each Cell.
+    pub fn fixed(&self) -> &Vec<Vec<CellValue<F>>> {
+        &self.fixed
     }
 }
 

--- a/halo2_proofs/src/plonk/permutation/keygen.rs
+++ b/halo2_proofs/src/plonk/permutation/keygen.rs
@@ -11,12 +11,17 @@ use crate::{
     },
 };
 
+/// Struct that accumulates all the necessary data in order to construct the permutation argument.
 #[derive(Debug)]
-pub(crate) struct Assembly {
-    columns: Vec<Column<Any>>,
-    pub(crate) mapping: Vec<Vec<(usize, usize)>>,
-    aux: Vec<Vec<(usize, usize)>>,
-    sizes: Vec<Vec<usize>>,
+pub struct Assembly {
+    /// Columns that participate on the copy permutation argument.
+    pub columns: Vec<Column<Any>>,
+    /// Mapping of the actual copies done.
+    pub mapping: Vec<Vec<(usize, usize)>>,
+    /// Some aux data used to swap positions directly when sorting.
+    pub aux: Vec<Vec<(usize, usize)>>,
+    /// More aux data
+    pub sizes: Vec<Vec<usize>>,
 }
 
 impl Assembly {


### PR DESCRIPTION
Exposes permutation argument & fixed columns of the `MockProver` instance to the dev.

This helps to detect (and maybe) prevent variadic-circuit behaviours.

Resolves #112 