### PR TITLE
Fix `parallelize` workload imbalance

### DIFF
--- a/halo2_proofs/src/arithmetic.rs
+++ b/halo2_proofs/src/arithmetic.rs
@@ -383,20 +383,59 @@ where
 
 /// This simple utility function will parallelize an operation that is to be
 /// performed over a mutable slice.
+#[allow(unsafe_code)]
 pub fn parallelize<T: Send, F: Fn(&mut [T], usize) + Send + Sync + Clone>(v: &mut [T], f: F) {
-    let n = v.len();
+
+    // Algorithm rationale:
+    //
+    // Using the stdlib `chunks_mut` will lead to severe load imbalance.
+    // From https://github.com/rust-lang/rust/blob/e94bda3/library/core/src/slice/iter.rs#L1607-L1637
+    // if the division is not exact, the last chunk will be the remainder.
+    //
+    // Dividing 40 items on 12 threads will lead to a chunk size of 40/12 = 3,
+    // the first 11 threads will work on 3 items and the last on 40-11*3 = 7 items,
+    // a 2.33x workload difference
+    //
+    // Instead we can divide work into chunks of size
+    // 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3 = 4*4 + 3*8 = 40
+    //
+    // This would lead to a 7/4 = 1.75x speedup
+    //
+    // Speedup can be even more dramatic if for exemple we had 351 items to split on 32 cores
+    // 351/32 = 10, 10*31 = 310, last chunk would be 41 items, a 4.1x workload difference.
+    //
+    // See also OpenMP spec (page 60)
+    // http://www.openmp.org/mp-documents/openmp-4.5.pdf
+    // "When no chunk_size is specified, the iteration space is divided into chunks
+    // that are approximately equal in size, and at most one chunk is distributed to
+    // each thread. The size of the chunks is unspecified in this case."
+    // This implies chunks are the same size ±1
+
+    let total_iters = v.len();
     let num_threads = multicore::current_num_threads();
-    let mut chunk = (n as usize) / num_threads;
-    if chunk < num_threads {
-        chunk = 1;
-    }
+    let num_chunks = std::cmp::min(num_threads, total_iters);
+    let base_chunk_size = total_iters / num_threads;
+    let cutoff = total_iters % num_threads;
 
     multicore::scope(|scope| {
-        for (chunk_num, v) in v.chunks_mut(chunk).enumerate() {
+        for chunk_id in 0..num_chunks {
             let f = f.clone();
+            let (offset, chunk_size) = if chunk_id < cutoff {
+                ((base_chunk_size+1) * chunk_id, base_chunk_size+1)
+            } else {
+                ((base_chunk_size * chunk_id) + cutoff, base_chunk_size)
+            };
+
+            // The borrow checker cannot prove that the chunks are disjoint slices.
+            // so we need to resort to raw pointers to construct mutable disjoint slices.
+            let chunk: &mut [T] = unsafe {
+                let ptr_offset = v.get_unchecked_mut(offset);
+                let len = std::cmp::min(total_iters-offset, chunk_size);
+                std::slice::from_raw_parts_mut(ptr_offset, len)
+            };
+
             scope.spawn(move |_| {
-                let start = chunk_num * chunk;
-                f(v, start);
+                f(chunk, offset);
             });
         }
     });

--- a/halo2_proofs/src/arithmetic.rs
+++ b/halo2_proofs/src/arithmetic.rs
@@ -381,11 +381,9 @@ where
     q
 }
 
-/// This simple utility function will parallelize an operation that is to be
+/// This utility function will parallelize an operation that is to be
 /// performed over a mutable slice.
-#[allow(unsafe_code)]
 pub fn parallelize<T: Send, F: Fn(&mut [T], usize) + Send + Sync + Clone>(v: &mut [T], f: F) {
-
     // Algorithm rationale:
     //
     // Using the stdlib `chunks_mut` will lead to severe load imbalance.
@@ -393,16 +391,14 @@ pub fn parallelize<T: Send, F: Fn(&mut [T], usize) + Send + Sync + Clone>(v: &mu
     // if the division is not exact, the last chunk will be the remainder.
     //
     // Dividing 40 items on 12 threads will lead to a chunk size of 40/12 = 3,
-    // the first 11 threads will work on 3 items and the last on 40-11*3 = 7 items,
-    // a 2.33x workload difference
+    // There will be a 13 chunks of size 3 and 1 of size 1 distributed on 12 threads.
+    // This leads to 1 thread working on 6 iterations, 1 on 4 iterations and 10 on 3 iterations,
+    // a load imbalance of 2x.
     //
     // Instead we can divide work into chunks of size
     // 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3 = 4*4 + 3*8 = 40
     //
-    // This would lead to a 7/4 = 1.75x speedup
-    //
-    // Speedup can be even more dramatic if for exemple we had 351 items to split on 32 cores
-    // 351/32 = 10, 10*31 = 310, last chunk would be 41 items, a 4.1x workload difference.
+    // This would lead to a 6/4 = 1.5x speedup compared to naive chunks_mut
     //
     // See also OpenMP spec (page 60)
     // http://www.openmp.org/mp-documents/openmp-4.5.pdf
@@ -411,32 +407,28 @@ pub fn parallelize<T: Send, F: Fn(&mut [T], usize) + Send + Sync + Clone>(v: &mu
     // each thread. The size of the chunks is unspecified in this case."
     // This implies chunks are the same size ±1
 
+    let f = &f;
     let total_iters = v.len();
     let num_threads = multicore::current_num_threads();
-    let num_chunks = std::cmp::min(num_threads, total_iters);
     let base_chunk_size = total_iters / num_threads;
-    let cutoff = total_iters % num_threads;
+    let cutoff_chunk_id = total_iters % num_threads;
+    let split_pos = cutoff_chunk_id * (base_chunk_size + 1);
+    let (v_hi, v_lo) = v.split_at_mut(split_pos);
 
     multicore::scope(|scope| {
-        for chunk_id in 0..num_chunks {
-            let f = f.clone();
-            let (offset, chunk_size) = if chunk_id < cutoff {
-                ((base_chunk_size+1) * chunk_id, base_chunk_size+1)
-            } else {
-                ((base_chunk_size * chunk_id) + cutoff, base_chunk_size)
-            };
-
-            // The borrow checker cannot prove that the chunks are disjoint slices.
-            // so we need to resort to raw pointers to construct mutable disjoint slices.
-            let chunk: &mut [T] = unsafe {
-                let ptr_offset = v.get_unchecked_mut(offset);
-                let len = std::cmp::min(total_iters-offset, chunk_size);
-                std::slice::from_raw_parts_mut(ptr_offset, len)
-            };
-
-            scope.spawn(move |_| {
-                f(chunk, offset);
-            });
+        // Skip special-case: number of iterations is cleanly divided by number of threads.
+        if cutoff_chunk_id != 0 {
+            for (chunk_id, chunk) in v_hi.chunks_exact_mut(base_chunk_size + 1).enumerate() {
+                let offset = chunk_id * (base_chunk_size + 1);
+                scope.spawn(move |_| f(chunk, offset));
+            }
+        }
+        // Skip special-case: less iterations than number of threads.
+        if base_chunk_size != 0 {
+            for (chunk_id, chunk) in v_lo.chunks_exact_mut(base_chunk_size).enumerate() {
+                let offset = split_pos + (chunk_id * base_chunk_size);
+                scope.spawn(move |_| f(chunk, offset));
+            }
         }
     });
 }


### PR DESCRIPTION
Currently if we take 40 items divided into 12 threads (AMD Ryzen 7800X, Apple M2 Pro or Intel i5-12600) the partitioning will lead to 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 7 = 3*11 + 7 = 40. The “remainder” thread will have 2.33x more work to do.

This can be quite extreme for example if we have 351 items to split on 32 cores, 351/32 = 10.96, rounded to 10 with integer division. 10*31 = 310, the last core needs to process 41 items, 4.1x more than the others.

This ensures whatever the number of items and the number of threads, the workload varies by at most 1.

This probably explains why not all cores are used while benchmarking (benchmarks TODO). See also [Amdahl's law](https://en.wikipedia.org/wiki/Amdahl%27s_law).

## Unsafe

Note: I'm not familiar with Rust standard library and parallelism development since October 2016 (my last foray into writing Rust programs).
I've looked into:
- https://doc.rust-lang.org/std/primitive.slice.html
- Rayon chunking: https://github.com/rayon-rs/rayon/blob/2c97943/src/slice/chunks.rs

Note of the chunking routines provides balanced partitioning of a range.
- Either the last chunk can be extremely large like with the current usage of ``chunks_mut``
- or it's not returned like in `array_chunks` and requires a separate `remainder` call
- or we get more chunks than our number of threads like with ``as_chunks``

I might very well have missed something though.