### PR TITLE
Add check for `k` in vk deserialization.

### DIFF
--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -80,7 +80,7 @@ where
         // Version byte that will be checked on read.
         writer.write_all(&[VERSION])?;
         let k = &self.domain.k();
-        assert!(*k <= C::Scalar::S as u32);
+        assert!(*k <= C::Scalar::S);
         // k value fits in 1 byte
         writer.write_all(&[*k as u8])?;
         writer.write_all(&[self.compress_selectors as u8])?;


### PR DESCRIPTION
# Description

The desiarlization of a verifier key involves recovering the circuit log size parameter `k`. This value is read directly as a `u32` without any checks. Its maximum allowed value is then `~2^( 2^32)`, which can become an issue since it is used later in the deseriarlization  to process the selector by initializing vectors of size `2^k`:
https://github.com/privacy-scaling-explorations/halo2/blob/3550ab07b1c791e01e61b4dff03607a5343b78de/halo2_proofs/src/plonk.rs#L152


There is a theoretic limitation of this value by the 2-adicity of the scalar field of the curves we use. All of the curves have a 2-adicity `<=32`.

# Changes
~Add a check that ensures `k <=32`.~
Add a check in key serialization and deserialization that ensures `k` <= `C::Scalar::S` (the field 2-adacity).