### PR TITLE
chore: fix typos in comments

### DIFF
--- a/halo2_gadgets/src/utilities/lookup_range_check.rs
+++ b/halo2_gadgets/src/utilities/lookup_range_check.rs
@@ -213,7 +213,7 @@ impl<F: PrimeFieldBits, const K: usize> LookupRangeCheckConfig<F, K> {
     }
 
     /// If `strict` is set to "true", the field element must fit into
-    /// `num_words * K` bits. In other words, the the final cumulative sum `z_{num_words}`
+    /// `num_words * K` bits. In other words, the final cumulative sum `z_{num_words}`
     /// must be zero.
     ///
     /// If `strict` is set to "false", the final `z_{num_words}` is not constrained.

--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -94,7 +94,7 @@ pub trait ParamsProver<'params, C: CurveAffine>: Params<'params, C> {
     fn verifier_params(&'params self) -> &'params Self::ParamsVerifier;
 }
 
-/// Verifier specific functionality with circuit constaints
+/// Verifier specific functionality with circuit constraints
 pub trait ParamsVerifier<'params, C: CurveAffine>: Params<'params, C> {}
 
 /// Multi scalar multiplication engine

--- a/halo2_proofs/src/transcript.rs
+++ b/halo2_proofs/src/transcript.rs
@@ -87,7 +87,7 @@ pub trait TranscriptReadBuffer<R: Read, C: CurveAffine, E: EncodedChallenge<C>>:
     fn init(reader: R) -> Self;
 }
 
-/// Manages begining and finising of transcript pipeline.
+/// Manages beginning and finishing of transcript pipeline.
 pub trait TranscriptWriterBuffer<W: Write, C: CurveAffine, E: EncodedChallenge<C>>:
     TranscriptWrite<C, E>
 {


### PR DESCRIPTION
fix some typos in comments