### PR TITLE
Call `synthesize` in `MockProver` multiple times to behave same as real prover

### DIFF
--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -15,9 +15,11 @@ use crate::{
     arithmetic::{FieldExt, Group},
     circuit,
     plonk::{
-        permutation, Advice, Any, Assigned, Assignment, Challenge, Circuit, Column, ColumnType,
-        ConstraintSystem, Error, Expression, Fixed, FloorPlanner, Instance, Phase, Selector,
-        VirtualCell,
+        permutation,
+        sealed::{self, SealedPhase},
+        Advice, Any, Assigned, Assignment, Challenge, Circuit, Column, ColumnType,
+        ConstraintSystem, Error, Expression, FirstPhase, Fixed, FloorPlanner, Instance, Phase,
+        Selector, VirtualCell,
     },
     poly::Rotation,
 };
@@ -307,6 +309,14 @@ pub struct MockProver<F: Group + Field> {
 
     // A range of available rows for assignment and copies.
     usable_rows: Range<usize>,
+
+    current_phase: sealed::Phase,
+}
+
+impl<F: Field + Group> MockProver<F> {
+    fn in_phase<P: Phase>(&self, phase: P) -> bool {
+        self.current_phase == phase.to_sealed()
+    }
 }
 
 impl<F: Field + Group> Assignment<F> for MockProver<F> {
@@ -315,6 +325,10 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
         NR: Into<String>,
         N: FnOnce() -> NR,
     {
+        if !self.in_phase(FirstPhase) {
+            return;
+        }
+
         assert!(self.current_region.is_none());
         self.current_region = Some(Region {
             name: name().into(),
@@ -327,6 +341,10 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
     }
 
     fn exit_region(&mut self) {
+        if !self.in_phase(FirstPhase) {
+            return;
+        }
+
         self.regions.push(self.current_region.take().unwrap());
     }
 
@@ -335,6 +353,10 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
         A: FnOnce() -> AR,
         AR: Into<String>,
     {
+        if !self.in_phase(FirstPhase) {
+            return;
+        }
+
         if let Some(region) = self.current_region.as_mut() {
             region
                 .annotations
@@ -347,6 +369,10 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
         A: FnOnce() -> AR,
         AR: Into<String>,
     {
+        if !self.in_phase(FirstPhase) {
+            return Ok(());
+        }
+
         if !self.usable_rows.contains(&row) {
             return Err(Error::not_enough_rows_available(self.k));
         }
@@ -395,25 +421,29 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
         A: FnOnce() -> AR,
         AR: Into<String>,
     {
-        if !self.usable_rows.contains(&row) {
-            return Err(Error::not_enough_rows_available(self.k));
+        if self.in_phase(FirstPhase) {
+            if !self.usable_rows.contains(&row) {
+                return Err(Error::not_enough_rows_available(self.k));
+            }
+
+            if let Some(region) = self.current_region.as_mut() {
+                region.update_extent(column.into(), row);
+                region
+                    .cells
+                    .entry((column.into(), row))
+                    .and_modify(|count| *count += 1)
+                    .or_default();
+            }
         }
 
-        if let Some(region) = self.current_region.as_mut() {
-            region.update_extent(column.into(), row);
-            region
-                .cells
-                .entry((column.into(), row))
-                .and_modify(|count| *count += 1)
-                .or_default();
+        if self.in_phase(column.column_type().phase) {
+            *self
+                .advice
+                .get_mut(column.index())
+                .and_then(|v| v.get_mut(row))
+                .ok_or(Error::BoundsFailure)? =
+                CellValue::Assigned(to().into_field().evaluate().assign()?);
         }
-
-        *self
-            .advice
-            .get_mut(column.index())
-            .and_then(|v| v.get_mut(row))
-            .ok_or(Error::BoundsFailure)? =
-            CellValue::Assigned(to().into_field().evaluate().assign()?);
 
         Ok(())
     }
@@ -431,6 +461,10 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
         A: FnOnce() -> AR,
         AR: Into<String>,
     {
+        if !self.in_phase(FirstPhase) {
+            return Ok(());
+        }
+
         if !self.usable_rows.contains(&row) {
             return Err(Error::not_enough_rows_available(self.k));
         }
@@ -461,6 +495,10 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
         right_column: Column<Any>,
         right_row: usize,
     ) -> Result<(), crate::plonk::Error> {
+        if !self.in_phase(FirstPhase) {
+            return Ok(());
+        }
+
         if !self.usable_rows.contains(&left_row) || !self.usable_rows.contains(&right_row) {
             return Err(Error::not_enough_rows_available(self.k));
         }
@@ -475,6 +513,10 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
         from_row: usize,
         to: circuit::Value<Assigned<F>>,
     ) -> Result<(), Error> {
+        if !self.in_phase(FirstPhase) {
+            return Ok(());
+        }
+
         if !self.usable_rows.contains(&from_row) {
             return Err(Error::not_enough_rows_available(self.k));
         }
@@ -487,6 +529,10 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
     }
 
     fn get_challenge(&self, challenge: Challenge) -> circuit::Value<F> {
+        if self.current_phase <= challenge.phase {
+            return circuit::Value::unknown();
+        }
+
         circuit::Value::known(self.challenges[challenge.index()])
     }
 
@@ -581,9 +627,18 @@ impl<F: FieldExt> MockProver<F> {
             challenges,
             permutation,
             usable_rows: 0..usable_rows,
+            current_phase: FirstPhase.to_sealed(),
         };
 
-        ConcreteCircuit::FloorPlanner::synthesize(&mut prover, circuit, config, constants)?;
+        for current_phase in prover.cs.phases() {
+            prover.current_phase = current_phase;
+            ConcreteCircuit::FloorPlanner::synthesize(
+                &mut prover,
+                circuit,
+                config.clone(),
+                constants.clone(),
+            )?;
+        }
 
         let (cs, selector_polys) = prover.cs.compress_selectors(prover.selectors.clone());
         prover.cs = cs;

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -76,6 +76,12 @@ pub(crate) mod sealed {
         }
     }
 
+    impl SealedPhase for Phase {
+        fn to_sealed(self) -> Phase {
+            self
+        }
+    }
+
     /// Sealed trait to help keep `Phase` private.
     pub trait SealedPhase {
         fn to_sealed(self) -> Phase;
@@ -496,7 +502,7 @@ impl TableColumn {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct Challenge {
     index: usize,
-    phase: sealed::Phase,
+    pub(crate) phase: sealed::Phase,
 }
 
 impl Challenge {


### PR DESCRIPTION
Since the adoption of challenge API in `zkevm-circuits` is not just a small part, it's getting more difficult to use real prover to test the mutli-phase circuit is written properly, so this PR aims to update the `MockProver` to call `synthesize` multiple times to behave exact same as real prover for easier debugging.

It should reduce the chance of issue like https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/1086 to happen.

Resolves https://github.com/privacy-scaling-explorations/halo2/issues/102.
