### PR TITLE
Improve root calculation for KZG setup()

### DIFF
--- a/halo2_proofs/src/poly/kzg/commitment.rs
+++ b/halo2_proofs/src/poly/kzg/commitment.rs
@@ -88,11 +88,9 @@ where
         };
 
         let mut g_lagrange_projective = vec![E::G1::identity(); n as usize];
-        let mut root = E::Scalar::ROOT_OF_UNITY_INV.invert().unwrap();
-        for _ in k..E::Scalar::S {
-            root = root.square();
-        }
-        let n_inv = Option::<E::Scalar>::from(E::Scalar::from(n).invert())
+        let root = E::Scalar::ROOT_OF_UNITY.pow_vartime([1 << (E::Scalar::S - k)]);
+        let n_inv = E::Scalar::from(n)
+            .invert()
             .expect("inversion should be ok for n = 1<<k");
         let multiplier = (s.pow_vartime([n]) - E::Scalar::ONE) * n_inv;
         parallelize(&mut g_lagrange_projective, |g, start| {
@@ -106,11 +104,9 @@ where
 
         let g_lagrange = {
             let mut g_lagrange = vec![E::G1Affine::identity(); n as usize];
-            parallelize(&mut g_lagrange, |g_lagrange, starts| {
-                E::G1::batch_normalize(
-                    &g_lagrange_projective[starts..(starts + g_lagrange.len())],
-                    g_lagrange,
-                );
+            parallelize(&mut g_lagrange, |g_lagrange, start| {
+                let end = start + g_lagrange.len();
+                E::G1::batch_normalize(&g_lagrange_projective[start..end], g_lagrange);
             });
             drop(g_lagrange_projective);
             g_lagrange
@@ -142,10 +138,9 @@ where
         Self {
             k,
             n: 1 << k,
-            g_lagrange: if let Some(g_l) = g_lagrange {
-                g_l
-            } else {
-                g_to_lagrange(g.iter().map(PrimeCurveAffine::to_curve).collect(), k)
+            g_lagrange: match g_lagrange {
+                Some(g_l) => g_l,
+                None => g_to_lagrange(g.iter().map(PrimeCurveAffine::to_curve).collect(), k),
             },
             g,
             g2,

--- a/halo2_proofs/src/poly/kzg/commitment.rs
+++ b/halo2_proofs/src/poly/kzg/commitment.rs
@@ -90,8 +90,8 @@ where
         let mut g_lagrange_projective = vec![E::G1::identity(); n as usize];
         let mut root = E::Scalar::ROOT_OF_UNITY;
         for _ in k..E::Scalar::S {
-             root = root.square();
-         }
+            root = root.square();
+        }
         let n_inv = E::Scalar::from(n)
             .invert()
             .expect("inversion should be ok for n = 1<<k");

--- a/halo2_proofs/src/poly/kzg/commitment.rs
+++ b/halo2_proofs/src/poly/kzg/commitment.rs
@@ -88,7 +88,10 @@ where
         };
 
         let mut g_lagrange_projective = vec![E::G1::identity(); n as usize];
-        let root = E::Scalar::ROOT_OF_UNITY.pow_vartime([1 << (E::Scalar::S - k)]);
+        let mut root = E::Scalar::ROOT_OF_UNITY;
+        for _ in k..E::Scalar::S {
+             root = root.square();
+         }
         let n_inv = E::Scalar::from(n)
             .invert()
             .expect("inversion should be ok for n = 1<<k");


### PR DESCRIPTION
Hi guys, I'm learning KZG so I checked `halo2` source code. Found some minor issues and can be improved.

```rust
                let mut root = <Bn256 as Engine>::Scalar::ROOT_OF_UNITY_INV
                    .invert()
                    .unwrap();
                for _ in k..<Bn256 as Engine>::Scalar::S {
                    root = root.square();
                }
```

Is equivalent to 

```rust
                let root = <Bn256 as Engine>::Scalar::ROOT_OF_UNITY
                    .pow_vartime([1 << (<Bn256 as Engine>::Scalar::S - k)]);
```

Result:

```text
                        root-of-unity time:   [1.4413 µs 1.4443 µs 1.4473 µs]                           
                        change: [-89.921% -89.897% -89.873%] (p = 0.00 < 0.05)
                        Performance has improved.
```