### PR TITLE
Extend Circuit trait to take parameters in config

### DIFF
--- a/halo2_gadgets/Cargo.toml
+++ b/halo2_gadgets/Cargo.toml
@@ -49,6 +49,7 @@ bench = false
 
 [features]
 dev-graph = ["halo2_proofs/dev-graph", "plotters"]
+circuit-params = ["halo2_proofs/circuit-params"]
 test-dependencies = ["proptest"]
 unstable = []
 

--- a/halo2_gadgets/benches/poseidon.rs
+++ b/halo2_gadgets/benches/poseidon.rs
@@ -63,10 +63,7 @@ where
         }
     }
 
-    fn configure(
-        meta: &mut ConstraintSystem<Fp>,
-        #[cfg(feature = "circuit-params")] _: &(),
-    ) -> Self::Config {
+    fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
         let state = (0..WIDTH).map(|_| meta.advice_column()).collect::<Vec<_>>();
         let expected = meta.instance_column();
         meta.enable_equality(expected);

--- a/halo2_gadgets/benches/poseidon.rs
+++ b/halo2_gadgets/benches/poseidon.rs
@@ -53,6 +53,7 @@ where
 {
     type Config = MyConfig<WIDTH, RATE, L>;
     type FloorPlanner = SimpleFloorPlanner;
+    #[cfg(feature = "circuit-params")]
     type Params = ();
 
     fn without_witnesses(&self) -> Self {
@@ -62,7 +63,10 @@ where
         }
     }
 
-    fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+    fn configure(
+        meta: &mut ConstraintSystem<Fp>,
+        #[cfg(feature = "circuit-params")] _: &(),
+    ) -> Self::Config {
         let state = (0..WIDTH).map(|_| meta.advice_column()).collect::<Vec<_>>();
         let expected = meta.instance_column();
         meta.enable_equality(expected);

--- a/halo2_gadgets/benches/poseidon.rs
+++ b/halo2_gadgets/benches/poseidon.rs
@@ -53,6 +53,7 @@ where
 {
     type Config = MyConfig<WIDTH, RATE, L>;
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self {

--- a/halo2_gadgets/benches/sha256.rs
+++ b/halo2_gadgets/benches/sha256.rs
@@ -37,6 +37,7 @@ fn bench(name: &str, k: u32, c: &mut Criterion) {
     impl Circuit<pallas::Base> for MyCircuit {
         type Config = Table16Config;
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             Self::default()

--- a/halo2_gadgets/benches/sha256.rs
+++ b/halo2_gadgets/benches/sha256.rs
@@ -37,13 +37,17 @@ fn bench(name: &str, k: u32, c: &mut Criterion) {
     impl Circuit<pallas::Base> for MyCircuit {
         type Config = Table16Config;
         type FloorPlanner = SimpleFloorPlanner;
+        #[cfg(feature = "circuit-params")]
         type Params = ();
 
         fn without_witnesses(&self) -> Self {
             Self::default()
         }
 
-        fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+        fn configure(
+            meta: &mut ConstraintSystem<pallas::Base>,
+            #[cfg(feature = "circuit-params")] _: &(),
+        ) -> Self::Config {
             Table16Chip::configure(meta)
         }
 

--- a/halo2_gadgets/benches/sha256.rs
+++ b/halo2_gadgets/benches/sha256.rs
@@ -44,10 +44,7 @@ fn bench(name: &str, k: u32, c: &mut Criterion) {
             Self::default()
         }
 
-        fn configure(
-            meta: &mut ConstraintSystem<pallas::Base>,
-            #[cfg(feature = "circuit-params")] _: &(),
-        ) -> Self::Config {
+        fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
             Table16Chip::configure(meta)
         }
 

--- a/halo2_gadgets/src/ecc.rs
+++ b/halo2_gadgets/src/ecc.rs
@@ -731,6 +731,7 @@ pub(crate) mod tests {
     impl Circuit<pallas::Base> for MyCircuit {
         type Config = EccConfig<TestFixedBases>;
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             MyCircuit { test_errors: false }

--- a/halo2_gadgets/src/ecc.rs
+++ b/halo2_gadgets/src/ecc.rs
@@ -738,10 +738,7 @@ pub(crate) mod tests {
             MyCircuit { test_errors: false }
         }
 
-        fn configure(
-            meta: &mut ConstraintSystem<pallas::Base>,
-            #[cfg(feature = "circuit-params")] _: &(),
-        ) -> Self::Config {
+        fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
             let advices = [
                 meta.advice_column(),
                 meta.advice_column(),

--- a/halo2_gadgets/src/ecc.rs
+++ b/halo2_gadgets/src/ecc.rs
@@ -731,13 +731,17 @@ pub(crate) mod tests {
     impl Circuit<pallas::Base> for MyCircuit {
         type Config = EccConfig<TestFixedBases>;
         type FloorPlanner = SimpleFloorPlanner;
+        #[cfg(feature = "circuit-params")]
         type Params = ();
 
         fn without_witnesses(&self) -> Self {
             MyCircuit { test_errors: false }
         }
 
-        fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+        fn configure(
+            meta: &mut ConstraintSystem<pallas::Base>,
+            #[cfg(feature = "circuit-params")] _: &(),
+        ) -> Self::Config {
             let advices = [
                 meta.advice_column(),
                 meta.advice_column(),

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
@@ -441,10 +441,7 @@ pub mod tests {
                 Self::default()
             }
 
-            fn configure(
-                meta: &mut ConstraintSystem<pallas::Base>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
                 let advices = [
                     meta.advice_column(),
                     meta.advice_column(),

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
@@ -434,6 +434,7 @@ pub mod tests {
         impl Circuit<pallas::Base> for MyCircuit {
             type Config = EccConfig<TestFixedBases>;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 Self::default()

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
@@ -434,13 +434,17 @@ pub mod tests {
         impl Circuit<pallas::Base> for MyCircuit {
             type Config = EccConfig<TestFixedBases>;
             type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 Self::default()
             }
 
-            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+            fn configure(
+                meta: &mut ConstraintSystem<pallas::Base>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 let advices = [
                     meta.advice_column(),
                     meta.advice_column(),

--- a/halo2_gadgets/src/poseidon/pow5.rs
+++ b/halo2_gadgets/src/poseidon/pow5.rs
@@ -620,6 +620,7 @@ mod tests {
     {
         type Config = Pow5Config<Fp, WIDTH, RATE>;
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             PermuteCircuit::<S, WIDTH, RATE>(PhantomData)
@@ -735,6 +736,7 @@ mod tests {
     {
         type Config = Pow5Config<Fp, WIDTH, RATE>;
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             Self {

--- a/halo2_gadgets/src/poseidon/pow5.rs
+++ b/halo2_gadgets/src/poseidon/pow5.rs
@@ -627,10 +627,7 @@ mod tests {
             PermuteCircuit::<S, WIDTH, RATE>(PhantomData)
         }
 
-        fn configure(
-            meta: &mut ConstraintSystem<Fp>,
-            #[cfg(feature = "circuit-params")] _: &(),
-        ) -> Pow5Config<Fp, WIDTH, RATE> {
+        fn configure(meta: &mut ConstraintSystem<Fp>) -> Pow5Config<Fp, WIDTH, RATE> {
             let state = (0..WIDTH).map(|_| meta.advice_column()).collect::<Vec<_>>();
             let partial_sbox = meta.advice_column();
 
@@ -751,10 +748,7 @@ mod tests {
             }
         }
 
-        fn configure(
-            meta: &mut ConstraintSystem<Fp>,
-            #[cfg(feature = "circuit-params")] _: &(),
-        ) -> Pow5Config<Fp, WIDTH, RATE> {
+        fn configure(meta: &mut ConstraintSystem<Fp>) -> Pow5Config<Fp, WIDTH, RATE> {
             let state = (0..WIDTH).map(|_| meta.advice_column()).collect::<Vec<_>>();
             let partial_sbox = meta.advice_column();
 

--- a/halo2_gadgets/src/poseidon/pow5.rs
+++ b/halo2_gadgets/src/poseidon/pow5.rs
@@ -620,13 +620,17 @@ mod tests {
     {
         type Config = Pow5Config<Fp, WIDTH, RATE>;
         type FloorPlanner = SimpleFloorPlanner;
+        #[cfg(feature = "circuit-params")]
         type Params = ();
 
         fn without_witnesses(&self) -> Self {
             PermuteCircuit::<S, WIDTH, RATE>(PhantomData)
         }
 
-        fn configure(meta: &mut ConstraintSystem<Fp>) -> Pow5Config<Fp, WIDTH, RATE> {
+        fn configure(
+            meta: &mut ConstraintSystem<Fp>,
+            #[cfg(feature = "circuit-params")] _: &(),
+        ) -> Pow5Config<Fp, WIDTH, RATE> {
             let state = (0..WIDTH).map(|_| meta.advice_column()).collect::<Vec<_>>();
             let partial_sbox = meta.advice_column();
 
@@ -736,6 +740,7 @@ mod tests {
     {
         type Config = Pow5Config<Fp, WIDTH, RATE>;
         type FloorPlanner = SimpleFloorPlanner;
+        #[cfg(feature = "circuit-params")]
         type Params = ();
 
         fn without_witnesses(&self) -> Self {
@@ -746,7 +751,10 @@ mod tests {
             }
         }
 
-        fn configure(meta: &mut ConstraintSystem<Fp>) -> Pow5Config<Fp, WIDTH, RATE> {
+        fn configure(
+            meta: &mut ConstraintSystem<Fp>,
+            #[cfg(feature = "circuit-params")] _: &(),
+        ) -> Pow5Config<Fp, WIDTH, RATE> {
             let state = (0..WIDTH).map(|_| meta.advice_column()).collect::<Vec<_>>();
             let partial_sbox = meta.advice_column();
 

--- a/halo2_gadgets/src/sha256/table16.rs
+++ b/halo2_gadgets/src/sha256/table16.rs
@@ -468,6 +468,7 @@ mod tests {
         impl Circuit<pallas::Base> for MyCircuit {
             type Config = Table16Config;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 MyCircuit {}

--- a/halo2_gadgets/src/sha256/table16.rs
+++ b/halo2_gadgets/src/sha256/table16.rs
@@ -475,10 +475,7 @@ mod tests {
                 MyCircuit {}
             }
 
-            fn configure(
-                meta: &mut ConstraintSystem<pallas::Base>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
                 Table16Chip::configure(meta)
             }
 

--- a/halo2_gadgets/src/sha256/table16.rs
+++ b/halo2_gadgets/src/sha256/table16.rs
@@ -468,13 +468,17 @@ mod tests {
         impl Circuit<pallas::Base> for MyCircuit {
             type Config = Table16Config;
             type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 MyCircuit {}
             }
 
-            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+            fn configure(
+                meta: &mut ConstraintSystem<pallas::Base>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 Table16Chip::configure(meta)
             }
 

--- a/halo2_gadgets/src/sha256/table16/compression.rs
+++ b/halo2_gadgets/src/sha256/table16/compression.rs
@@ -954,6 +954,7 @@ mod tests {
         impl Circuit<pallas::Base> for MyCircuit {
             type Config = Table16Config;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 MyCircuit {}

--- a/halo2_gadgets/src/sha256/table16/compression.rs
+++ b/halo2_gadgets/src/sha256/table16/compression.rs
@@ -954,13 +954,17 @@ mod tests {
         impl Circuit<pallas::Base> for MyCircuit {
             type Config = Table16Config;
             type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 MyCircuit {}
             }
 
-            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+            fn configure(
+                meta: &mut ConstraintSystem<pallas::Base>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 Table16Chip::configure(meta)
             }
 

--- a/halo2_gadgets/src/sha256/table16/compression.rs
+++ b/halo2_gadgets/src/sha256/table16/compression.rs
@@ -961,10 +961,7 @@ mod tests {
                 MyCircuit {}
             }
 
-            fn configure(
-                meta: &mut ConstraintSystem<pallas::Base>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
                 Table16Chip::configure(meta)
             }
 

--- a/halo2_gadgets/src/sha256/table16/message_schedule.rs
+++ b/halo2_gadgets/src/sha256/table16/message_schedule.rs
@@ -411,13 +411,17 @@ mod tests {
         impl Circuit<pallas::Base> for MyCircuit {
             type Config = Table16Config;
             type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 MyCircuit {}
             }
 
-            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+            fn configure(
+                meta: &mut ConstraintSystem<pallas::Base>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 Table16Chip::configure(meta)
             }
 

--- a/halo2_gadgets/src/sha256/table16/message_schedule.rs
+++ b/halo2_gadgets/src/sha256/table16/message_schedule.rs
@@ -418,10 +418,7 @@ mod tests {
                 MyCircuit {}
             }
 
-            fn configure(
-                meta: &mut ConstraintSystem<pallas::Base>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
                 Table16Chip::configure(meta)
             }
 

--- a/halo2_gadgets/src/sha256/table16/message_schedule.rs
+++ b/halo2_gadgets/src/sha256/table16/message_schedule.rs
@@ -411,6 +411,7 @@ mod tests {
         impl Circuit<pallas::Base> for MyCircuit {
             type Config = Table16Config;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 MyCircuit {}

--- a/halo2_gadgets/src/sha256/table16/spread_table.rs
+++ b/halo2_gadgets/src/sha256/table16/spread_table.rs
@@ -311,10 +311,7 @@ mod tests {
                 MyCircuit {}
             }
 
-            fn configure(
-                meta: &mut ConstraintSystem<F>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
                 let input_tag = meta.advice_column();
                 let input_dense = meta.advice_column();
                 let input_spread = meta.advice_column();

--- a/halo2_gadgets/src/sha256/table16/spread_table.rs
+++ b/halo2_gadgets/src/sha256/table16/spread_table.rs
@@ -304,13 +304,17 @@ mod tests {
         impl<F: PrimeField> Circuit<F> for MyCircuit {
             type Config = SpreadTableConfig;
             type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 MyCircuit {}
             }
 
-            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            fn configure(
+                meta: &mut ConstraintSystem<F>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 let input_tag = meta.advice_column();
                 let input_dense = meta.advice_column();
                 let input_spread = meta.advice_column();

--- a/halo2_gadgets/src/sha256/table16/spread_table.rs
+++ b/halo2_gadgets/src/sha256/table16/spread_table.rs
@@ -304,6 +304,7 @@ mod tests {
         impl<F: PrimeField> Circuit<F> for MyCircuit {
             type Config = SpreadTableConfig;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 MyCircuit {}

--- a/halo2_gadgets/src/sinsemilla.rs
+++ b/halo2_gadgets/src/sinsemilla.rs
@@ -533,10 +533,7 @@ pub(crate) mod tests {
         }
 
         #[allow(non_snake_case)]
-        fn configure(
-            meta: &mut ConstraintSystem<pallas::Base>,
-            #[cfg(feature = "circuit-params")] _: &(),
-        ) -> Self::Config {
+        fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
             let advices = [
                 meta.advice_column(),
                 meta.advice_column(),

--- a/halo2_gadgets/src/sinsemilla.rs
+++ b/halo2_gadgets/src/sinsemilla.rs
@@ -525,6 +525,7 @@ pub(crate) mod tests {
             SinsemillaConfig<TestHashDomain, TestCommitDomain, TestFixedBases>,
         );
         type FloorPlanner = SimpleFloorPlanner;
+        #[cfg(feature = "circuit-params")]
         type Params = ();
 
         fn without_witnesses(&self) -> Self {
@@ -532,7 +533,10 @@ pub(crate) mod tests {
         }
 
         #[allow(non_snake_case)]
-        fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+        fn configure(
+            meta: &mut ConstraintSystem<pallas::Base>,
+            #[cfg(feature = "circuit-params")] _: &(),
+        ) -> Self::Config {
             let advices = [
                 meta.advice_column(),
                 meta.advice_column(),

--- a/halo2_gadgets/src/sinsemilla.rs
+++ b/halo2_gadgets/src/sinsemilla.rs
@@ -525,6 +525,7 @@ pub(crate) mod tests {
             SinsemillaConfig<TestHashDomain, TestCommitDomain, TestFixedBases>,
         );
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             MyCircuit {}

--- a/halo2_gadgets/src/sinsemilla/merkle.rs
+++ b/halo2_gadgets/src/sinsemilla/merkle.rs
@@ -213,6 +213,7 @@ pub mod tests {
             MerkleConfig<TestHashDomain, TestCommitDomain, TestFixedBases>,
         );
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             Self::default()

--- a/halo2_gadgets/src/sinsemilla/merkle.rs
+++ b/halo2_gadgets/src/sinsemilla/merkle.rs
@@ -220,10 +220,7 @@ pub mod tests {
             Self::default()
         }
 
-        fn configure(
-            meta: &mut ConstraintSystem<pallas::Base>,
-            #[cfg(feature = "circuit-params")] _: &(),
-        ) -> Self::Config {
+        fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
             let advices = [
                 meta.advice_column(),
                 meta.advice_column(),

--- a/halo2_gadgets/src/sinsemilla/merkle.rs
+++ b/halo2_gadgets/src/sinsemilla/merkle.rs
@@ -213,13 +213,17 @@ pub mod tests {
             MerkleConfig<TestHashDomain, TestCommitDomain, TestFixedBases>,
         );
         type FloorPlanner = SimpleFloorPlanner;
+        #[cfg(feature = "circuit-params")]
         type Params = ();
 
         fn without_witnesses(&self) -> Self {
             Self::default()
         }
 
-        fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+        fn configure(
+            meta: &mut ConstraintSystem<pallas::Base>,
+            #[cfg(feature = "circuit-params")] _: &(),
+        ) -> Self::Config {
             let advices = [
                 meta.advice_column(),
                 meta.advice_column(),

--- a/halo2_gadgets/src/utilities.rs
+++ b/halo2_gadgets/src/utilities.rs
@@ -271,6 +271,7 @@ mod tests {
         impl<const RANGE: usize> Circuit<pallas::Base> for MyCircuit<RANGE> {
             type Config = Config;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 MyCircuit(self.0)

--- a/halo2_gadgets/src/utilities.rs
+++ b/halo2_gadgets/src/utilities.rs
@@ -271,13 +271,17 @@ mod tests {
         impl<const RANGE: usize> Circuit<pallas::Base> for MyCircuit<RANGE> {
             type Config = Config;
             type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 MyCircuit(self.0)
             }
 
-            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+            fn configure(
+                meta: &mut ConstraintSystem<pallas::Base>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 let selector = meta.selector();
                 let advice = meta.advice_column();
 

--- a/halo2_gadgets/src/utilities.rs
+++ b/halo2_gadgets/src/utilities.rs
@@ -278,10 +278,7 @@ mod tests {
                 MyCircuit(self.0)
             }
 
-            fn configure(
-                meta: &mut ConstraintSystem<pallas::Base>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
                 let selector = meta.selector();
                 let advice = meta.advice_column();
 

--- a/halo2_gadgets/src/utilities/cond_swap.rs
+++ b/halo2_gadgets/src/utilities/cond_swap.rs
@@ -217,6 +217,7 @@ mod tests {
         impl<F: PrimeField> Circuit<F> for MyCircuit<F> {
             type Config = CondSwapConfig;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 Self::default()

--- a/halo2_gadgets/src/utilities/cond_swap.rs
+++ b/halo2_gadgets/src/utilities/cond_swap.rs
@@ -217,13 +217,17 @@ mod tests {
         impl<F: PrimeField> Circuit<F> for MyCircuit<F> {
             type Config = CondSwapConfig;
             type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 Self::default()
             }
 
-            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            fn configure(
+                meta: &mut ConstraintSystem<F>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 let advices = [
                     meta.advice_column(),
                     meta.advice_column(),

--- a/halo2_gadgets/src/utilities/cond_swap.rs
+++ b/halo2_gadgets/src/utilities/cond_swap.rs
@@ -224,10 +224,7 @@ mod tests {
                 Self::default()
             }
 
-            fn configure(
-                meta: &mut ConstraintSystem<F>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
                 let advices = [
                     meta.advice_column(),
                     meta.advice_column(),

--- a/halo2_gadgets/src/utilities/decompose_running_sum.rs
+++ b/halo2_gadgets/src/utilities/decompose_running_sum.rs
@@ -253,10 +253,7 @@ mod tests {
                 }
             }
 
-            fn configure(
-                meta: &mut ConstraintSystem<F>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
                 let z = meta.advice_column();
                 let q_range_check = meta.selector();
                 let constants = meta.fixed_column();

--- a/halo2_gadgets/src/utilities/decompose_running_sum.rs
+++ b/halo2_gadgets/src/utilities/decompose_running_sum.rs
@@ -243,6 +243,7 @@ mod tests {
         {
             type Config = RunningSumConfig<F, WINDOW_NUM_BITS>;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 Self {

--- a/halo2_gadgets/src/utilities/decompose_running_sum.rs
+++ b/halo2_gadgets/src/utilities/decompose_running_sum.rs
@@ -243,6 +243,7 @@ mod tests {
         {
             type Config = RunningSumConfig<F, WINDOW_NUM_BITS>;
             type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
             fn without_witnesses(&self) -> Self {
@@ -252,7 +253,10 @@ mod tests {
                 }
             }
 
-            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            fn configure(
+                meta: &mut ConstraintSystem<F>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 let z = meta.advice_column();
                 let q_range_check = meta.selector();
                 let constants = meta.fixed_column();

--- a/halo2_gadgets/src/utilities/lookup_range_check.rs
+++ b/halo2_gadgets/src/utilities/lookup_range_check.rs
@@ -417,10 +417,7 @@ mod tests {
                 *self
             }
 
-            fn configure(
-                meta: &mut ConstraintSystem<F>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
                 let running_sum = meta.advice_column();
                 let table_idx = meta.lookup_table_column();
                 let constants = meta.fixed_column();
@@ -521,10 +518,7 @@ mod tests {
                 }
             }
 
-            fn configure(
-                meta: &mut ConstraintSystem<F>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
                 let running_sum = meta.advice_column();
                 let table_idx = meta.lookup_table_column();
                 let constants = meta.fixed_column();

--- a/halo2_gadgets/src/utilities/lookup_range_check.rs
+++ b/halo2_gadgets/src/utilities/lookup_range_check.rs
@@ -410,6 +410,7 @@ mod tests {
         impl<F: PrimeFieldBits> Circuit<F> for MyCircuit<F> {
             type Config = LookupRangeCheckConfig<F, K>;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 *self
@@ -506,6 +507,7 @@ mod tests {
         impl<F: PrimeFieldBits> Circuit<F> for MyCircuit<F> {
             type Config = LookupRangeCheckConfig<F, K>;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 MyCircuit {

--- a/halo2_gadgets/src/utilities/lookup_range_check.rs
+++ b/halo2_gadgets/src/utilities/lookup_range_check.rs
@@ -410,13 +410,17 @@ mod tests {
         impl<F: PrimeFieldBits> Circuit<F> for MyCircuit<F> {
             type Config = LookupRangeCheckConfig<F, K>;
             type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 *self
             }
 
-            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            fn configure(
+                meta: &mut ConstraintSystem<F>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 let running_sum = meta.advice_column();
                 let table_idx = meta.lookup_table_column();
                 let constants = meta.fixed_column();
@@ -507,6 +511,7 @@ mod tests {
         impl<F: PrimeFieldBits> Circuit<F> for MyCircuit<F> {
             type Config = LookupRangeCheckConfig<F, K>;
             type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
             fn without_witnesses(&self) -> Self {
@@ -516,7 +521,10 @@ mod tests {
                 }
             }
 
-            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            fn configure(
+                meta: &mut ConstraintSystem<F>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 let running_sum = meta.advice_column();
                 let table_idx = meta.lookup_table_column();
                 let constants = meta.fixed_column();

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -79,6 +79,7 @@ dev-graph = ["plotters", "tabbycat"]
 gadget-traces = ["backtrace"]
 sanity-checks = []
 batch = ["rand_core/getrandom"]
+circuit-params = []
 
 [lib]
 bench = false

--- a/halo2_proofs/benches/dev_lookup.rs
+++ b/halo2_proofs/benches/dev_lookup.rs
@@ -28,6 +28,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     impl<F: PrimeField> Circuit<F> for MyCircuit<F> {
         type Config = MyConfig;
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             Self::default()

--- a/halo2_proofs/benches/dev_lookup.rs
+++ b/halo2_proofs/benches/dev_lookup.rs
@@ -28,13 +28,17 @@ fn criterion_benchmark(c: &mut Criterion) {
     impl<F: PrimeField> Circuit<F> for MyCircuit<F> {
         type Config = MyConfig;
         type FloorPlanner = SimpleFloorPlanner;
+        #[cfg(feature = "circuit-params")]
         type Params = ();
 
         fn without_witnesses(&self) -> Self {
             Self::default()
         }
 
-        fn configure(meta: &mut ConstraintSystem<F>) -> MyConfig {
+        fn configure(
+            meta: &mut ConstraintSystem<F>,
+            #[cfg(feature = "circuit-params")] _: &(),
+        ) -> MyConfig {
             let config = MyConfig {
                 selector: meta.complex_selector(),
                 table: meta.lookup_table_column(),

--- a/halo2_proofs/benches/dev_lookup.rs
+++ b/halo2_proofs/benches/dev_lookup.rs
@@ -35,10 +35,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             Self::default()
         }
 
-        fn configure(
-            meta: &mut ConstraintSystem<F>,
-            #[cfg(feature = "circuit-params")] _: &(),
-        ) -> MyConfig {
+        fn configure(meta: &mut ConstraintSystem<F>) -> MyConfig {
             let config = MyConfig {
                 selector: meta.complex_selector(),
                 table: meta.lookup_table_column(),

--- a/halo2_proofs/benches/plonk.rs
+++ b/halo2_proofs/benches/plonk.rs
@@ -183,6 +183,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     impl<F: Field> Circuit<F> for MyCircuit<F> {
         type Config = PlonkConfig;
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             Self {

--- a/halo2_proofs/benches/plonk.rs
+++ b/halo2_proofs/benches/plonk.rs
@@ -183,6 +183,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     impl<F: Field> Circuit<F> for MyCircuit<F> {
         type Config = PlonkConfig;
         type FloorPlanner = SimpleFloorPlanner;
+        #[cfg(feature = "circuit-params")]
         type Params = ();
 
         fn without_witnesses(&self) -> Self {
@@ -192,7 +193,10 @@ fn criterion_benchmark(c: &mut Criterion) {
             }
         }
 
-        fn configure(meta: &mut ConstraintSystem<F>) -> PlonkConfig {
+        fn configure(
+            meta: &mut ConstraintSystem<F>,
+            #[cfg(feature = "circuit-params")] _: &(),
+        ) -> PlonkConfig {
             meta.set_minimum_degree(5);
 
             let a = meta.advice_column();

--- a/halo2_proofs/benches/plonk.rs
+++ b/halo2_proofs/benches/plonk.rs
@@ -193,10 +193,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             }
         }
 
-        fn configure(
-            meta: &mut ConstraintSystem<F>,
-            #[cfg(feature = "circuit-params")] _: &(),
-        ) -> PlonkConfig {
+        fn configure(meta: &mut ConstraintSystem<F>) -> PlonkConfig {
             meta.set_minimum_degree(5);
 
             let a = meta.advice_column();

--- a/halo2_proofs/examples/circuit-layout.rs
+++ b/halo2_proofs/examples/circuit-layout.rs
@@ -161,6 +161,7 @@ impl<FF: Field> StandardCs<FF> for StandardPlonk<FF> {
 impl<F: Field> Circuit<F> for MyCircuit<F> {
     type Config = PlonkConfig;
     type FloorPlanner = SimpleFloorPlanner;
+    #[cfg(feature = "circuit-params")]
     type Params = ();
 
     fn without_witnesses(&self) -> Self {
@@ -171,7 +172,10 @@ impl<F: Field> Circuit<F> for MyCircuit<F> {
     }
 
     #[allow(clippy::many_single_char_names)]
-    fn configure(meta: &mut ConstraintSystem<F>) -> PlonkConfig {
+    fn configure(
+        meta: &mut ConstraintSystem<F>,
+        #[cfg(feature = "circuit-params")] _: &(),
+    ) -> PlonkConfig {
         let e = meta.advice_column();
         let a = meta.advice_column();
         let b = meta.advice_column();

--- a/halo2_proofs/examples/circuit-layout.rs
+++ b/halo2_proofs/examples/circuit-layout.rs
@@ -172,10 +172,7 @@ impl<F: Field> Circuit<F> for MyCircuit<F> {
     }
 
     #[allow(clippy::many_single_char_names)]
-    fn configure(
-        meta: &mut ConstraintSystem<F>,
-        #[cfg(feature = "circuit-params")] _: &(),
-    ) -> PlonkConfig {
+    fn configure(meta: &mut ConstraintSystem<F>) -> PlonkConfig {
         let e = meta.advice_column();
         let a = meta.advice_column();
         let b = meta.advice_column();

--- a/halo2_proofs/examples/circuit-layout.rs
+++ b/halo2_proofs/examples/circuit-layout.rs
@@ -161,6 +161,7 @@ impl<FF: Field> StandardCs<FF> for StandardPlonk<FF> {
 impl<F: Field> Circuit<F> for MyCircuit<F> {
     type Config = PlonkConfig;
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self {

--- a/halo2_proofs/examples/serialization.rs
+++ b/halo2_proofs/examples/serialization.rs
@@ -86,6 +86,7 @@ struct StandardPlonk(Fr);
 impl Circuit<Fr> for StandardPlonk {
     type Config = StandardPlonkConfig;
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self::default()
@@ -140,8 +141,12 @@ fn main() {
 
     let f = File::open("serialization-test.pk").unwrap();
     let mut reader = BufReader::new(f);
-    let pk = ProvingKey::<G1Affine>::read::<_, StandardPlonk>(&mut reader, SerdeFormat::RawBytes)
-        .unwrap();
+    let pk = ProvingKey::<G1Affine>::read::<_, StandardPlonk>(
+        &mut reader,
+        SerdeFormat::RawBytes,
+        &circuit.params(),
+    )
+    .unwrap();
 
     std::fs::remove_file("serialization-test.pk").unwrap();
 

--- a/halo2_proofs/examples/serialization.rs
+++ b/halo2_proofs/examples/serialization.rs
@@ -86,13 +86,17 @@ struct StandardPlonk(Fr);
 impl Circuit<Fr> for StandardPlonk {
     type Config = StandardPlonkConfig;
     type FloorPlanner = SimpleFloorPlanner;
+    #[cfg(feature = "circuit-params")]
     type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self::default()
     }
 
-    fn configure(meta: &mut ConstraintSystem<Fr>) -> Self::Config {
+    fn configure(
+        meta: &mut ConstraintSystem<Fr>,
+        #[cfg(feature = "circuit-params")] _: &(),
+    ) -> Self::Config {
         StandardPlonkConfig::configure(meta)
     }
 
@@ -144,6 +148,7 @@ fn main() {
     let pk = ProvingKey::<G1Affine>::read::<_, StandardPlonk>(
         &mut reader,
         SerdeFormat::RawBytes,
+        #[cfg(feature = "circuit-params")]
         &circuit.params(),
     )
     .unwrap();

--- a/halo2_proofs/examples/serialization.rs
+++ b/halo2_proofs/examples/serialization.rs
@@ -93,10 +93,7 @@ impl Circuit<Fr> for StandardPlonk {
         Self::default()
     }
 
-    fn configure(
-        meta: &mut ConstraintSystem<Fr>,
-        #[cfg(feature = "circuit-params")] _: &(),
-    ) -> Self::Config {
+    fn configure(meta: &mut ConstraintSystem<Fr>) -> Self::Config {
         StandardPlonkConfig::configure(meta)
     }
 
@@ -145,11 +142,12 @@ fn main() {
 
     let f = File::open("serialization-test.pk").unwrap();
     let mut reader = BufReader::new(f);
+    #[allow(clippy::unit_arg)]
     let pk = ProvingKey::<G1Affine>::read::<_, StandardPlonk>(
         &mut reader,
         SerdeFormat::RawBytes,
         #[cfg(feature = "circuit-params")]
-        &circuit.params(),
+        circuit.params(),
     )
     .unwrap();
 

--- a/halo2_proofs/examples/shuffle.rs
+++ b/halo2_proofs/examples/shuffle.rs
@@ -136,6 +136,7 @@ impl<F: Field, const W: usize, const H: usize> MyCircuit<F, W, H> {
 impl<F: Field, const W: usize, const H: usize> Circuit<F> for MyCircuit<F, W, H> {
     type Config = MyConfig<W>;
     type FloorPlanner = V1;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self::default()

--- a/halo2_proofs/examples/shuffle.rs
+++ b/halo2_proofs/examples/shuffle.rs
@@ -143,10 +143,7 @@ impl<F: Field, const W: usize, const H: usize> Circuit<F> for MyCircuit<F, W, H>
         Self::default()
     }
 
-    fn configure(
-        meta: &mut ConstraintSystem<F>,
-        #[cfg(feature = "circuit-params")] _: &(),
-    ) -> Self::Config {
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
         MyConfig::configure(meta)
     }
 

--- a/halo2_proofs/examples/shuffle.rs
+++ b/halo2_proofs/examples/shuffle.rs
@@ -136,13 +136,17 @@ impl<F: Field, const W: usize, const H: usize> MyCircuit<F, W, H> {
 impl<F: Field, const W: usize, const H: usize> Circuit<F> for MyCircuit<F, W, H> {
     type Config = MyConfig<W>;
     type FloorPlanner = V1;
+    #[cfg(feature = "circuit-params")]
     type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self::default()
     }
 
-    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+    fn configure(
+        meta: &mut ConstraintSystem<F>,
+        #[cfg(feature = "circuit-params")] _: &(),
+    ) -> Self::Config {
         MyConfig::configure(meta)
     }
 

--- a/halo2_proofs/examples/simple-example.rs
+++ b/halo2_proofs/examples/simple-example.rs
@@ -255,10 +255,7 @@ impl<F: Field> Circuit<F> for MyCircuit<F> {
         Self::default()
     }
 
-    fn configure(
-        meta: &mut ConstraintSystem<F>,
-        #[cfg(feature = "circuit-params")] _: &(),
-    ) -> Self::Config {
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
         // We create the two advice columns that FieldChip uses for I/O.
         let advice = [meta.advice_column(), meta.advice_column()];
 

--- a/halo2_proofs/examples/simple-example.rs
+++ b/halo2_proofs/examples/simple-example.rs
@@ -248,13 +248,17 @@ impl<F: Field> Circuit<F> for MyCircuit<F> {
     // Since we are using a single chip for everything, we can just reuse its config.
     type Config = FieldConfig;
     type FloorPlanner = SimpleFloorPlanner;
+    #[cfg(feature = "circuit-params")]
     type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self::default()
     }
 
-    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+    fn configure(
+        meta: &mut ConstraintSystem<F>,
+        #[cfg(feature = "circuit-params")] _: &(),
+    ) -> Self::Config {
         // We create the two advice columns that FieldChip uses for I/O.
         let advice = [meta.advice_column(), meta.advice_column()];
 

--- a/halo2_proofs/examples/simple-example.rs
+++ b/halo2_proofs/examples/simple-example.rs
@@ -248,6 +248,7 @@ impl<F: Field> Circuit<F> for MyCircuit<F> {
     // Since we are using a single chip for everything, we can just reuse its config.
     type Config = FieldConfig;
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self::default()

--- a/halo2_proofs/examples/two-chip.rs
+++ b/halo2_proofs/examples/two-chip.rs
@@ -458,6 +458,7 @@ impl<F: Field> Circuit<F> for MyCircuit<F> {
     // Since we are using a single chip for everything, we can just reuse its config.
     type Config = FieldConfig;
     type FloorPlanner = SimpleFloorPlanner;
+    type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self::default()

--- a/halo2_proofs/examples/two-chip.rs
+++ b/halo2_proofs/examples/two-chip.rs
@@ -465,10 +465,7 @@ impl<F: Field> Circuit<F> for MyCircuit<F> {
         Self::default()
     }
 
-    fn configure(
-        meta: &mut ConstraintSystem<F>,
-        #[cfg(feature = "circuit-params")] _: &(),
-    ) -> Self::Config {
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
         // We create the two advice columns that FieldChip uses for I/O.
         let advice = [meta.advice_column(), meta.advice_column()];
 

--- a/halo2_proofs/examples/two-chip.rs
+++ b/halo2_proofs/examples/two-chip.rs
@@ -458,13 +458,17 @@ impl<F: Field> Circuit<F> for MyCircuit<F> {
     // Since we are using a single chip for everything, we can just reuse its config.
     type Config = FieldConfig;
     type FloorPlanner = SimpleFloorPlanner;
+    #[cfg(feature = "circuit-params")]
     type Params = ();
 
     fn without_witnesses(&self) -> Self {
         Self::default()
     }
 
-    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+    fn configure(
+        meta: &mut ConstraintSystem<F>,
+        #[cfg(feature = "circuit-params")] _: &(),
+    ) -> Self::Config {
         // We create the two advice columns that FieldChip uses for I/O.
         let advice = [meta.advice_column(), meta.advice_column()];
 

--- a/halo2_proofs/src/circuit/floor_planner/single_pass.rs
+++ b/halo2_proofs/src/circuit/floor_planner/single_pass.rs
@@ -479,13 +479,17 @@ mod tests {
         impl Circuit<vesta::Scalar> for MyCircuit {
             type Config = Column<Advice>;
             type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 MyCircuit {}
             }
 
-            fn configure(meta: &mut crate::plonk::ConstraintSystem<vesta::Scalar>) -> Self::Config {
+            fn configure(
+                meta: &mut crate::plonk::ConstraintSystem<vesta::Scalar>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 meta.advice_column()
             }
 

--- a/halo2_proofs/src/circuit/floor_planner/single_pass.rs
+++ b/halo2_proofs/src/circuit/floor_planner/single_pass.rs
@@ -486,10 +486,7 @@ mod tests {
                 MyCircuit {}
             }
 
-            fn configure(
-                meta: &mut crate::plonk::ConstraintSystem<vesta::Scalar>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut crate::plonk::ConstraintSystem<vesta::Scalar>) -> Self::Config {
                 meta.advice_column()
             }
 

--- a/halo2_proofs/src/circuit/floor_planner/single_pass.rs
+++ b/halo2_proofs/src/circuit/floor_planner/single_pass.rs
@@ -479,6 +479,7 @@ mod tests {
         impl Circuit<vesta::Scalar> for MyCircuit {
             type Config = Column<Advice>;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 MyCircuit {}

--- a/halo2_proofs/src/circuit/floor_planner/v1.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1.rs
@@ -524,10 +524,7 @@ mod tests {
                 MyCircuit {}
             }
 
-            fn configure(
-                meta: &mut crate::plonk::ConstraintSystem<vesta::Scalar>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut crate::plonk::ConstraintSystem<vesta::Scalar>) -> Self::Config {
                 meta.advice_column()
             }
 

--- a/halo2_proofs/src/circuit/floor_planner/v1.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1.rs
@@ -517,13 +517,17 @@ mod tests {
         impl Circuit<vesta::Scalar> for MyCircuit {
             type Config = Column<Advice>;
             type FloorPlanner = super::V1;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 MyCircuit {}
             }
 
-            fn configure(meta: &mut crate::plonk::ConstraintSystem<vesta::Scalar>) -> Self::Config {
+            fn configure(
+                meta: &mut crate::plonk::ConstraintSystem<vesta::Scalar>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 meta.advice_column()
             }
 

--- a/halo2_proofs/src/circuit/floor_planner/v1.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1.rs
@@ -517,6 +517,7 @@ mod tests {
         impl Circuit<vesta::Scalar> for MyCircuit {
             type Config = Column<Advice>;
             type FloorPlanner = super::V1;
+            type Params = ();
 
             fn without_witnesses(&self) -> Self {
                 MyCircuit {}

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -208,6 +208,7 @@ impl<F: Field> Mul<F> for Value<F> {
 /// impl<F: PrimeField> Circuit<F> for MyCircuit {
 ///     type Config = MyConfig;
 ///     type FloorPlanner = SimpleFloorPlanner;
+///     #[cfg(feature = "circuit-params")]
 ///     type Params = ();
 ///
 ///     fn without_witnesses(&self) -> Self {
@@ -602,7 +603,11 @@ impl<F: FromUniformBytes<64> + Ord> MockProver<F> {
         let n = 1 << k;
 
         let mut cs = ConstraintSystem::default();
-        let config = ConcreteCircuit::configure_with_params(&mut cs, &circuit.params());
+        let config = ConcreteCircuit::configure(
+            &mut cs,
+            #[cfg(feature = "circuit-params")]
+            &circuit.params(),
+        );
         let cs = cs;
 
         assert!(
@@ -1537,9 +1542,13 @@ mod tests {
         impl Circuit<Fp> for FaultyCircuit {
             type Config = FaultyCircuitConfig;
             type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
-            fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+            fn configure(
+                meta: &mut ConstraintSystem<Fp>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 let a = meta.advice_column();
                 let b = meta.advice_column();
                 let q = meta.selector();
@@ -1624,9 +1633,13 @@ mod tests {
         impl Circuit<Fp> for FaultyCircuit {
             type Config = FaultyCircuitConfig;
             type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
-            fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+            fn configure(
+                meta: &mut ConstraintSystem<Fp>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 let a = meta.advice_column();
                 let q = meta.complex_selector();
                 let table = meta.instance_column();
@@ -1794,9 +1807,13 @@ mod tests {
         impl Circuit<Fp> for FaultyCircuit {
             type Config = FaultyCircuitConfig;
             type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
-            fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+            fn configure(
+                meta: &mut ConstraintSystem<Fp>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 let a = meta.advice_column();
                 let q = meta.complex_selector();
                 let table = meta.lookup_table_column();
@@ -1929,9 +1946,13 @@ mod tests {
         impl Circuit<Fp> for FaultyCircuit {
             type Config = FaultyCircuitConfig;
             type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
             type Params = ();
 
-            fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+            fn configure(
+                meta: &mut ConstraintSystem<Fp>,
+                #[cfg(feature = "circuit-params")] _: &(),
+            ) -> Self::Config {
                 let a = meta.advice_column();
                 let b = meta.advice_column();
                 let c = meta.advice_column();

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -208,6 +208,7 @@ impl<F: Field> Mul<F> for Value<F> {
 /// impl<F: PrimeField> Circuit<F> for MyCircuit {
 ///     type Config = MyConfig;
 ///     type FloorPlanner = SimpleFloorPlanner;
+///     type Params = ();
 ///
 ///     fn without_witnesses(&self) -> Self {
 ///         Self::default()
@@ -601,7 +602,7 @@ impl<F: FromUniformBytes<64> + Ord> MockProver<F> {
         let n = 1 << k;
 
         let mut cs = ConstraintSystem::default();
-        let config = ConcreteCircuit::configure(&mut cs);
+        let config = ConcreteCircuit::configure_with_params(&mut cs, &circuit.params());
         let cs = cs;
 
         assert!(
@@ -1536,6 +1537,7 @@ mod tests {
         impl Circuit<Fp> for FaultyCircuit {
             type Config = FaultyCircuitConfig;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
                 let a = meta.advice_column();
@@ -1622,6 +1624,7 @@ mod tests {
         impl Circuit<Fp> for FaultyCircuit {
             type Config = FaultyCircuitConfig;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
                 let a = meta.advice_column();
@@ -1791,6 +1794,7 @@ mod tests {
         impl Circuit<Fp> for FaultyCircuit {
             type Config = FaultyCircuitConfig;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
                 let a = meta.advice_column();
@@ -1925,6 +1929,7 @@ mod tests {
         impl Circuit<Fp> for FaultyCircuit {
             type Config = FaultyCircuitConfig;
             type FloorPlanner = SimpleFloorPlanner;
+            type Params = ();
 
             fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
                 let a = meta.advice_column();

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -603,11 +603,10 @@ impl<F: FromUniformBytes<64> + Ord> MockProver<F> {
         let n = 1 << k;
 
         let mut cs = ConstraintSystem::default();
-        let config = ConcreteCircuit::configure(
-            &mut cs,
-            #[cfg(feature = "circuit-params")]
-            &circuit.params(),
-        );
+        #[cfg(feature = "circuit-params")]
+        let config = ConcreteCircuit::configure_with_params(&mut cs, circuit.params());
+        #[cfg(not(feature = "circuit-params"))]
+        let config = ConcreteCircuit::configure(&mut cs);
         let cs = cs;
 
         assert!(
@@ -1545,10 +1544,7 @@ mod tests {
             #[cfg(feature = "circuit-params")]
             type Params = ();
 
-            fn configure(
-                meta: &mut ConstraintSystem<Fp>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
                 let a = meta.advice_column();
                 let b = meta.advice_column();
                 let q = meta.selector();
@@ -1636,10 +1632,7 @@ mod tests {
             #[cfg(feature = "circuit-params")]
             type Params = ();
 
-            fn configure(
-                meta: &mut ConstraintSystem<Fp>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
                 let a = meta.advice_column();
                 let q = meta.complex_selector();
                 let table = meta.instance_column();
@@ -1810,10 +1803,7 @@ mod tests {
             #[cfg(feature = "circuit-params")]
             type Params = ();
 
-            fn configure(
-                meta: &mut ConstraintSystem<Fp>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
                 let a = meta.advice_column();
                 let q = meta.complex_selector();
                 let table = meta.lookup_table_column();
@@ -1949,10 +1939,7 @@ mod tests {
             #[cfg(feature = "circuit-params")]
             type Params = ();
 
-            fn configure(
-                meta: &mut ConstraintSystem<Fp>,
-                #[cfg(feature = "circuit-params")] _: &(),
-            ) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
                 let a = meta.advice_column();
                 let b = meta.advice_column();
                 let c = meta.advice_column();

--- a/halo2_proofs/src/dev/cost.rs
+++ b/halo2_proofs/src/dev/cost.rs
@@ -150,7 +150,11 @@ impl<G: PrimeGroup, ConcreteCircuit: Circuit<G::Scalar>> CircuitCost<G, Concrete
     pub fn measure(k: usize, circuit: &ConcreteCircuit) -> Self {
         // Collect the layout details.
         let mut cs = ConstraintSystem::default();
-        let config = ConcreteCircuit::configure_with_params(&mut cs, &circuit.params());
+        let config = ConcreteCircuit::configure(
+            &mut cs,
+            #[cfg(feature = "circuit-params")]
+            &circuit.params(),
+        );
         let mut assembly = Assembly {
             selectors: vec![vec![false; 1 << k]; cs.num_selectors],
         };

--- a/halo2_proofs/src/dev/cost.rs
+++ b/halo2_proofs/src/dev/cost.rs
@@ -150,7 +150,7 @@ impl<G: PrimeGroup, ConcreteCircuit: Circuit<G::Scalar>> CircuitCost<G, Concrete
     pub fn measure(k: usize, circuit: &ConcreteCircuit) -> Self {
         // Collect the layout details.
         let mut cs = ConstraintSystem::default();
-        let config = ConcreteCircuit::configure(&mut cs);
+        let config = ConcreteCircuit::configure_with_params(&mut cs, &circuit.params());
         let mut assembly = Assembly {
             selectors: vec![vec![false; 1 << k]; cs.num_selectors],
         };

--- a/halo2_proofs/src/dev/cost.rs
+++ b/halo2_proofs/src/dev/cost.rs
@@ -150,11 +150,10 @@ impl<G: PrimeGroup, ConcreteCircuit: Circuit<G::Scalar>> CircuitCost<G, Concrete
     pub fn measure(k: usize, circuit: &ConcreteCircuit) -> Self {
         // Collect the layout details.
         let mut cs = ConstraintSystem::default();
-        let config = ConcreteCircuit::configure(
-            &mut cs,
-            #[cfg(feature = "circuit-params")]
-            &circuit.params(),
-        );
+        #[cfg(feature = "circuit-params")]
+        let config = ConcreteCircuit::configure_with_params(&mut cs, circuit.params());
+        #[cfg(not(feature = "circuit-params"))]
+        let config = ConcreteCircuit::configure(&mut cs);
         let mut assembly = Assembly {
             selectors: vec![vec![false; 1 << k]; cs.num_selectors],
         };

--- a/halo2_proofs/src/dev/gates.rs
+++ b/halo2_proofs/src/dev/gates.rs
@@ -106,15 +106,14 @@ pub struct CircuitGates {
 impl CircuitGates {
     /// Collects the gates from within the circuit.
     pub fn collect<F: PrimeField, C: Circuit<F>>(
-        #[cfg(feature = "circuit-params")] params: &C::Params,
+        #[cfg(feature = "circuit-params")] params: C::Params,
     ) -> Self {
         // Collect the graph details.
         let mut cs = ConstraintSystem::default();
-        let _ = C::configure(
-            &mut cs,
-            #[cfg(feature = "circuit-params")]
-            params,
-        );
+        #[cfg(feature = "circuit-params")]
+        let _ = C::configure_with_params(&mut cs, params);
+        #[cfg(not(feature = "circuit-params"))]
+        let _ = C::configure(&mut cs);
 
         let gates = cs
             .gates

--- a/halo2_proofs/src/dev/gates.rs
+++ b/halo2_proofs/src/dev/gates.rs
@@ -49,6 +49,7 @@ struct Gate {
 /// impl<F: Field> Circuit<F> for MyCircuit {
 ///     type Config = MyConfig;
 ///     type FloorPlanner = SimpleFloorPlanner;
+///     type Params = ();
 ///
 ///     fn without_witnesses(&self) -> Self {
 ///         Self::default()
@@ -79,7 +80,7 @@ struct Gate {
 ///     }
 /// }
 ///
-/// let gates = CircuitGates::collect::<pallas::Base, MyCircuit>();
+/// let gates = CircuitGates::collect::<pallas::Base, MyCircuit>(&());
 /// assert_eq!(
 ///     format!("{}", gates),
 ///     r#####"R1CS constraint:
@@ -103,10 +104,10 @@ pub struct CircuitGates {
 
 impl CircuitGates {
     /// Collects the gates from within the circuit.
-    pub fn collect<F: PrimeField, C: Circuit<F>>() -> Self {
+    pub fn collect<F: PrimeField, C: Circuit<F>>(params: &C::Params) -> Self {
         // Collect the graph details.
         let mut cs = ConstraintSystem::default();
-        let _ = C::configure(&mut cs);
+        let _ = C::configure_with_params(&mut cs, params);
 
         let gates = cs
             .gates

--- a/halo2_proofs/src/dev/gates.rs
+++ b/halo2_proofs/src/dev/gates.rs
@@ -81,7 +81,10 @@ struct Gate {
 ///     }
 /// }
 ///
-/// let gates = CircuitGates::collect::<pallas::Base, MyCircuit>(&());
+/// #[cfg(feature = "circuit-params")]
+/// let gates = CircuitGates::collect::<pallas::Base, MyCircuit>(());
+/// #[cfg(not(feature = "circuit-params"))]
+/// let gates = CircuitGates::collect::<pallas::Base, MyCircuit>();
 /// assert_eq!(
 ///     format!("{}", gates),
 ///     r#####"R1CS constraint:

--- a/halo2_proofs/src/dev/gates.rs
+++ b/halo2_proofs/src/dev/gates.rs
@@ -49,6 +49,7 @@ struct Gate {
 /// impl<F: Field> Circuit<F> for MyCircuit {
 ///     type Config = MyConfig;
 ///     type FloorPlanner = SimpleFloorPlanner;
+///     #[cfg(feature = "circuit-params")]
 ///     type Params = ();
 ///
 ///     fn without_witnesses(&self) -> Self {
@@ -104,10 +105,16 @@ pub struct CircuitGates {
 
 impl CircuitGates {
     /// Collects the gates from within the circuit.
-    pub fn collect<F: PrimeField, C: Circuit<F>>(params: &C::Params) -> Self {
+    pub fn collect<F: PrimeField, C: Circuit<F>>(
+        #[cfg(feature = "circuit-params")] params: &C::Params,
+    ) -> Self {
         // Collect the graph details.
         let mut cs = ConstraintSystem::default();
-        let _ = C::configure_with_params(&mut cs, params);
+        let _ = C::configure(
+            &mut cs,
+            #[cfg(feature = "circuit-params")]
+            params,
+        );
 
         let gates = cs
             .gates

--- a/halo2_proofs/src/dev/graph.rs
+++ b/halo2_proofs/src/dev/graph.rs
@@ -22,11 +22,10 @@ pub fn circuit_dot_graph<F: Field, ConcreteCircuit: Circuit<F>>(
 ) -> String {
     // Collect the graph details.
     let mut cs = ConstraintSystem::default();
-    let config = ConcreteCircuit::configure(
-        &mut cs,
-        #[cfg(feature = "circuit-params")]
-        &circuit.params(),
-    );
+    #[cfg(feature = "circuit-params")]
+    let config = ConcreteCircuit::configure_with_params(&mut cs, circuit.params());
+    #[cfg(not(feature = "circuit-params"))]
+    let config = ConcreteCircuit::configure(&mut cs);
     let mut graph = Graph::default();
     ConcreteCircuit::FloorPlanner::synthesize(&mut graph, circuit, config, cs.constants).unwrap();
 

--- a/halo2_proofs/src/dev/graph.rs
+++ b/halo2_proofs/src/dev/graph.rs
@@ -22,7 +22,11 @@ pub fn circuit_dot_graph<F: Field, ConcreteCircuit: Circuit<F>>(
 ) -> String {
     // Collect the graph details.
     let mut cs = ConstraintSystem::default();
-    let config = ConcreteCircuit::configure(&mut cs);
+    let config = ConcreteCircuit::configure(
+        &mut cs,
+        #[cfg(feature = "circuit-params")]
+        &circuit.params(),
+    );
     let mut graph = Graph::default();
     ConcreteCircuit::FloorPlanner::synthesize(&mut graph, circuit, config, cs.constants).unwrap();
 

--- a/halo2_proofs/src/dev/graph/layout.rs
+++ b/halo2_proofs/src/dev/graph/layout.rs
@@ -97,11 +97,10 @@ impl CircuitLayout {
         let n = 1 << k;
         // Collect the layout details.
         let mut cs = ConstraintSystem::default();
-        let config = ConcreteCircuit::configure(
-            &mut cs,
-            #[cfg(feature = "circuit-params")]
-            &circuit.params(),
-        );
+        #[cfg(feature = "circuit-params")]
+        let config = ConcreteCircuit::configure_with_params(&mut cs, circuit.params());
+        #[cfg(not(feature = "circuit-params"))]
+        let config = ConcreteCircuit::configure(&mut cs);
         let mut layout = Layout::new(k, n, cs.num_selectors);
         ConcreteCircuit::FloorPlanner::synthesize(
             &mut layout,

--- a/halo2_proofs/src/dev/graph/layout.rs
+++ b/halo2_proofs/src/dev/graph/layout.rs
@@ -97,7 +97,11 @@ impl CircuitLayout {
         let n = 1 << k;
         // Collect the layout details.
         let mut cs = ConstraintSystem::default();
-        let config = ConcreteCircuit::configure(&mut cs);
+        let config = ConcreteCircuit::configure(
+            &mut cs,
+            #[cfg(feature = "circuit-params")]
+            &circuit.params(),
+        );
         let mut layout = Layout::new(k, n, cs.num_selectors);
         ConcreteCircuit::FloorPlanner::synthesize(
             &mut layout,

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -101,11 +101,12 @@ where
     pub fn read<R: io::Read, ConcreteCircuit: Circuit<C::Scalar>>(
         reader: &mut R,
         format: SerdeFormat,
+        params: &ConcreteCircuit::Params,
     ) -> io::Result<Self> {
         let mut k = [0u8; 4];
         reader.read_exact(&mut k)?;
         let k = u32::from_be_bytes(k);
-        let (domain, cs, _) = keygen::create_domain::<C, ConcreteCircuit>(k);
+        let (domain, cs, _) = keygen::create_domain::<C, ConcreteCircuit>(k, params);
         let mut num_fixed_columns = [0u8; 4];
         reader.read_exact(&mut num_fixed_columns)?;
         let num_fixed_columns = u32::from_be_bytes(num_fixed_columns);
@@ -150,8 +151,9 @@ where
     pub fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(
         mut bytes: &[u8],
         format: SerdeFormat,
+        params: &ConcreteCircuit::Params,
     ) -> io::Result<Self> {
-        Self::read::<_, ConcreteCircuit>(&mut bytes, format)
+        Self::read::<_, ConcreteCircuit>(&mut bytes, format, params)
     }
 }
 
@@ -335,8 +337,9 @@ where
     pub fn read<R: io::Read, ConcreteCircuit: Circuit<C::Scalar>>(
         reader: &mut R,
         format: SerdeFormat,
+        params: &ConcreteCircuit::Params,
     ) -> io::Result<Self> {
-        let vk = VerifyingKey::<C>::read::<R, ConcreteCircuit>(reader, format)?;
+        let vk = VerifyingKey::<C>::read::<R, ConcreteCircuit>(reader, format, params)?;
         let l0 = Polynomial::read(reader, format)?;
         let l_last = Polynomial::read(reader, format)?;
         let l_active_row = Polynomial::read(reader, format)?;
@@ -369,8 +372,9 @@ where
     pub fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(
         mut bytes: &[u8],
         format: SerdeFormat,
+        params: &ConcreteCircuit::Params,
     ) -> io::Result<Self> {
-        Self::read::<_, ConcreteCircuit>(&mut bytes, format)
+        Self::read::<_, ConcreteCircuit>(&mut bytes, format, params)
     }
 }
 

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -101,7 +101,7 @@ where
     pub fn read<R: io::Read, ConcreteCircuit: Circuit<C::Scalar>>(
         reader: &mut R,
         format: SerdeFormat,
-        #[cfg(feature = "circuit-params")] params: &ConcreteCircuit::Params,
+        #[cfg(feature = "circuit-params")] params: ConcreteCircuit::Params,
     ) -> io::Result<Self> {
         let mut k = [0u8; 4];
         reader.read_exact(&mut k)?;
@@ -155,7 +155,7 @@ where
     pub fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(
         mut bytes: &[u8],
         format: SerdeFormat,
-        #[cfg(feature = "circuit-params")] params: &ConcreteCircuit::Params,
+        #[cfg(feature = "circuit-params")] params: ConcreteCircuit::Params,
     ) -> io::Result<Self> {
         Self::read::<_, ConcreteCircuit>(
             &mut bytes,
@@ -346,7 +346,7 @@ where
     pub fn read<R: io::Read, ConcreteCircuit: Circuit<C::Scalar>>(
         reader: &mut R,
         format: SerdeFormat,
-        #[cfg(feature = "circuit-params")] params: &ConcreteCircuit::Params,
+        #[cfg(feature = "circuit-params")] params: ConcreteCircuit::Params,
     ) -> io::Result<Self> {
         let vk = VerifyingKey::<C>::read::<R, ConcreteCircuit>(
             reader,
@@ -386,7 +386,7 @@ where
     pub fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(
         mut bytes: &[u8],
         format: SerdeFormat,
-        #[cfg(feature = "circuit-params")] params: &ConcreteCircuit::Params,
+        #[cfg(feature = "circuit-params")] params: ConcreteCircuit::Params,
     ) -> io::Result<Self> {
         Self::read::<_, ConcreteCircuit>(
             &mut bytes,

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -101,12 +101,16 @@ where
     pub fn read<R: io::Read, ConcreteCircuit: Circuit<C::Scalar>>(
         reader: &mut R,
         format: SerdeFormat,
-        params: &ConcreteCircuit::Params,
+        #[cfg(feature = "circuit-params")] params: &ConcreteCircuit::Params,
     ) -> io::Result<Self> {
         let mut k = [0u8; 4];
         reader.read_exact(&mut k)?;
         let k = u32::from_be_bytes(k);
-        let (domain, cs, _) = keygen::create_domain::<C, ConcreteCircuit>(k, params);
+        let (domain, cs, _) = keygen::create_domain::<C, ConcreteCircuit>(
+            k,
+            #[cfg(feature = "circuit-params")]
+            params,
+        );
         let mut num_fixed_columns = [0u8; 4];
         reader.read_exact(&mut num_fixed_columns)?;
         let num_fixed_columns = u32::from_be_bytes(num_fixed_columns);
@@ -151,9 +155,14 @@ where
     pub fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(
         mut bytes: &[u8],
         format: SerdeFormat,
-        params: &ConcreteCircuit::Params,
+        #[cfg(feature = "circuit-params")] params: &ConcreteCircuit::Params,
     ) -> io::Result<Self> {
-        Self::read::<_, ConcreteCircuit>(&mut bytes, format, params)
+        Self::read::<_, ConcreteCircuit>(
+            &mut bytes,
+            format,
+            #[cfg(feature = "circuit-params")]
+            params,
+        )
     }
 }
 
@@ -337,9 +346,14 @@ where
     pub fn read<R: io::Read, ConcreteCircuit: Circuit<C::Scalar>>(
         reader: &mut R,
         format: SerdeFormat,
-        params: &ConcreteCircuit::Params,
+        #[cfg(feature = "circuit-params")] params: &ConcreteCircuit::Params,
     ) -> io::Result<Self> {
-        let vk = VerifyingKey::<C>::read::<R, ConcreteCircuit>(reader, format, params)?;
+        let vk = VerifyingKey::<C>::read::<R, ConcreteCircuit>(
+            reader,
+            format,
+            #[cfg(feature = "circuit-params")]
+            params,
+        )?;
         let l0 = Polynomial::read(reader, format)?;
         let l_last = Polynomial::read(reader, format)?;
         let l_active_row = Polynomial::read(reader, format)?;
@@ -372,9 +386,14 @@ where
     pub fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(
         mut bytes: &[u8],
         format: SerdeFormat,
-        params: &ConcreteCircuit::Params,
+        #[cfg(feature = "circuit-params")] params: &ConcreteCircuit::Params,
     ) -> io::Result<Self> {
-        Self::read::<_, ConcreteCircuit>(&mut bytes, format, params)
+        Self::read::<_, ConcreteCircuit>(
+            &mut bytes,
+            format,
+            #[cfg(feature = "circuit-params")]
+            params,
+        )
     }
 }
 

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -664,13 +664,29 @@ pub trait Circuit<F: Field> {
     /// The floor planner used for this circuit. This is an associated type of the
     /// `Circuit` trait because its behaviour is circuit-critical.
     type FloorPlanner: FloorPlanner;
+    /// Optional circuit configuration parameters.
+    type Params: Default;
 
     /// Returns a copy of this circuit with no witness values (i.e. all witnesses set to
     /// `None`). For most circuits, this will be equal to `Self::default()`.
     fn without_witnesses(&self) -> Self;
 
+    /// Returns a reference to the parameters that should be used to configure the circuit.
+    fn params(&self) -> Self::Params {
+        Self::Params::default()
+    }
+
     /// The circuit is given an opportunity to describe the exact gate
     /// arrangement, column arrangement, etc.
+    fn configure_with_params(
+        meta: &mut ConstraintSystem<F>,
+        _params: &Self::Params,
+    ) -> Self::Config {
+        Self::configure(meta)
+    }
+
+    /// Configuration function without parameters.  This method is usually only called via the default
+    /// `configure_with_params` implementation for backwards-compatibility purposes.
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config;
 
     /// Given the provided `cs`, synthesize the circuit. The concrete type of

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -664,7 +664,8 @@ pub trait Circuit<F: Field> {
     /// The floor planner used for this circuit. This is an associated type of the
     /// `Circuit` trait because its behaviour is circuit-critical.
     type FloorPlanner: FloorPlanner;
-    /// Optional circuit configuration parameters.
+    /// Optional circuit configuration parameters. Requires the `circuit-params` feature.
+    #[cfg(feature = "circuit-params")]
     type Params: Default;
 
     /// Returns a copy of this circuit with no witness values (i.e. all witnesses set to
@@ -672,21 +673,20 @@ pub trait Circuit<F: Field> {
     fn without_witnesses(&self) -> Self;
 
     /// Returns a reference to the parameters that should be used to configure the circuit.
+    /// Requires the `circuit-params` feature.
+    #[cfg(feature = "circuit-params")]
     fn params(&self) -> Self::Params {
         Self::Params::default()
     }
 
     /// The circuit is given an opportunity to describe the exact gate
-    /// arrangement, column arrangement, etc.
-    fn configure_with_params(
-        meta: &mut ConstraintSystem<F>,
-        _params: &Self::Params,
-    ) -> Self::Config {
-        Self::configure(meta)
-    }
+    /// arrangement, column arrangement, etc.  Takes a runtime parameter.
+    #[cfg(feature = "circuit-params")]
+    fn configure(meta: &mut ConstraintSystem<F>, params: &Self::Params) -> Self::Config;
 
-    /// Configuration function without parameters.  This method is usually only called via the default
-    /// `configure_with_params` implementation for backwards-compatibility purposes.
+    /// The circuit is given an opportunity to describe the exact gate
+    /// arrangement, column arrangement, etc.
+    #[cfg(not(feature = "circuit-params"))]
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config;
 
     /// Given the provided `cs`, synthesize the circuit. The concrete type of

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -680,13 +680,19 @@ pub trait Circuit<F: Field> {
     }
 
     /// The circuit is given an opportunity to describe the exact gate
-    /// arrangement, column arrangement, etc.  Takes a runtime parameter.
+    /// arrangement, column arrangement, etc.  Takes a runtime parameter.  The default
+    /// implementation calls `configure` ignoring the `_params` argument in order to easily support
+    /// circuits that don't use configuration parameters.
     #[cfg(feature = "circuit-params")]
-    fn configure(meta: &mut ConstraintSystem<F>, params: &Self::Params) -> Self::Config;
+    fn configure_with_params(
+        meta: &mut ConstraintSystem<F>,
+        _params: Self::Params,
+    ) -> Self::Config {
+        Self::configure(meta)
+    }
 
     /// The circuit is given an opportunity to describe the exact gate
     /// arrangement, column arrangement, etc.
-    #[cfg(not(feature = "circuit-params"))]
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config;
 
     /// Given the provided `cs`, synthesize the circuit. The concrete type of

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -26,7 +26,7 @@ use crate::{
 
 pub(crate) fn create_domain<C, ConcreteCircuit>(
     k: u32,
-    #[cfg(feature = "circuit-params")] params: &ConcreteCircuit::Params,
+    #[cfg(feature = "circuit-params")] params: ConcreteCircuit::Params,
 ) -> (
     EvaluationDomain<C::Scalar>,
     ConstraintSystem<C::Scalar>,
@@ -37,11 +37,10 @@ where
     ConcreteCircuit: Circuit<C::Scalar>,
 {
     let mut cs = ConstraintSystem::default();
-    let config = ConcreteCircuit::configure(
-        &mut cs,
-        #[cfg(feature = "circuit-params")]
-        params,
-    );
+    #[cfg(feature = "circuit-params")]
+    let config = ConcreteCircuit::configure_with_params(&mut cs, params);
+    #[cfg(not(feature = "circuit-params"))]
+    let config = ConcreteCircuit::configure(&mut cs);
 
     let degree = cs.degree();
 
@@ -218,7 +217,7 @@ where
     let (domain, cs, config) = create_domain::<C, ConcreteCircuit>(
         params.k(),
         #[cfg(feature = "circuit-params")]
-        &circuit.params(),
+        circuit.params(),
     );
 
     if (params.n() as usize) < cs.minimum_rows() {
@@ -280,11 +279,10 @@ where
     ConcreteCircuit: Circuit<C::Scalar>,
 {
     let mut cs = ConstraintSystem::default();
-    let config = ConcreteCircuit::configure(
-        &mut cs,
-        #[cfg(feature = "circuit-params")]
-        &circuit.params(),
-    );
+    #[cfg(feature = "circuit-params")]
+    let config = ConcreteCircuit::configure_with_params(&mut cs, circuit.params());
+    #[cfg(not(feature = "circuit-params"))]
+    let config = ConcreteCircuit::configure(&mut cs);
 
     let cs = cs;
 

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -26,7 +26,7 @@ use crate::{
 
 pub(crate) fn create_domain<C, ConcreteCircuit>(
     k: u32,
-    params: &ConcreteCircuit::Params,
+    #[cfg(feature = "circuit-params")] params: &ConcreteCircuit::Params,
 ) -> (
     EvaluationDomain<C::Scalar>,
     ConstraintSystem<C::Scalar>,
@@ -37,7 +37,11 @@ where
     ConcreteCircuit: Circuit<C::Scalar>,
 {
     let mut cs = ConstraintSystem::default();
-    let config = ConcreteCircuit::configure_with_params(&mut cs, params);
+    let config = ConcreteCircuit::configure(
+        &mut cs,
+        #[cfg(feature = "circuit-params")]
+        params,
+    );
 
     let degree = cs.degree();
 
@@ -211,7 +215,11 @@ where
     ConcreteCircuit: Circuit<C::Scalar>,
     C::Scalar: FromUniformBytes<64>,
 {
-    let (domain, cs, config) = create_domain::<C, ConcreteCircuit>(params.k(), &circuit.params());
+    let (domain, cs, config) = create_domain::<C, ConcreteCircuit>(
+        params.k(),
+        #[cfg(feature = "circuit-params")]
+        &circuit.params(),
+    );
 
     if (params.n() as usize) < cs.minimum_rows() {
         return Err(Error::not_enough_rows_available(params.k()));
@@ -272,7 +280,11 @@ where
     ConcreteCircuit: Circuit<C::Scalar>,
 {
     let mut cs = ConstraintSystem::default();
-    let config = ConcreteCircuit::configure_with_params(&mut cs, &circuit.params());
+    let config = ConcreteCircuit::configure(
+        &mut cs,
+        #[cfg(feature = "circuit-params")]
+        &circuit.params(),
+    );
 
     let cs = cs;
 

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -26,6 +26,7 @@ use crate::{
 
 pub(crate) fn create_domain<C, ConcreteCircuit>(
     k: u32,
+    params: &ConcreteCircuit::Params,
 ) -> (
     EvaluationDomain<C::Scalar>,
     ConstraintSystem<C::Scalar>,
@@ -36,7 +37,7 @@ where
     ConcreteCircuit: Circuit<C::Scalar>,
 {
     let mut cs = ConstraintSystem::default();
-    let config = ConcreteCircuit::configure(&mut cs);
+    let config = ConcreteCircuit::configure_with_params(&mut cs, params);
 
     let degree = cs.degree();
 
@@ -210,7 +211,7 @@ where
     ConcreteCircuit: Circuit<C::Scalar>,
     C::Scalar: FromUniformBytes<64>,
 {
-    let (domain, cs, config) = create_domain::<C, ConcreteCircuit>(params.k());
+    let (domain, cs, config) = create_domain::<C, ConcreteCircuit>(params.k(), &circuit.params());
 
     if (params.n() as usize) < cs.minimum_rows() {
         return Err(Error::not_enough_rows_available(params.k()));
@@ -271,7 +272,7 @@ where
     ConcreteCircuit: Circuit<C::Scalar>,
 {
     let mut cs = ConstraintSystem::default();
-    let config = ConcreteCircuit::configure(&mut cs);
+    let config = ConcreteCircuit::configure_with_params(&mut cs, &circuit.params());
 
     let cs = cs;
 

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -68,11 +68,10 @@ where
 
     let domain = &pk.vk.domain;
     let mut meta = ConstraintSystem::default();
-    let config = ConcreteCircuit::configure(
-        &mut meta,
-        #[cfg(feature = "circuit-params")]
-        &circuits[0].params(),
-    );
+    #[cfg(feature = "circuit-params")]
+    let config = ConcreteCircuit::configure_with_params(&mut meta, circuits[0].params());
+    #[cfg(not(feature = "circuit-params"))]
+    let config = ConcreteCircuit::configure(&mut meta);
 
     // Selector optimizations cannot be applied here; use the ConstraintSystem
     // from the verification key.

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -68,7 +68,11 @@ where
 
     let domain = &pk.vk.domain;
     let mut meta = ConstraintSystem::default();
-    let config = ConcreteCircuit::configure_with_params(&mut meta, &circuits[0].params());
+    let config = ConcreteCircuit::configure(
+        &mut meta,
+        #[cfg(feature = "circuit-params")]
+        &circuits[0].params(),
+    );
 
     // Selector optimizations cannot be applied here; use the ConstraintSystem
     // from the verification key.

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -68,7 +68,7 @@ where
 
     let domain = &pk.vk.domain;
     let mut meta = ConstraintSystem::default();
-    let config = ConcreteCircuit::configure(&mut meta);
+    let config = ConcreteCircuit::configure_with_params(&mut meta, &circuits[0].params());
 
     // Selector optimizations cannot be applied here; use the ConstraintSystem
     // from the verification key.

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -275,10 +275,7 @@ fn plonk_api() {
             }
         }
 
-        fn configure(
-            meta: &mut ConstraintSystem<F>,
-            #[cfg(feature = "circuit-params")] _: &(),
-        ) -> PlonkConfig {
+        fn configure(meta: &mut ConstraintSystem<F>) -> PlonkConfig {
             let e = meta.advice_column();
             let a = meta.advice_column();
             let b = meta.advice_column();

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -265,6 +265,7 @@ fn plonk_api() {
     impl<F: Field> Circuit<F> for MyCircuit<F> {
         type Config = PlonkConfig;
         type FloorPlanner = SimpleFloorPlanner;
+        #[cfg(feature = "circuit-params")]
         type Params = ();
 
         fn without_witnesses(&self) -> Self {
@@ -274,7 +275,10 @@ fn plonk_api() {
             }
         }
 
-        fn configure(meta: &mut ConstraintSystem<F>) -> PlonkConfig {
+        fn configure(
+            meta: &mut ConstraintSystem<F>,
+            #[cfg(feature = "circuit-params")] _: &(),
+        ) -> PlonkConfig {
             let e = meta.advice_column();
             let a = meta.advice_column();
             let b = meta.advice_column();

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -265,6 +265,7 @@ fn plonk_api() {
     impl<F: Field> Circuit<F> for MyCircuit<F> {
         type Config = PlonkConfig;
         type FloorPlanner = SimpleFloorPlanner;
+        type Params = ();
 
         fn without_witnesses(&self) -> Self {
             Self {


### PR DESCRIPTION
The Circuit trait is extended with the following:
```Rust
pub trait Circuit<F: Field> {
    /// [...]
    type Params: Default;

    fn params(&self) -> Self::Params {
        Self::Params::default()
    }

    fn configure_with_params(meta: &mut ConstraintSystem<F>, params: Self::Params) -> Self::Config {
        Self::configure(meta)
    }

    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config;
}
```

This allows runtime parametrization of the circuit configuration.  The extension to the Circuit trait has been designed to minimize the breaking change: existing circuits only need to define the associated `type Params`.

Unfortunately "Associated type defaults" are unstable in Rust, otherwise this would be a non-breaking change.  See https://github.com/rust-lang/rust/issues/29661

Resolve https://github.com/privacy-scaling-explorations/halo2/issues/106