### PR TITLE
fix: Allow to compare `Assembly` structs

### DIFF
--- a/halo2_proofs/src/plonk/permutation/keygen.rs
+++ b/halo2_proofs/src/plonk/permutation/keygen.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// Struct that accumulates all the necessary data in order to construct the permutation argument.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Assembly {
     /// Columns that participate on the copy permutation argument.
     pub columns: Vec<Column<Any>>,


### PR DESCRIPTION
This was missing in #123 so this PR fixes it.