### PR TITLE
Implement Clone trait for Poseidon Hash struct

### DIFF
--- a/halo2_gadgets/src/poseidon/primitives.rs
+++ b/halo2_gadgets/src/poseidon/primitives.rs
@@ -166,7 +166,7 @@ mod private {
 pub trait SpongeMode: private::SealedSpongeMode {}
 
 /// The absorbing state of the `Sponge`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Absorbing<F, const RATE: usize>(pub(crate) SpongeRate<F, RATE>);
 
 /// The squeezing state of the `Sponge`.
@@ -188,6 +188,7 @@ impl<F: fmt::Debug, const RATE: usize> Absorbing<F, RATE> {
     }
 }
 
+#[derive(Clone)]
 /// A Poseidon sponge.
 pub(crate) struct Sponge<
     F: Field,
@@ -329,6 +330,7 @@ impl<F: PrimeField, const RATE: usize, const L: usize> Domain<F, RATE> for Const
     }
 }
 
+#[derive(Clone)]
 /// A Poseidon hash function, built around a sponge.
 pub struct Hash<
     F: Field,


### PR DESCRIPTION
### Description

Implement Clone trait for Poseidon `Hash` struct and dependent structs `Absorbing` and `Sponge`
 
### Issue Link

Related to #165

### How Has This Been Tested?

`cargo test` 

I get an error but I don't know if this is related to this PR
```
test plonk_api ... FAILED

thread 'plonk_api' panicked at 'assertion failed: `(left == right)`
  left: `13`,
 right: `16`: iterators must have the same length', /Users/enricobottazzi/Developer/GitHub/halo2/halo2_proofs/src/plonk/vanishing/prover.rs:68:14
```