### PR TITLE
feat: Parallel random blinder poly impl

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -28,6 +28,10 @@ name = "arithmetic"
 harness = false
 
 [[bench]]
+name = "commit_zk"
+harness = false
+
+[[bench]]
 name = "hashtocurve"
 harness = false
 
@@ -53,6 +57,7 @@ rand_core = { version = "0.6", default-features = false }
 tracing = "0.1"
 blake2b_simd = "1"
 sha3 = "0.9.1"
+rand_chacha = "0.3"
 
 # Developer tooling dependencies
 plotters = { version = "0.3.0", optional = true }

--- a/halo2_proofs/benches/commit_zk.rs
+++ b/halo2_proofs/benches/commit_zk.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate criterion;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};

--- a/halo2_proofs/benches/commit_zk.rs
+++ b/halo2_proofs/benches/commit_zk.rs
@@ -1,0 +1,69 @@
+#[macro_use]
+extern crate criterion;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use group::ff::Field;
+use halo2_proofs::poly::{LagrangeCoeff, Polynomial};
+use halo2_proofs::*;
+use halo2curves::pasta::pallas::Scalar;
+use rand_chacha::rand_core::RngCore;
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use rayon::{
+    current_num_threads,
+    prelude::{IntoParallelRefIterator, ParallelIterator},
+};
+
+fn rand_poly_serial(mut rng: ChaCha20Rng, domain: usize) -> Polynomial<Scalar, LagrangeCoeff> {
+    // Sample a random polynomial of degree n - 1
+    let mut random_poly = vec![Scalar::zero(); 1 << domain];
+    for coeff in random_poly.iter_mut() {
+        *coeff = Scalar::random(&mut rng);
+    }
+    assert_eq!(random_poly.len(), 1 << domain);
+    Polynomial::from_evals(random_poly)
+}
+
+fn rand_poly_par(mut rng: ChaCha20Rng, domain: usize) -> Polynomial<Scalar, LagrangeCoeff> {
+    // Sample a random polynomial of degree n - 1
+    let n_threads = current_num_threads();
+    let needed_scalars = (1 << domain) / n_threads;
+
+    let thread_seeds: Vec<ChaCha20Rng> = (0..n_threads)
+        .into_iter()
+        .map(|_| {
+            let mut seed = [0u8; 32];
+            rng.fill_bytes(&mut seed);
+            ChaCha20Rng::from_seed(seed)
+        })
+        .collect();
+
+    let rand_vec: Vec<Scalar> = thread_seeds
+        .par_iter()
+        .flat_map(|rng| vec![Scalar::random(rng.to_owned()); needed_scalars])
+        .collect();
+
+    assert_eq!(rand_vec.len(), 1 << domain);
+    Polynomial::from_evals(rand_vec)
+}
+
+fn bench_commit(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Blinder_poly");
+    let rand = ChaCha20Rng::from_seed([1u8; 32]);
+    for i in [
+        18usize, 19usize, 20usize, 21usize, 22usize, 23usize, 24usize, 25usize,
+    ]
+    .iter()
+    {
+        group.bench_with_input(BenchmarkId::new("serial", i), i, |b, i| {
+            b.iter(|| rand_poly_serial(rand.clone(), *i))
+        });
+        group.bench_with_input(BenchmarkId::new("parallel", i), i, |b, i| {
+            b.iter(|| rand_poly_par(rand.clone(), *i))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_commit);
+criterion_main!(benches);

--- a/halo2_proofs/src/plonk/vanishing/prover.rs
+++ b/halo2_proofs/src/plonk/vanishing/prover.rs
@@ -54,7 +54,6 @@ impl<C: CurveAffine> Argument<C> {
         let n_chunks = n_threads + if n % n_threads != 0 { 1 } else { 0 };
         let mut rand_vec = vec![C::Scalar::zero(); n];
 
-        // We always round up the division by adding 1 extra seed.
         let mut thread_seeds: Vec<ChaCha20Rng> = (0..n_chunks)
             .into_iter()
             .map(|_| {
@@ -72,9 +71,6 @@ impl<C: CurveAffine> Argument<C> {
                     .iter_mut()
                     .for_each(|v| *v = C::Scalar::random(&mut rng))
             });
-
-        // Truncate the leftover elements of the Vec (if any).
-        rand_vec.truncate(1usize << domain.k() as usize);
 
         let random_poly: Polynomial<C::Scalar, Coeff> = domain.coeff_from_vec(rand_vec);
 

--- a/halo2_proofs/src/plonk/vanishing/prover.rs
+++ b/halo2_proofs/src/plonk/vanishing/prover.rs
@@ -52,7 +52,7 @@ impl<C: CurveAffine> Argument<C> {
         let n_threads = std::thread::available_parallelism().unwrap().get();
         let needed_scalars = (1usize << domain.k() as usize) / n_threads;
 
-        let thread_seeds: Vec<ChaCha20Rng> = (0..needed_scalars)
+        let thread_seeds: Vec<ChaCha20Rng> = (0..n_threads)
             .into_iter()
             .map(|_| {
                 let mut seed = [0u8; 32];

--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -145,14 +145,6 @@ impl<F, B> Polynomial<F, B> {
     pub fn num_coeffs(&self) -> usize {
         self.values.len()
     }
-
-    /// Allows to create a Polynomial from a Vec.
-    pub fn from_evals(vector: Vec<F>) -> Self {
-        Polynomial {
-            values: vector,
-            _marker: PhantomData,
-        }
-    }
 }
 
 impl<F: SerdePrimeField, B> Polynomial<F, B> {

--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -145,6 +145,14 @@ impl<F, B> Polynomial<F, B> {
     pub fn num_coeffs(&self) -> usize {
         self.values.len()
     }
+
+    /// Allows to create a Polynomial from a Vec.
+    pub fn from_evals(vector: Vec<F>) -> Self {
+        Polynomial {
+            values: vector,
+            _marker: PhantomData,
+        }
+    }
 }
 
 impl<F: SerdePrimeField, B> Polynomial<F, B> {


### PR DESCRIPTION
So I got to a better solution. Which definitely seems solid and secure. And reduces aprox ~5-10x the execution time.

I also ran benches. Here the results:
```
Blinder_poly/serial/18  time:   [28.717 ms 28.779 ms 28.860 ms]                                   
                        change: [+0.0164% +0.2972% +0.5927%] (p = 0.05 < 0.05)
                       
Blinder_poly/parallel/18                                                                             
                        time:   [2.4532 ms 2.4792 ms 2.5064 ms]
                        change: [+0.7593% +2.2239% +3.7108%] (p = 0.00 < 0.05)
                        


Blinder_poly/serial/19  time:   [57.679 ms 57.764 ms 57.866 ms]                                   
                        change: [-1.1429% -0.7681% -0.4110%] (p = 0.00 < 0.05)
                        
Blinder_poly/parallel/19                                                                             
                        time:   [5.4919 ms 5.5360 ms 5.5832 ms]
                        change: [-0.2678% +0.8128% +1.9086%] (p = 0.14 > 0.05)
                        


Blinder_poly/serial/20  time:   [124.00 ms 124.12 ms 124.26 ms]                                   
                        change: [+0.4412% +0.6006% +0.7628%] (p = 0.00 < 0.05)
                        
Blinder_poly/parallel/20                                                                            
                        time:   [19.797 ms 19.868 ms 19.948 ms]
                        change: [-0.8847% -0.3244% +0.2474%] (p = 0.27 > 0.05)
                        


Blinder_poly/serial/21  time:   [243.33 ms 245.28 ms 246.94 ms]                                   
                        change: [-1.4546% -0.6227% +0.0895%] (p = 0.11 > 0.05)
                       
Blinder_poly/parallel/21                                                                            
                        time:   [42.218 ms 44.177 ms 46.453 ms]
                        change: [+4.8431% +9.3787% +14.967%] (p = 0.00 < 0.05)
                        


Blinder_poly/serial/22  time:   [496.53 ms 497.06 ms 497.65 ms]                                   
                        change: [+0.0300% +0.3798% +0.6700%] (p = 0.02 < 0.05)
                       
Blinder_poly/parallel/22                                                                            
                        time:   [79.689 ms 79.914 ms 80.162 ms]
                        change: [-7.9753% -4.9272% -2.8485%] (p = 0.00 < 0.05)
                        
```

cpu info:
```
Model name:            Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
    CPU family:          6
    Model:               165
    Thread(s) per core:  2
    Core(s) per socket:  8
```

This should close: #151 