### PR TITLE
Expose mockprover data

### DIFF
--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -319,9 +319,12 @@ pub struct MockProver<F: Field> {
     current_phase: sealed::Phase,
 }
 
+/// Instance Value
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum InstanceValue<F: Field> {
+pub enum InstanceValue<F: Field> {
+    /// Assigned instance value
     Assigned(F),
+    /// Padding
     Padding,
 }
 
@@ -1713,7 +1716,7 @@ impl<F: FromUniformBytes<64> + Ord> MockProver<F> {
     }
 
     /// Returns the list of Instance Columns used within a MockProver instance and the associated values contained on each Cell.
-    pub fn instance(&self) -> &Vec<Vec<F>> {
+    pub fn instance(&self) -> &Vec<Vec<InstanceValue<F>>> {
         &self.instance
     }
 

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -1687,9 +1687,34 @@ impl<F: FromUniformBytes<64> + Ord> MockProver<F> {
         }
     }
 
+    /// Returns the constraint system
+    pub fn cs(&self) -> &ConstraintSystem<F> {
+        &self.cs
+    }
+
+    /// Returns the usable rows
+    pub fn usable_rows(&self) -> &Range<usize> {
+        &self.usable_rows
+    }
+
+    /// Returns the list of Advice Columns used within a MockProver instance and the associated values contained on each Cell.
+    pub fn advice(&self) -> &Vec<Vec<CellValue<F>>> {
+        &self.advice
+    }
+
     /// Returns the list of Fixed Columns used within a MockProver instance and the associated values contained on each Cell.
     pub fn fixed(&self) -> &Vec<Vec<CellValue<F>>> {
         &self.fixed
+    }
+
+    /// Returns the list of Selector Columns used within a MockProver instance and the associated values contained on each Cell.
+    pub fn selectors(&self) -> &Vec<Vec<bool>> {
+        &self.selectors
+    }
+
+    /// Returns the list of Instance Columns used within a MockProver instance and the associated values contained on each Cell.
+    pub fn instance(&self) -> &Vec<Vec<F>> {
+        &self.instance
     }
 
     /// Returns the permutation argument (`Assembly`) used within a MockProver instance.


### PR DESCRIPTION
This information is useful for debugging tools that inspect advice cells and more data.