### PR TITLE
Add more getters to expose internal fields

### DIFF
--- a/halo2_proofs/src/dev/metadata.rs
+++ b/halo2_proofs/src/dev/metadata.rs
@@ -15,6 +15,17 @@ pub struct Column {
     pub(super) index: usize,
 }
 
+impl Column {
+    /// Return the column type.
+    pub fn column_type(&self) -> Any {
+        self.column_type
+    }
+    /// Return the column index.
+    pub fn index(&self) -> usize {
+        self.index
+    }
+}
+
 impl fmt::Display for Column {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Column('{:?}', {})", self.column_type, self.index)

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -466,6 +466,11 @@ impl Selector {
         self.1
     }
 
+    /// Returns index of this selector
+    pub fn index(&self) -> usize {
+        self.0
+    }
+
     /// Return expression from selector
     pub fn expr<F: Field>(&self) -> Expression<F> {
         Expression::Selector(*self)
@@ -1498,11 +1503,13 @@ pub struct Gate<F: Field> {
 }
 
 impl<F: Field> Gate<F> {
-    pub(crate) fn name(&self) -> &str {
+    /// Returns the gate name.
+    pub fn name(&self) -> &str {
         self.name.as_str()
     }
 
-    pub(crate) fn constraint_name(&self, constraint_index: usize) -> &str {
+    /// Returns the name of the constraint at index `constraint_index`.
+    pub fn constraint_name(&self, constraint_index: usize) -> &str {
         self.constraint_names[constraint_index].as_str()
     }
 
@@ -1903,7 +1910,7 @@ impl<F: Field> ConstraintSystem<F> {
     /// find which fixed column corresponds with a given `Selector`.
     ///
     /// Do not call this twice. Yes, this should be a builder pattern instead.
-    pub(crate) fn compress_selectors(mut self, selectors: Vec<Vec<bool>>) -> (Self, Vec<Vec<F>>) {
+    pub fn compress_selectors(mut self, selectors: Vec<Vec<bool>>) -> (Self, Vec<Vec<F>>) {
         // The number of provided selector assignments must be the number we
         // counted for this constraint system.
         assert_eq!(selectors.len(), self.num_selectors);
@@ -2240,6 +2247,11 @@ impl<F: Field> ConstraintSystem<F> {
         self.num_instance_columns
     }
 
+    /// Returns number of selectors
+    pub fn num_selectors(&self) -> usize {
+        self.num_selectors
+    }
+
     /// Returns number of challenges
     pub fn num_challenges(&self) -> usize {
         self.num_challenges
@@ -2261,6 +2273,11 @@ impl<F: Field> ConstraintSystem<F> {
     /// Returns gates
     pub fn gates(&self) -> &Vec<Gate<F>> {
         &self.gates
+    }
+
+    /// Returns general column annotations
+    pub fn general_column_annotations(&self) -> &HashMap<metadata::Column, String> {
+        &self.general_column_annotations
     }
 
     /// Returns advice queries

--- a/halo2_proofs/src/plonk/lookup.rs
+++ b/halo2_proofs/src/plonk/lookup.rs
@@ -91,4 +91,9 @@ impl<F: Field> Argument<F> {
     pub fn table_expressions(&self) -> &Vec<Expression<F>> {
         &self.table_expressions
     }
+
+    /// Returns name of this argument
+    pub fn name(&self) -> &str {
+        &self.name
+    }
 }


### PR DESCRIPTION
This is a small PR to add more getters to the types `Column`, `Selector`, `Gate` and `ConstraintSystem` and `Argument`.
I believe they are all safe and don't break any abstraction.
Having these getters is very useful to collect information from a halo2 circuit to later be used in debugging tools, or to prove the circuit in a different backend.