### PR TITLE
[feat] Make selector compression optional

### DIFF
--- a/halo2_proofs/src/helpers.rs
+++ b/halo2_proofs/src/helpers.rs
@@ -55,6 +55,14 @@ pub trait SerdeCurveAffine: CurveAffine + SerdeObject {
             _ => self.write_raw(writer),
         }
     }
+
+    /// Byte length of an affine curve element according to `format`.
+    fn byte_length(format: SerdeFormat) -> usize {
+        match format {
+            SerdeFormat::Processed => Self::default().to_bytes().as_ref().len(),
+            _ => Self::Repr::default().as_ref().len() * 2,
+        }
+    }
 }
 impl<C: CurveAffine + SerdeObject> SerdeCurveAffine for C {}
 

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -84,6 +84,9 @@ where
         }
         self.permutation.write(writer, format)?;
 
+        if !self.compress_selectors {
+            assert!(self.selectors.is_empty());
+        }
         // write self.selectors
         for selector in &self.selectors {
             // since `selector` is filled with `bool`, we pack them 8 at a time into bytes and then write
@@ -144,20 +147,27 @@ where
 
         let permutation = permutation::VerifyingKey::read(reader, &cs.permutation, format)?;
 
-        // read selectors
-        let selectors: Vec<Vec<bool>> = vec![vec![false; 1 << k]; cs.num_selectors]
-            .into_iter()
-            .map(|mut selector| {
-                let mut selector_bytes = vec![0u8; (selector.len() + 7) / 8];
-                reader.read_exact(&mut selector_bytes)?;
-                for (bits, byte) in selector.chunks_mut(8).zip(selector_bytes) {
-                    crate::helpers::unpack(byte, bits);
-                }
-                Ok(selector)
-            })
-            .collect::<io::Result<_>>()?;
-        let max_degree = if compress_selectors { cs.degree() } else { 0 };
-        let (cs, _) = cs.compress_selectors_up_to_degree(selectors.clone(), max_degree);
+        let (cs, selectors) = if compress_selectors {
+            // read selectors
+            let selectors: Vec<Vec<bool>> = vec![vec![false; 1 << k]; cs.num_selectors]
+                .into_iter()
+                .map(|mut selector| {
+                    let mut selector_bytes = vec![0u8; (selector.len() + 7) / 8];
+                    reader.read_exact(&mut selector_bytes)?;
+                    for (bits, byte) in selector.chunks_mut(8).zip(selector_bytes) {
+                        crate::helpers::unpack(byte, bits);
+                    }
+                    Ok(selector)
+                })
+                .collect::<io::Result<_>>()?;
+            let (cs, _) = cs.compress_selectors(selectors.clone());
+            (cs, selectors)
+        } else {
+            // we still need to replace selectors with fixed Expressions in `cs`
+            let fake_selectors = vec![vec![false]; cs.num_selectors];
+            let (cs, _) = cs.directly_convert_selectors_to_fixed(fake_selectors);
+            (cs, vec![])
+        };
 
         Ok(Self::from_parts(
             domain,

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -181,7 +181,7 @@ where
 
     /// Writes a verifying key to a vector of bytes using [`Self::write`].
     pub fn to_bytes(&self, format: SerdeFormat) -> Vec<u8> {
-        let mut bytes = Vec::<u8>::with_capacity(self.bytes_length());
+        let mut bytes = Vec::<u8>::with_capacity(self.bytes_length(format));
         Self::write(self, &mut bytes, format).expect("Writing to vector should not fail");
         bytes
     }
@@ -202,9 +202,12 @@ where
 }
 
 impl<C: CurveAffine> VerifyingKey<C> {
-    fn bytes_length(&self) -> usize {
-        8 + (self.fixed_commitments.len() * C::default().to_bytes().as_ref().len())
-            + self.permutation.bytes_length()
+    fn bytes_length(&self, format: SerdeFormat) -> usize
+    where
+        C: SerdeCurveAffine,
+    {
+        10 + (self.fixed_commitments.len() * C::byte_length(format))
+            + self.permutation.bytes_length(format)
             + self.selectors.len()
                 * (self
                     .selectors
@@ -336,9 +339,12 @@ where
     }
 
     /// Gets the total number of bytes in the serialization of `self`
-    fn bytes_length(&self) -> usize {
+    fn bytes_length(&self, format: SerdeFormat) -> usize
+    where
+        C: SerdeCurveAffine,
+    {
         let scalar_len = C::Scalar::default().to_repr().as_ref().len();
-        self.vk.bytes_length()
+        self.vk.bytes_length(format)
             + 12
             + scalar_len * (self.l0.len() + self.l_last.len() + self.l_active_row.len())
             + polynomial_slice_byte_length(&self.fixed_values)
@@ -419,7 +425,7 @@ where
 
     /// Writes a proving key to a vector of bytes using [`Self::write`].
     pub fn to_bytes(&self, format: SerdeFormat) -> Vec<u8> {
-        let mut bytes = Vec::<u8>::with_capacity(self.bytes_length());
+        let mut bytes = Vec::<u8>::with_capacity(self.bytes_length(format));
         Self::write(self, &mut bytes, format).expect("Writing to vector should not fail");
         bytes
     }

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -56,6 +56,8 @@ pub struct VerifyingKey<C: CurveAffine> {
     /// The representative of this `VerifyingKey` in transcripts.
     transcript_repr: C::Scalar,
     selectors: Vec<Vec<bool>>,
+    /// Whether selector compression is turned on or not.
+    compress_selectors: bool,
 }
 
 impl<C: SerdeCurveAffine> VerifyingKey<C>
@@ -72,8 +74,11 @@ where
     /// Writes a field element into raw bytes in its internal Montgomery representation,
     /// WITHOUT performing the expensive Montgomery reduction.
     pub fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
-        writer.write_all(&self.domain.k().to_be_bytes())?;
-        writer.write_all(&(self.fixed_commitments.len() as u32).to_be_bytes())?;
+        // Version byte that will be checked on read.
+        writer.write_all(&[0x02])?;
+        writer.write_all(&self.domain.k().to_le_bytes())?;
+        writer.write_all(&[self.compress_selectors as u8])?;
+        writer.write_all(&(self.fixed_commitments.len() as u32).to_le_bytes())?;
         for commitment in &self.fixed_commitments {
             commitment.write(writer, format)?;
         }
@@ -104,9 +109,26 @@ where
         format: SerdeFormat,
         #[cfg(feature = "circuit-params")] params: ConcreteCircuit::Params,
     ) -> io::Result<Self> {
+        let mut version_byte = [0u8; 1];
+        reader.read_exact(&mut version_byte)?;
+        if 0x02 != version_byte[0] {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unexpected version byte",
+            ));
+        }
         let mut k = [0u8; 4];
         reader.read_exact(&mut k)?;
-        let k = u32::from_be_bytes(k);
+        let k = u32::from_le_bytes(k);
+        let mut compress_selectors = [0u8; 1];
+        reader.read_exact(&mut compress_selectors)?;
+        if compress_selectors[0] != 0 && compress_selectors[0] != 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unexpected compress_selectors not boolean",
+            ));
+        }
+        let compress_selectors = compress_selectors[0] == 1;
         let (domain, cs, _) = keygen::create_domain::<C, ConcreteCircuit>(
             k,
             #[cfg(feature = "circuit-params")]
@@ -114,7 +136,7 @@ where
         );
         let mut num_fixed_columns = [0u8; 4];
         reader.read_exact(&mut num_fixed_columns)?;
-        let num_fixed_columns = u32::from_be_bytes(num_fixed_columns);
+        let num_fixed_columns = u32::from_le_bytes(num_fixed_columns);
 
         let fixed_commitments: Vec<_> = (0..num_fixed_columns)
             .map(|_| C::read(reader, format))
@@ -134,7 +156,8 @@ where
                 Ok(selector)
             })
             .collect::<io::Result<_>>()?;
