### PR TITLE
chore: g & g_lagrange assignment for ParamsKZG

### DIFF
--- a/halo2_proofs/src/poly/kzg/commitment.rs
+++ b/halo2_proofs/src/poly/kzg/commitment.rs
@@ -141,7 +141,7 @@ where
         Self {
             k,
             n: 1 << k,
-            g,
+            g.clone(),
             g_lagrange: match g_lagrange {
                 Some(g_l) => g_l,
                 None => g_to_lagrange(g.iter().map(PrimeCurveAffine::to_curve).collect(), k),

--- a/halo2_proofs/src/poly/kzg/commitment.rs
+++ b/halo2_proofs/src/poly/kzg/commitment.rs
@@ -141,11 +141,11 @@ where
         Self {
             k,
             n: 1 << k,
+            g,
             g_lagrange: match g_lagrange {
                 Some(g_l) => g_l,
                 None => g_to_lagrange(g.iter().map(PrimeCurveAffine::to_curve).collect(), k),
             },
-            g,
             g2,
             s_g2,
         }


### PR DESCRIPTION
g and g_lagrange is swapped for correctness.