### PR TITLE
Revert double-assignment mock prover check

### DIFF
--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -461,12 +461,7 @@ impl<F: Field> Assignment<F> for MockProver<F> {
                     .get_mut(column.index())
                     .and_then(|v| v.get_mut(row))
                     .expect("bounds failure");
-                if let CellValue::Assigned(value) = value {
-                    // Inconsistent assignment between different phases.
-                    assert_eq!(value, &to, "value={:?}, to={:?}", value, &to);
-                } else {
-                    *value = CellValue::Assigned(to);
-                }
+                *value = CellValue::Assigned(to);
             }
             Err(err) => {
                 // Propagate `assign` error if the column is in current phase.


### PR DESCRIPTION
Revert the check introduced in
https://github.com/privacy-scaling-explorations/halo2/pull/129 to detect double assignments with different values, because it breaks some tests in the zkevm project.

There's a legitimate use case of double assignment with different values, which is overwriting cells in order to perform negative tests (tests with bad witness that should not pass the constraints).

Also in the EVM Circuit from the zkevm project we "abuse" the assignment of cells as a cache: sometimes we assign some cells with a guess value, and later on we reassign with the correct value.

I believe this check is interesting to have, so we could think of ways to add it back as an optional feature.