### PR TITLE
Updates halo2_curves dependency to released package

### DIFF
--- a/halo2_gadgets/Cargo.toml
+++ b/halo2_gadgets/Cargo.toml
@@ -28,7 +28,7 @@ ff = { version = "0.13", features = ["bits"] }
 group = "0.13"
 halo2_proofs = { version = "0.2", path = "../halo2_proofs" }
 lazy_static = "1"
-halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves', tag = "0.3.2" }
+halo2curves = { version = "0.1.0" }
 proptest = { version = "1.0.0", optional = true }
 rand = "0.8"
 subtle = "2.3"

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -52,7 +52,7 @@ backtrace = { version = "0.3", optional = true }
 rayon = "1.5.1"
 ff = "0.13"
 group = "0.13"
-halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves', tag = "0.3.2" }
+halo2curves = { version = "0.1.0" }
 rand_core = { version = "0.6", default-features = false }
 tracing = "0.1"
 blake2b_simd = "1"


### PR DESCRIPTION
Halo2curve's package release resets the version from those inherited by the legacy halo2curves repo's fork history.
This sets the halo2curve dependency to use the released crate.

The upstream diff is:
https://github.com/privacy-scaling-explorations/halo2curves/compare/9f5c50810bbefe779ee5cf1d852b2fe85dc35d5e..9a7f726fa74c8765bc7cdab11519cf285d169ecf

This addresses https://github.com/privacy-scaling-explorations/halo2curves/issues/63 and allows halo2curves to develop tagging. Should you not want to take the upgrade, another option is to depend on halo2curves at a particular git commit hash (rather than a tag), ideally the one pointed at by v0.3.2, i.e. https://github.com/privacy-scaling-explorations/halo2curves/commit/9f5c50810bbefe779ee5cf1d852b2fe85dc35d5e. I'm happy to amend the current PR, should this be the case.

/cc @CPerezz 