-        let (cs, _) = cs.compress_selectors(selectors.clone());
+        let max_degree = if compress_selectors { cs.degree() } else { 0 };
+        let (cs, _) = cs.compress_selectors_up_to_degree(selectors.clone(), max_degree);
 
         Ok(Self::from_parts(
             domain,
@@ -142,6 +165,7 @@ where
             permutation,
             cs,
             selectors,
+            compress_selectors,
         ))
     }
 
@@ -185,6 +209,7 @@ impl<C: CurveAffine> VerifyingKey<C> {
         permutation: permutation::VerifyingKey<C>,
         cs: ConstraintSystem<C::Scalar>,
         selectors: Vec<Vec<bool>>,
+        compress_selectors: bool,
     ) -> Self
     where
         C::ScalarExt: FromUniformBytes<64>,
@@ -201,6 +226,7 @@ impl<C: CurveAffine> VerifyingKey<C> {
             // Temporary, this is not pinned.
             transcript_repr: C::Scalar::ZERO,
             selectors,
+            compress_selectors,
         };
 
         let mut hasher = Blake2bParams::new()

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -164,7 +164,7 @@ where
             (cs, selectors)
         } else {
             // we still need to replace selectors with fixed Expressions in `cs`
-            let fake_selectors = vec![vec![false]; cs.num_selectors];
+            let fake_selectors = vec![vec![]; cs.num_selectors];
             let (cs, _) = cs.directly_convert_selectors_to_fixed(fake_selectors);
             (cs, vec![])
         };

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -2073,7 +2073,7 @@ impl<F: Field> ConstraintSystem<F> {
 
         // Substitute selectors for the real fixed columns in all gates
         for expr in self.gates.iter_mut().flat_map(|gate| gate.polys.iter_mut()) {
-            replace_selectors(expr, &selector_replacements, false);
+            replace_selectors(expr, selector_replacements, false);
         }
 
         // Substitute non-simple selectors for the real fixed columns in all
@@ -2084,7 +2084,7 @@ impl<F: Field> ConstraintSystem<F> {
                 .iter_mut()
                 .chain(lookup.table_expressions.iter_mut())
         }) {
-            replace_selectors(expr, &selector_replacements, true);
+            replace_selectors(expr, selector_replacements, true);
         }
 
         for expr in self.shuffles.iter_mut().flat_map(|shuffle| {
@@ -2093,7 +2093,7 @@ impl<F: Field> ConstraintSystem<F> {
                 .iter_mut()
                 .chain(shuffle.shuffle_expressions.iter_mut())
         }) {
-            replace_selectors(expr, &selector_replacements, true);
+            replace_selectors(expr, selector_replacements, true);
         }
     }
 

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -214,7 +214,7 @@ where
     ConcreteCircuit: Circuit<C::Scalar>,
     C::Scalar: FromUniformBytes<64>,
 {
-    keygen_vk_custom(params, circuit, false)
+    keygen_vk_custom(params, circuit, true)
 }
 
 /// Generate a `VerifyingKey` from an instance of `Circuit`.

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -259,7 +259,6 @@ where
     )?;
 
     let mut fixed = batch_invert_assigned(assembly.fixed);
