### PR TITLE
Add derive_serde feature

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -95,6 +95,7 @@ sanity-checks = []
 batch = ["rand_core/getrandom"]
 circuit-params = []
 cost-estimator = ["serde", "serde_derive"]
+derive_serde = ["halo2curves/derive_serde"]
 
 [lib]
 bench = false


### PR DESCRIPTION
Sometimes we want to be able to serialize Fr. However feature `derive_serde` is available on `halo2curves`. This PR adds a feature `derive_serde` to halo2_proofs which activates `derive_serde` feature on `halo2curves`.