### PR TITLE
Expose mod `permutation` and re-export `permutation::keygen::Assembly`

### DIFF
--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -973,7 +973,7 @@ impl<F: FieldExt> MockProver<F> {
 
             // Iterate over each column of the permutation
             self.permutation
-                .mapping
+                .mapping()
                 .iter()
                 .enumerate()
                 .flat_map(move |(column, values)| {
@@ -1334,7 +1334,7 @@ impl<F: FieldExt> MockProver<F> {
 
             // Iterate over each column of the permutation
             self.permutation
-                .mapping
+                .mapping()
                 .iter()
                 .enumerate()
                 .flat_map(move |(column, values)| {

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -27,7 +27,7 @@ mod error;
 mod evaluation;
 mod keygen;
 mod lookup;
-pub(crate) mod permutation;
+pub mod permutation;
 mod vanishing;
 
 mod prover;

--- a/halo2_proofs/src/plonk/permutation.rs
+++ b/halo2_proofs/src/plonk/permutation.rs
@@ -1,3 +1,5 @@
+//! Implementation of permutation argument.
+
 use super::circuit::{Any, Column};
 use crate::{
     arithmetic::CurveAffine,
@@ -13,6 +15,8 @@ use ff::PrimeField;
 pub(crate) mod keygen;
 pub(crate) mod prover;
 pub(crate) mod verifier;
+
+pub use keygen::Assembly;
 
 use std::io;
 
@@ -72,6 +76,7 @@ impl Argument {
         }
     }
 
+    /// Returns columns that participate on the permutation argument.
     pub fn get_columns(&self) -> Vec<Column<Any>> {
         self.columns.clone()
     }

--- a/halo2_proofs/src/plonk/permutation/keygen.rs
+++ b/halo2_proofs/src/plonk/permutation/keygen.rs
@@ -15,13 +15,13 @@ use crate::{
 #[derive(Debug, PartialEq, Eq)]
 pub struct Assembly {
     /// Columns that participate on the copy permutation argument.
-    pub columns: Vec<Column<Any>>,
+    columns: Vec<Column<Any>>,
     /// Mapping of the actual copies done.
-    pub mapping: Vec<Vec<(usize, usize)>>,
+    mapping: Vec<Vec<(usize, usize)>>,
     /// Some aux data used to swap positions directly when sorting.
-    pub aux: Vec<Vec<(usize, usize)>>,
+    aux: Vec<Vec<(usize, usize)>>,
     /// More aux data
-    pub sizes: Vec<Vec<usize>>,
+    sizes: Vec<Vec<usize>>,
 }
 
 impl Assembly {
@@ -238,5 +238,15 @@ impl Assembly {
             polys,
             cosets,
         }
+    }
+
+    /// Returns columns that participate on the permutation argument.
+    pub fn columns(&self) -> &[Column<Any>] {
+        &self.columns
+    }
+
+    /// Returns mappings of the copies.
+    pub fn mapping(&self) -> &[Vec<(usize, usize)>] {
+        &self.mapping
     }
 }

--- a/halo2_proofs/src/plonk/permutation/keygen.rs
+++ b/halo2_proofs/src/plonk/permutation/keygen.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// Struct that accumulates all the necessary data in order to construct the permutation argument.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Assembly {
     /// Columns that participate on the copy permutation argument.
     columns: Vec<Column<Any>>,


### PR DESCRIPTION
Expose module `plonk::permutation` and re-export `plonk::permutation::keygen::Assembly`. Also update the field of `Assembly` to be private to avoid misuse, and instead add getter for the `columns` and `mapping`.

Resolves https://github.com/privacy-scaling-explorations/halo2/issues/146