-    let max_degree = if compress_selectors { cs.degree() } else { 0 };
     let (cs, selector_polys) = if compress_selectors {
         cs.compress_selectors(assembly.selectors.clone())
     } else {
@@ -333,11 +332,6 @@ where
     )?;
 
     let mut fixed = batch_invert_assigned(assembly.fixed);
-    let max_degree = if vk.compress_selectors {
-        cs.degree()
-    } else {
-        0
-    };
     let (cs, selector_polys) = if vk.compress_selectors {
         cs.compress_selectors(assembly.selectors)
     } else {

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -203,9 +203,27 @@ impl<F: Field> Assignment<F> for Assembly<F> {
 }
 
 /// Generate a `VerifyingKey` from an instance of `Circuit`.
+/// By default, selector compression is turned **off**.
 pub fn keygen_vk<'params, C, P, ConcreteCircuit>(
     params: &P,
     circuit: &ConcreteCircuit,
+) -> Result<VerifyingKey<C>, Error>
+where
+    C: CurveAffine,
+    P: Params<'params, C>,
+    ConcreteCircuit: Circuit<C::Scalar>,
+    C::Scalar: FromUniformBytes<64>,
+{
+    keygen_vk_custom(params, circuit, false)
+}
+
+/// Generate a `VerifyingKey` from an instance of `Circuit`.
+///
+/// The selector compression optimization is turned on only if `compress_selectors` is `true`.
+pub fn keygen_vk_custom<'params, C, P, ConcreteCircuit>(
+    params: &P,
+    circuit: &ConcreteCircuit,
+    compress_selectors: bool,
 ) -> Result<VerifyingKey<C>, Error>
 where
     C: CurveAffine,
