### PR TITLE
chores: adjust domain api visibility

### DIFF
--- a/halo2_proofs/src/poly/domain.rs
+++ b/halo2_proofs/src/poly/domain.rs
@@ -186,7 +186,7 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
 
     /// Returns an empty (zero) polynomial in the Lagrange coefficient basis, with
     /// deferred inversions.
-    pub(crate) fn empty_lagrange_assigned(&self) -> Polynomial<Assigned<F>, LagrangeCoeff> {
+    pub fn empty_lagrange_assigned(&self) -> Polynomial<Assigned<F>, LagrangeCoeff> {
         Polynomial {
             values: vec![F::ZERO.into(); self.n as usize],
             _marker: PhantomData,


### PR DESCRIPTION
### Context

Recently in zkEVM proof chunk we introduce `user-challenge` to derive application level challenge by random oracle with selected columns commitments. To derive commitment of advices column, we follow halo2 create_proof api, where one of the halo2 domain api need to adjust visibility to public, since this is the only way to derive `Polynomial<Assigned<F>, LagrangeCoeff>` type.


Furthermore, another domain api `fn empty_lagrange` is also public so it make sense for `fn empty_lagrange_assigned` as well.

reference usecase zkEVM PR https://github.com/privacy-scaling-explorations/zkevm-circuits/pull/1709 

