### PR TITLE
Fix gh page doc index

### DIFF
--- a/.github/workflows/docs-ghpages.yml
+++ b/.github/workflows/docs-ghpages.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           rm -rf ./docs
           cp -R ./target/doc ./docs
-          echo "<meta http-equiv=\"refresh\" content=\"0; url=pse_halo2\">" > ./docs/index.html
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=halo2_proofs\">" > ./docs/index.html
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION

Currently, if we go `https://privacy-scaling-explorations.github.io/halo2/`, it gets redirected to `https://privacy-scaling-explorations.github.io/halo2/pse_halo2`, which is not a valid URL.

We fixed the index page to redirect to a valid crate page. I think halo2_proofs is the most helpful destination for readers.