### PR TITLE
fix: explicitly define mds diff type

### DIFF
--- a/halo2_gadgets/src/poseidon/primitives/mds.rs
+++ b/halo2_gadgets/src/poseidon/primitives/mds.rs
@@ -82,7 +82,8 @@ pub(super) fn generate_mds<F: FromUniformBytes<64> + Ord, const T: usize>(
                 acc
             } else {
                 // We can invert freely; by construction, the elements of xs are distinct.
-                acc * (x - x_m) * (x_j - x_m).invert().unwrap()
+                let diff: F = (x_j - *x_m);
+                acc * (x - x_m) * diff.invert().unwrap()
             }
         })
     };

--- a/halo2_gadgets/src/poseidon/primitives/mds.rs
+++ b/halo2_gadgets/src/poseidon/primitives/mds.rs
@@ -82,7 +82,7 @@ pub(super) fn generate_mds<F: FromUniformBytes<64> + Ord, const T: usize>(
                 acc
             } else {
                 // We can invert freely; by construction, the elements of xs are distinct.
-                let diff: F = (x_j - *x_m);
+                let diff: F = x_j - *x_m;
                 acc * (x - x_m) * diff.invert().unwrap()
             }
         })


### PR DESCRIPTION
Certain compiler versions, and targets, particularly `wasm-unknown-unknown`, error out on the following lines of `halo2_gadgets/src/poseidon/primitives/mds.rs:85:28`: 

```rust
            } else {
                // We can invert freely; by construction, the elements of xs are distinct.
                acc * (x - x_m) * (x_j - x_m).invert().unwrap()
            }
        })
    };
```

with the error 

```bash
let diff = (x_j - *x_m).invert();
   |       ^^^^^^^^^^^^ cannot infer type
```

This PR applies a simple patch to allow for compilation for those targets ! 