### PR TITLE
fix: Fix serialization for VerifyingKey

### DIFF
--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -177,7 +177,7 @@ where
                 * (self
                     .selectors
                     .get(0)
-                    .map(|selector| selector.len() / 8 + 1)
+                    .map(|selector| (selector.len() + 7) / 8)
                     .unwrap_or(0))
     }
 


### PR DESCRIPTION
Now the value returned when the number of selectors is a multiple of 8 is correct.

Resolves: #175