### PR TITLE
 fix(clippy): allow unprivileged runs of clippy 

### DIFF
--- a/.github/workflows/lints-beta.yml
+++ b/.github/workflows/lints-beta.yml
@@ -5,22 +5,39 @@ name: Beta lints
 on: push
 
 jobs:
-  clippy-beta:
-    name: Clippy (beta)
+  clippy:
+    name: Clippy
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    continue-on-error: true
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v2
         with:
-          components: clippy
-          override: false
-      - name: Run Clippy (beta)
-        uses: actions-rs/clippy-check@v1
-        continue-on-error: true
+          persist-credentials: false
+
+      - name: Check workflow permissions
+        id: check_permissions
+        uses: scherermichael-oss/action-has-permission@1.0.6
         with:
-          name: Clippy (beta)
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run clippy action to produce annotations
+        uses: actions-rs/clippy-check@v1.0.7
+        if: ${{ steps.check_permissions.outputs.has-permission }}
+        with:
+          # GitHub displays the clippy job and its results as separate entries
+          name: Clippy (stable) Results
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets -- -W clippy::all
+          args: --all-features --all-targets -- -D warnings
+
+      - uses: actions-rs/toolchain@v1.0.1
+        if: ${{ !steps.check_permissions.outputs.has-permission }}
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run clippy manually without annotations
+        if: ${{ !steps.check_permissions.outputs.has-permission }}
+        run: cargo clippy --all-features --all-targets -- -D warnings

--- a/.github/workflows/lints-stable.yml
+++ b/.github/workflows/lints-stable.yml
@@ -5,19 +5,38 @@ on: pull_request
 
 jobs:
   clippy:
-    name: Clippy (1.56.1)
+    name: Clippy
     timeout-minutes: 30
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v2
         with:
-          components: clippy
-          override: false
-      - name: Run clippy
-        uses: actions-rs/clippy-check@v1
+          persist-credentials: false
+
+      - name: Check workflow permissions
+        id: check_permissions
+        uses: scherermichael-oss/action-has-permission@1.0.6
         with:
-          name: Clippy (1.56.1)
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run clippy action to produce annotations
+        uses: actions-rs/clippy-check@v1.0.7
+        if: ${{ steps.check_permissions.outputs.has-permission }}
+        with:
+          # GitHub displays the clippy job and its results as separate entries
+          name: Clippy (stable) Results
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
+
+      - uses: actions-rs/toolchain@v1.0.1
+        if: ${{ !steps.check_permissions.outputs.has-permission }}
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run clippy manually without annotations
+        if: ${{ !steps.check_permissions.outputs.has-permission }}
+        run: cargo clippy --all-features --all-targets -- -D warnings


### PR DESCRIPTION
Since this repo is a fork, Clippy checks won't work directly while creating inline annotations.
See: https://github.com/actions-rs/clippy-check/issues/2

This PR tries to fix the CI temporarily while a better solution is found.