@@ -241,7 +259,9 @@ where
     )?;
 
     let mut fixed = batch_invert_assigned(assembly.fixed);
-    let (cs, selector_polys) = cs.compress_selectors(assembly.selectors.clone());
+    let max_degree = if compress_selectors { cs.degree() } else { 0 };
+    let (cs, selector_polys) =
+        cs.compress_selectors_up_to_degree(assembly.selectors.clone(), max_degree);
     fixed.extend(
         selector_polys
             .into_iter()

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -283,6 +283,7 @@ where
         permutation_vk,
         cs,
         assembly.selectors,
+        compress_selectors,
     ))
 }
 
@@ -327,7 +328,12 @@ where
     )?;
 
     let mut fixed = batch_invert_assigned(assembly.fixed);
-    let (cs, selector_polys) = cs.compress_selectors(assembly.selectors);
+    let max_degree = if vk.compress_selectors {
+        cs.degree()
+    } else {
+        0
+    };
+    let (cs, selector_polys) = cs.compress_selectors_up_to_degree(assembly.selectors, max_degree);
     fixed.extend(
         selector_polys
             .into_iter()

--- a/halo2_proofs/src/plonk/permutation.rs
+++ b/halo2_proofs/src/plonk/permutation.rs
@@ -117,8 +117,11 @@ impl<C: CurveAffine> VerifyingKey<C> {
         Ok(VerifyingKey { commitments })
     }
 
-    pub(crate) fn bytes_length(&self) -> usize {
-        self.commitments.len() * C::default().to_bytes().as_ref().len()
+    pub(crate) fn bytes_length(&self, format: SerdeFormat) -> usize
+    where
+        C: SerdeCurveAffine,
+    {
+        self.commitments.len() * C::byte_length(format)
     }
 }
 


### PR DESCRIPTION
Selector compression is an optimization, but often it can lead to unexpected behavior / makes life complicated when doing more complicated proof composability like with SNARK recursion or universal verifiers such as in `snark-verifier` and `halo2-solidity-verifier`. As such, it is useful to be able to optionally turn it off.

This PR does the following:
- Addresses https://github.com/privacy-scaling-explorations/halo2/issues/176 by adding a version byte to vkey serialization and using little endian everywhere for consistency.
- Adds `keygen_vk_custom` function where user can choose whether to turn on selector compression(=combination) or not.
- For backwards compatibility, `keygen_vk` will be set so the default is with selector compression, so it matches current behavior.
- When selector compression is off, the `VerifyingKey` does not need to store anything about selectors. After `keygen_vk_custom`, the `ConstraintSystem` has entirely replaced selectors with fixed columns, and fixed commitments have been updated. The `verify_proof` function does not use selectors in any way. In `keygen_pk` you still need to know about selectors, but it reconstructs the `ConstraintSystem` from scratch anyways.
- I think I've modified the `VerifyingKey::read` and `write` functions accordingly, where there is now a new byte recording whether selector compression is on or off. When off, I skip serializing selectors since they are unnecessary for reasons mentioned above.

I also did not realize until now how inefficient `keygen_vk` and `keygen_pk` are: it re-does the FFTs for all fixed columns twice, once in `keygen_vk` and again in `keygen_pk` because `VerifyingKey` can't store the results of the FFT. The fact that you need to re-generate the constraint system to handle selectors is also a bad design pattern in many ways, but for now I opted for the path of least code changes.