### PR TITLE
refactor: move the `halo2_common::arithmetic` to `halo2_backend`(post fe-be split)

### DIFF
--- a/halo2_backend/src/arithmetic.rs
+++ b/halo2_backend/src/arithmetic.rs
@@ -89,7 +89,7 @@ fn multiexp_serial<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C], acc: &mut 
                         other += a;
                         other
                     }
-                    Bucket::Projective(a) => other + &a,
+                    Bucket::Projective(a) => other + a,
                 }
             }
         }

--- a/halo2_backend/src/arithmetic.rs
+++ b/halo2_backend/src/arithmetic.rs
@@ -1,11 +1,11 @@
 //! This module provides common utilities, traits and structures for group,
 //! field and polynomial arithmetic.
 
-use super::multicore;
 use group::{
     ff::{BatchInvert, PrimeField},
     Curve, Group, GroupOpsOwned, ScalarMulOwned,
 };
+use halo2_common::multicore;
 pub use halo2_middleware::ff::Field;
 
 pub use halo2curves::{CurveAffine, CurveExt};
@@ -531,7 +531,7 @@ pub fn powers<F: Field>(base: F) -> impl Iterator<Item = F> {
 use rand_core::OsRng;
 
 #[cfg(test)]
-use crate::halo2curves::pasta::Fp;
+use halo2curves::pasta::Fp;
 
 #[test]
 fn test_lagrange_interpolate() {

--- a/halo2_backend/src/helpers.rs
+++ b/halo2_backend/src/helpers.rs
@@ -6,7 +6,7 @@ use std::io;
 pub(crate) use halo2_common::helpers::{pack, unpack, CurveRead, SerdeCurveAffine};
 
 /// Reads a vector of polynomials from buffer
-pub fn read_polynomial_vec<R: io::Read, F: SerdePrimeField, B>(
+pub(crate) fn read_polynomial_vec<R: io::Read, F: SerdePrimeField, B>(
     reader: &mut R,
     format: SerdeFormat,
 ) -> io::Result<Vec<Polynomial<F, B>>> {
@@ -20,7 +20,7 @@ pub fn read_polynomial_vec<R: io::Read, F: SerdePrimeField, B>(
 }
 
 /// Writes a slice of polynomials to buffer
-pub fn write_polynomial_slice<W: io::Write, F: SerdePrimeField, B>(
+pub(crate) fn write_polynomial_slice<W: io::Write, F: SerdePrimeField, B>(
     slice: &[Polynomial<F, B>],
     writer: &mut W,
     format: SerdeFormat,
@@ -33,7 +33,7 @@ pub fn write_polynomial_slice<W: io::Write, F: SerdePrimeField, B>(
 }
 
 /// Gets the total number of bytes of a slice of polynomials, assuming all polynomials are the same length
-pub fn polynomial_slice_byte_length<F: PrimeField, B>(slice: &[Polynomial<F, B>]) -> usize {
+pub(crate) fn polynomial_slice_byte_length<F: PrimeField, B>(slice: &[Polynomial<F, B>]) -> usize {
     let field_len = F::default().to_repr().as_ref().len();
     4 + slice.len() * (4 + field_len * slice.get(0).map(|poly| poly.len()).unwrap_or(0))
 }

--- a/halo2_backend/src/lib.rs
+++ b/halo2_backend/src/lib.rs
@@ -1,9 +1,9 @@
+pub mod arithmetic;
 mod helpers;
 pub mod plonk;
 pub mod poly;
 
 // Internal re-exports
-pub use halo2_common::arithmetic;
 pub use halo2_common::circuit;
 pub use halo2_common::multicore;
 pub use halo2_common::transcript;

--- a/halo2_backend/src/plonk.rs
+++ b/halo2_backend/src/plonk.rs
@@ -183,7 +183,6 @@ where
     }
 
     /// Writes a verifying key to a vector of bytes using [`Self::write`].
-    #[allow(unused)]
     pub fn to_bytes(&self, format: SerdeFormat) -> Vec<u8> {
         let mut bytes = Vec::<u8>::with_capacity(self.bytes_length(format));
         Self::write(self, &mut bytes, format).expect("Writing to vector should not fail");
@@ -191,7 +190,6 @@ where
     }
 
     /// Reads a verification key from a slice of bytes using [`Self::read`].
-    #[allow(unused)]
     pub fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(
         mut bytes: &[u8],
         format: SerdeFormat,
@@ -292,7 +290,6 @@ impl<C: CurveAffine> VerifyingKey<C> {
     }
 
     /// Returns `VerifyingKey` of permutation
-    #[allow(unused)]
     pub fn permutation(&self) -> &permutation::VerifyingKey<C> {
         &self.permutation
     }
@@ -303,7 +300,6 @@ impl<C: CurveAffine> VerifyingKey<C> {
     }
 
     /// Returns representative of this `VerifyingKey` in transcripts
-    #[allow(unused)]
     pub fn transcript_repr(&self) -> C::Scalar {
         self.transcript_repr
     }

--- a/halo2_backend/src/plonk.rs
+++ b/halo2_backend/src/plonk.rs
@@ -62,11 +62,7 @@ where
     /// - Otherwise: Writes an uncompressed curve element with coordinates in Montgomery form
     /// Writes a field element into raw bytes in its internal Montgomery representation,
     /// WITHOUT performing the expensive Montgomery reduction.
-    pub(crate) fn write<W: io::Write>(
-        &self,
-        writer: &mut W,
-        format: SerdeFormat,
-    ) -> io::Result<()> {
+    pub fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
         // Version byte that will be checked on read.
         writer.write_all(&[VERSION])?;
         let k = &self.domain.k();
@@ -103,7 +99,7 @@ where
     /// Checks that field elements are less than modulus, and then checks that the point is on the curve.
     /// - `RawBytesUnchecked`: Reads an uncompressed curve element with coordinates in Montgomery form;
     /// does not perform any checks
-    pub(crate) fn read<R: io::Read, ConcreteCircuit: Circuit<C::Scalar>>(
+    pub fn read<R: io::Read, ConcreteCircuit: Circuit<C::Scalar>>(
         reader: &mut R,
         format: SerdeFormat,
         #[cfg(feature = "circuit-params")] params: ConcreteCircuit::Params,
@@ -188,7 +184,7 @@ where
 
     /// Writes a verifying key to a vector of bytes using [`Self::write`].
     #[allow(unused)]
-    pub(crate) fn to_bytes(&self, format: SerdeFormat) -> Vec<u8> {
+    pub fn to_bytes(&self, format: SerdeFormat) -> Vec<u8> {
         let mut bytes = Vec::<u8>::with_capacity(self.bytes_length(format));
         Self::write(self, &mut bytes, format).expect("Writing to vector should not fail");
         bytes
@@ -196,7 +192,7 @@ where
 
     /// Reads a verification key from a slice of bytes using [`Self::read`].
     #[allow(unused)]
-    pub(crate) fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(
+    pub fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(
         mut bytes: &[u8],
         format: SerdeFormat,
         #[cfg(feature = "circuit-params")] params: ConcreteCircuit::Params,
@@ -297,18 +293,18 @@ impl<C: CurveAffine> VerifyingKey<C> {
 
     /// Returns `VerifyingKey` of permutation
     #[allow(unused)]
-    pub(crate) fn permutation(&self) -> &permutation::VerifyingKey<C> {
+    pub fn permutation(&self) -> &permutation::VerifyingKey<C> {
         &self.permutation
     }
 
     /// Returns `ConstraintSystem`
-    pub(crate) fn cs(&self) -> &ConstraintSystem<C::Scalar> {
+    pub fn cs(&self) -> &ConstraintSystem<C::Scalar> {
         &self.cs
     }
 
     /// Returns representative of this `VerifyingKey` in transcripts
     #[allow(unused)]
-    pub(crate) fn transcript_repr(&self) -> C::Scalar {
+    pub fn transcript_repr(&self) -> C::Scalar {
         self.transcript_repr
     }
 }

--- a/halo2_backend/src/plonk.rs
+++ b/halo2_backend/src/plonk.rs
@@ -62,7 +62,7 @@ where
     /// - Otherwise: Writes an uncompressed curve element with coordinates in Montgomery form
     /// Writes a field element into raw bytes in its internal Montgomery representation,
     /// WITHOUT performing the expensive Montgomery reduction.
-    pub fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
+    pub(crate) fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
         // Version byte that will be checked on read.
         writer.write_all(&[VERSION])?;
         let k = &self.domain.k();
@@ -99,7 +99,7 @@ where
     /// Checks that field elements are less than modulus, and then checks that the point is on the curve.
     /// - `RawBytesUnchecked`: Reads an uncompressed curve element with coordinates in Montgomery form;
     /// does not perform any checks
-    pub fn read<R: io::Read, ConcreteCircuit: Circuit<C::Scalar>>(
+    pub(crate) fn read<R: io::Read, ConcreteCircuit: Circuit<C::Scalar>>(
         reader: &mut R,
         format: SerdeFormat,
         #[cfg(feature = "circuit-params")] params: ConcreteCircuit::Params,
@@ -183,14 +183,14 @@ where
     }
 
     /// Writes a verifying key to a vector of bytes using [`Self::write`].
-    pub fn to_bytes(&self, format: SerdeFormat) -> Vec<u8> {
+    pub(crate) fn to_bytes(&self, format: SerdeFormat) -> Vec<u8> {
         let mut bytes = Vec::<u8>::with_capacity(self.bytes_length(format));
         Self::write(self, &mut bytes, format).expect("Writing to vector should not fail");
         bytes
     }
 
     /// Reads a verification key from a slice of bytes using [`Self::read`].
-    pub fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(
+    pub(crate) fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(
         mut bytes: &[u8],
         format: SerdeFormat,
         #[cfg(feature = "circuit-params")] params: ConcreteCircuit::Params,
@@ -290,17 +290,17 @@ impl<C: CurveAffine> VerifyingKey<C> {
     }
 
     /// Returns `VerifyingKey` of permutation
-    pub fn permutation(&self) -> &permutation::VerifyingKey<C> {
+    pub(crate) fn permutation(&self) -> &permutation::VerifyingKey<C> {
         &self.permutation
     }
 
     /// Returns `ConstraintSystem`
-    pub fn cs(&self) -> &ConstraintSystem<C::Scalar> {
+    pub(crate) fn cs(&self) -> &ConstraintSystem<C::Scalar> {
         &self.cs
     }
 
     /// Returns representative of this `VerifyingKey` in transcripts
-    pub fn transcript_repr(&self) -> C::Scalar {
+    pub(crate) fn transcript_repr(&self) -> C::Scalar {
         self.transcript_repr
     }
 }

--- a/halo2_backend/src/plonk.rs
+++ b/halo2_backend/src/plonk.rs
@@ -1,6 +1,7 @@
 use blake2b_simd::Params as Blake2bParams;
 use group::ff::{Field, FromUniformBytes, PrimeField};
 
+use crate::arithmetic::CurveAffine;
 use crate::helpers::{
     self, polynomial_slice_byte_length, read_polynomial_vec, write_polynomial_slice,
     SerdeCurveAffine, SerdePrimeField,
@@ -10,7 +11,6 @@ use crate::poly::{
     Polynomial,
 };
 use evaluation::Evaluator;
-use halo2_common::arithmetic::CurveAffine;
 use halo2_common::plonk::{Circuit, ConstraintSystem, PinnedConstraintSystem};
 use halo2_common::transcript::{EncodedChallenge, Transcript};
 use halo2_common::SerdeFormat;

--- a/halo2_backend/src/plonk.rs
+++ b/halo2_backend/src/plonk.rs
@@ -187,6 +187,7 @@ where
     }
 
     /// Writes a verifying key to a vector of bytes using [`Self::write`].
+    #[allow(unused)]
     pub(crate) fn to_bytes(&self, format: SerdeFormat) -> Vec<u8> {
         let mut bytes = Vec::<u8>::with_capacity(self.bytes_length(format));
         Self::write(self, &mut bytes, format).expect("Writing to vector should not fail");
@@ -194,6 +195,7 @@ where
     }
 
     /// Reads a verification key from a slice of bytes using [`Self::read`].
+    #[allow(unused)]
     pub(crate) fn from_bytes<ConcreteCircuit: Circuit<C::Scalar>>(
         mut bytes: &[u8],
         format: SerdeFormat,
@@ -294,6 +296,7 @@ impl<C: CurveAffine> VerifyingKey<C> {
     }
 
     /// Returns `VerifyingKey` of permutation
+    #[allow(unused)]
     pub(crate) fn permutation(&self) -> &permutation::VerifyingKey<C> {
         &self.permutation
     }
@@ -304,6 +307,7 @@ impl<C: CurveAffine> VerifyingKey<C> {
     }
 
     /// Returns representative of this `VerifyingKey` in transcripts
+    #[allow(unused)]
     pub(crate) fn transcript_repr(&self) -> C::Scalar {
         self.transcript_repr
     }

--- a/halo2_backend/src/plonk.rs
+++ b/halo2_backend/src/plonk.rs
@@ -62,7 +62,11 @@ where
     /// - Otherwise: Writes an uncompressed curve element with coordinates in Montgomery form
     /// Writes a field element into raw bytes in its internal Montgomery representation,
     /// WITHOUT performing the expensive Montgomery reduction.
-    pub(crate) fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
+    pub(crate) fn write<W: io::Write>(
+        &self,
+        writer: &mut W,
+        format: SerdeFormat,
+    ) -> io::Result<()> {
         // Version byte that will be checked on read.
         writer.write_all(&[VERSION])?;
         let k = &self.domain.k();

--- a/halo2_backend/src/plonk/lookup.rs
+++ b/halo2_backend/src/plonk/lookup.rs
@@ -1,4 +1,4 @@
-pub mod prover;
-pub mod verifier;
+pub(crate) mod prover;
+pub(crate) mod verifier;
 
 pub use halo2_common::plonk::lookup::Argument;

--- a/halo2_backend/src/plonk/permutation.rs
+++ b/halo2_backend/src/plonk/permutation.rs
@@ -23,7 +23,6 @@ pub struct VerifyingKey<C: CurveAffine> {
 
 impl<C: CurveAffine> VerifyingKey<C> {
     /// Returns commitments of sigma polynomials
-    #[allow(unused)]
     pub fn commitments(&self) -> &Vec<C> {
         &self.commitments
     }

--- a/halo2_backend/src/plonk/permutation.rs
+++ b/halo2_backend/src/plonk/permutation.rs
@@ -17,7 +17,7 @@ pub mod verifier;
 
 /// The verifying key for a single permutation argument.
 #[derive(Clone, Debug)]
-pub(crate) struct VerifyingKey<C: CurveAffine> {
+pub struct VerifyingKey<C: CurveAffine> {
     commitments: Vec<C>,
 }
 

--- a/halo2_backend/src/plonk/permutation.rs
+++ b/halo2_backend/src/plonk/permutation.rs
@@ -17,7 +17,7 @@ pub mod verifier;
 
 /// The verifying key for a single permutation argument.
 #[derive(Clone, Debug)]
-pub struct VerifyingKey<C: CurveAffine> {
+pub(crate) struct VerifyingKey<C: CurveAffine> {
     commitments: Vec<C>,
 }
 
@@ -61,7 +61,7 @@ impl<C: CurveAffine> VerifyingKey<C> {
 
 /// The proving key for a single permutation argument.
 #[derive(Clone, Debug)]
-pub struct ProvingKey<C: CurveAffine> {
+pub(crate) struct ProvingKey<C: CurveAffine> {
     permutations: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
     polys: Vec<Polynomial<C::Scalar, Coeff>>,
     pub(super) cosets: Vec<Polynomial<C::Scalar, ExtendedLagrangeCoeff>>,

--- a/halo2_backend/src/plonk/permutation.rs
+++ b/halo2_backend/src/plonk/permutation.rs
@@ -23,6 +23,7 @@ pub(crate) struct VerifyingKey<C: CurveAffine> {
 
 impl<C: CurveAffine> VerifyingKey<C> {
     /// Returns commitments of sigma polynomials
+    #[allow(unused)]
     pub fn commitments(&self) -> &Vec<C> {
         &self.commitments
     }

--- a/halo2_backend/src/plonk/permutation/prover.rs
+++ b/halo2_backend/src/plonk/permutation/prover.rs
@@ -33,7 +33,7 @@ pub(crate) struct Committed<C: CurveAffine> {
     pub(crate) sets: Vec<CommittedSet<C>>,
 }
 
-pub struct ConstructedSet<C: CurveAffine> {
+pub(crate) struct ConstructedSet<C: CurveAffine> {
     permutation_product_poly: Polynomial<C::Scalar, Coeff>,
     permutation_product_blind: Blind<C::Scalar>,
 }

--- a/halo2_backend/src/plonk/permutation/verifier.rs
+++ b/halo2_backend/src/plonk/permutation/verifier.rs
@@ -12,22 +12,22 @@ use halo2_common::plonk::{ChallengeBeta, ChallengeGamma, ChallengeX, Error};
 use halo2_middleware::circuit::Any;
 use halo2_middleware::poly::Rotation;
 
-pub struct Committed<C: CurveAffine> {
+pub(crate) struct Committed<C: CurveAffine> {
     permutation_product_commitments: Vec<C>,
 }
 
-pub struct EvaluatedSet<C: CurveAffine> {
+pub(crate) struct EvaluatedSet<C: CurveAffine> {
     permutation_product_commitment: C,
     permutation_product_eval: C::Scalar,
     permutation_product_next_eval: C::Scalar,
     permutation_product_last_eval: Option<C::Scalar>,
 }
 
-pub struct CommonEvaluated<C: CurveAffine> {
+pub(crate) struct CommonEvaluated<C: CurveAffine> {
     permutation_evals: Vec<C::Scalar>,
 }
 
-pub struct Evaluated<C: CurveAffine> {
+pub(crate) struct Evaluated<C: CurveAffine> {
     sets: Vec<EvaluatedSet<C>>,
 }
 

--- a/halo2_backend/src/plonk/prover.rs
+++ b/halo2_backend/src/plonk/prover.rs
@@ -4,6 +4,7 @@ use rand_core::RngCore;
 use std::collections::{BTreeSet, HashSet};
 use std::{collections::HashMap, iter};
 
+use crate::arithmetic::{eval_polynomial, CurveAffine};
 use crate::plonk::lookup::prover::lookup_commit_permuted;
 use crate::plonk::permutation::prover::permutation_commit;
 use crate::plonk::shuffle::prover::shuffle_commit_product;
@@ -12,12 +13,11 @@ use crate::poly::{
     commitment::{Blind, CommitmentScheme, Params, Prover},
     Basis, Coeff, LagrangeCoeff, Polynomial, ProverQuery,
 };
+
+use group::prime::PrimeCurveAffine;
 use halo2_common::plonk::{
     circuit::sealed, ChallengeBeta, ChallengeGamma, ChallengeTheta, ChallengeX, ChallengeY, Error,
 };
-
-use group::prime::PrimeCurveAffine;
-use halo2_common::arithmetic::{eval_polynomial, CurveAffine};
 use halo2_common::transcript::{EncodedChallenge, TranscriptWrite};
 
 /// Collection of instance data used during proving for a single circuit proof.

--- a/halo2_backend/src/plonk/shuffle.rs
+++ b/halo2_backend/src/plonk/shuffle.rs
@@ -1,4 +1,4 @@
-pub mod prover;
-pub mod verifier;
+pub(crate) mod prover;
+pub(crate) mod verifier;
 
 pub use halo2_common::plonk::shuffle::Argument;

--- a/halo2_backend/src/plonk/shuffle/verifier.rs
+++ b/halo2_backend/src/plonk/shuffle/verifier.rs
@@ -11,11 +11,11 @@ use halo2_common::plonk::{ChallengeGamma, ChallengeTheta, ChallengeX, Error, Exp
 use halo2_middleware::ff::Field;
 use halo2_middleware::poly::Rotation;
 
-pub struct Committed<C: CurveAffine> {
+pub(crate) struct Committed<C: CurveAffine> {
     product_commitment: C,
 }
 
-pub struct Evaluated<C: CurveAffine> {
+pub(crate) struct Evaluated<C: CurveAffine> {
     committed: Committed<C>,
     product_eval: C::Scalar,
     product_next_eval: C::Scalar,

--- a/halo2_backend/src/poly.rs
+++ b/halo2_backend/src/poly.rs
@@ -172,7 +172,7 @@ impl<F, B> Polynomial<F, B> {
 
 impl<F: SerdePrimeField, B> Polynomial<F, B> {
     /// Reads polynomial from buffer using `SerdePrimeField::read`.  
-    pub fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self> {
+    pub(crate) fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self> {
         let mut poly_len = [0u8; 4];
         reader.read_exact(&mut poly_len)?;
         let poly_len = u32::from_be_bytes(poly_len);
@@ -187,7 +187,7 @@ impl<F: SerdePrimeField, B> Polynomial<F, B> {
     }
 
     /// Writes polynomial to buffer using `SerdePrimeField::write`.  
-    pub fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
+    pub(crate) fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
         writer.write_all(&(self.values.len() as u32).to_be_bytes())?;
         for value in self.values.iter() {
             value.write(writer, format)?;

--- a/halo2_backend/src/poly.rs
+++ b/halo2_backend/src/poly.rs
@@ -187,7 +187,11 @@ impl<F: SerdePrimeField, B> Polynomial<F, B> {
     }
 
     /// Writes polynomial to buffer using `SerdePrimeField::write`.  
-    pub(crate) fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
+    pub(crate) fn write<W: io::Write>(
+        &self,
+        writer: &mut W,
+        format: SerdeFormat,
+    ) -> io::Result<()> {
         writer.write_all(&(self.values.len() as u32).to_be_bytes())?;
         for value in self.values.iter() {
             value.write(writer, format)?;

--- a/halo2_backend/src/poly/ipa/commitment.rs
+++ b/halo2_backend/src/poly/ipa/commitment.rs
@@ -23,12 +23,12 @@ use std::io;
 /// Public parameters for IPA commitment scheme
 #[derive(Debug, Clone)]
 pub struct ParamsIPA<C: CurveAffine> {
-    pub k: u32,
-    pub n: u64,
-    pub g: Vec<C>,
-    pub g_lagrange: Vec<C>,
-    pub w: C,
-    pub u: C,
+    pub(crate) k: u32,
+    pub(crate) n: u64,
+    pub(crate) g: Vec<C>,
+    pub(crate) g_lagrange: Vec<C>,
+    pub(crate) w: C,
+    pub(crate) u: C,
 }
 
 /// Concrete IPA commitment scheme

--- a/halo2_backend/src/poly/ipa/msm.rs
+++ b/halo2_backend/src/poly/ipa/msm.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 /// A multiscalar multiplication in the polynomial commitment scheme
 #[derive(Debug, Clone)]
 pub struct MSMIPA<'params, C: CurveAffine> {
-    pub params: &'params ParamsVerifierIPA<C>,
+    pub(crate) params: &'params ParamsVerifierIPA<C>,
     g_scalars: Option<Vec<C::Scalar>>,
     w_scalar: Option<C::Scalar>,
     u_scalar: Option<C::Scalar>,

--- a/halo2_backend/src/poly/ipa/multiopen.rs
+++ b/halo2_backend/src/poly/ipa/multiopen.rs
@@ -37,10 +37,10 @@ type ChallengeX4<F> = ChallengeScalar<F, X4>;
 
 #[derive(Debug)]
 struct CommitmentData<F, T: PartialEq> {
-    pub commitment: T,
-    pub set_index: usize,
-    pub point_indices: Vec<usize>,
-    pub evals: Vec<F>,
+    pub(crate) commitment: T,
+    pub(crate) set_index: usize,
+    pub(crate) point_indices: Vec<usize>,
+    pub(crate) evals: Vec<F>,
 }
 
 impl<F, T: PartialEq> CommitmentData<F, T> {

--- a/halo2_backend/src/poly/ipa/multiopen/prover.rs
+++ b/halo2_backend/src/poly/ipa/multiopen/prover.rs
@@ -16,7 +16,7 @@ use std::marker::PhantomData;
 /// IPA multi-open prover
 #[derive(Debug)]
 pub struct ProverIPA<'params, C: CurveAffine> {
-    pub params: &'params ParamsIPA<C>,
+    pub(crate) params: &'params ParamsIPA<C>,
 }
 
 impl<'params, C: CurveAffine> Prover<'params, IPACommitmentScheme<C>> for ProverIPA<'params, C> {

--- a/halo2_backend/src/poly/ipa/strategy.rs
+++ b/halo2_backend/src/poly/ipa/strategy.rs
@@ -17,10 +17,10 @@ use rand_core::OsRng;
 /// Wrapper for verification accumulator
 #[derive(Debug, Clone)]
 pub struct GuardIPA<'params, C: CurveAffine> {
-    pub msm: MSMIPA<'params, C>,
-    pub neg_c: C::Scalar,
-    pub u: Vec<C::Scalar>,
-    pub u_packed: Vec<C::Scalar>,
+    pub(crate) msm: MSMIPA<'params, C>,
+    pub(crate) neg_c: C::Scalar,
+    pub(crate) u: Vec<C::Scalar>,
+    pub(crate) u_packed: Vec<C::Scalar>,
 }
 
 /// An accumulator instance consisting of an evaluation claim and a proof.

--- a/halo2_backend/src/poly/kzg/commitment.rs
+++ b/halo2_backend/src/poly/kzg/commitment.rs
@@ -19,12 +19,12 @@ use super::msm::MSMKZG;
 /// These are the public parameters for the polynomial commitment scheme.
 #[derive(Debug, Clone)]
 pub struct ParamsKZG<E: Engine> {
-    pub k: u32,
-    pub n: u64,
-    pub g: Vec<E::G1Affine>,
-    pub g_lagrange: Vec<E::G1Affine>,
-    pub g2: E::G2Affine,
-    pub s_g2: E::G2Affine,
+    pub(crate) k: u32,
+    pub(crate) n: u64,
+    pub(crate) g: Vec<E::G1Affine>,
+    pub(crate) g_lagrange: Vec<E::G1Affine>,
+    pub(crate) g2: E::G2Affine,
+    pub(crate) s_g2: E::G2Affine,
 }
 
 /// Umbrella commitment scheme construction for all KZG variants

--- a/halo2_backend/src/poly/kzg/msm.rs
+++ b/halo2_backend/src/poly/kzg/msm.rs
@@ -18,8 +18,8 @@ where
     E::G1Affine: CurveAffine<ScalarExt = <E as Engine>::Fr, CurveExt = <E as Engine>::G1>,
     E::G1: CurveExt<AffineExt = E::G1Affine>,
 {
-    pub scalars: Vec<E::Fr>,
-    pub bases: Vec<E::G1>,
+    pub(crate) scalars: Vec<E::Fr>,
+    pub(crate) bases: Vec<E::G1>,
 }
 
 impl<E: Engine> MSMKZG<E>
@@ -95,7 +95,7 @@ where
 
 /// A projective point collector
 #[derive(Debug, Clone)]
-pub struct PreMSM<E: Engine>
+pub(crate) struct PreMSM<E: Engine>
 where
     E::G1Affine: CurveAffine<ScalarExt = <E as Engine>::Fr, CurveExt = <E as Engine>::G1>,
     E::G1: CurveExt<AffineExt = E::G1Affine>,
@@ -120,7 +120,7 @@ where
     E::G1Affine: CurveAffine<ScalarExt = <E as Engine>::Fr, CurveExt = <E as Engine>::G1>,
     E::G1: CurveExt<AffineExt = E::G1Affine>,
 {
-    pub fn normalize(self) -> MSMKZG<E> {
+    pub(crate) fn normalize(self) -> MSMKZG<E> {
         let (scalars, bases) = self
             .projectives_msms
             .into_iter()
@@ -133,7 +133,7 @@ where
         }
     }
 
-    pub fn add_msm(&mut self, other: MSMKZG<E>) {
+    pub(crate) fn add_msm(&mut self, other: MSMKZG<E>) {
         self.projectives_msms.push(other);
     }
 }
@@ -155,9 +155,9 @@ where
     E::G1Affine: CurveAffine<ScalarExt = <E as Engine>::Fr, CurveExt = <E as Engine>::G1>,
     E::G1: CurveExt<AffineExt = E::G1Affine>,
 {
-    pub params: &'a ParamsKZG<E>,
-    pub left: MSMKZG<E>,
-    pub right: MSMKZG<E>,
+    pub(crate) params: &'a ParamsKZG<E>,
+    pub(crate) left: MSMKZG<E>,
+    pub(crate) right: MSMKZG<E>,
 }
 
 impl<'a, E: MultiMillerLoop + Debug> DualMSM<'a, E>

--- a/halo2_backend/src/poly/kzg/strategy.rs
+++ b/halo2_backend/src/poly/kzg/strategy.rs
@@ -25,7 +25,7 @@ where
     E::G1Affine: CurveAffine<ScalarExt = <E as Engine>::Fr, CurveExt = <E as Engine>::G1>,
     E::G1: CurveExt<AffineExt = E::G1Affine>,
 {
-    pub msm_accumulator: DualMSM<'params, E>,
+    pub(crate) msm_accumulator: DualMSM<'params, E>,
 }
 
 /// Define accumulator type as `DualMSM`
@@ -45,7 +45,7 @@ where
     E::G1Affine: CurveAffine<ScalarExt = <E as Engine>::Fr, CurveExt = <E as Engine>::G1>,
     E::G1: CurveExt<AffineExt = E::G1Affine>,
 {
-    pub fn new(msm_accumulator: DualMSM<'params, E>) -> Self {
+    pub(crate) fn new(msm_accumulator: DualMSM<'params, E>) -> Self {
         Self { msm_accumulator }
     }
 }
@@ -57,7 +57,7 @@ where
     E::G1Affine: CurveAffine<ScalarExt = <E as Engine>::Fr, CurveExt = <E as Engine>::G1>,
     E::G1: CurveExt<AffineExt = E::G1Affine>,
 {
-    pub msm_accumulator: DualMSM<'params, E>,
+    pub(crate) msm_accumulator: DualMSM<'params, E>,
 }
 
 impl<'params, E: MultiMillerLoop + Debug> AccumulatorStrategy<'params, E>
@@ -66,14 +66,14 @@ where
     E::G1: CurveExt<AffineExt = E::G1Affine>,
 {
     /// Constructs an empty batch verifier
-    pub fn new(params: &'params ParamsKZG<E>) -> Self {
+    pub(crate) fn new(params: &'params ParamsKZG<E>) -> Self {
         AccumulatorStrategy {
             msm_accumulator: DualMSM::new(params),
         }
     }
 
     /// Constructs and initialized new batch verifier
-    pub fn with(msm_accumulator: DualMSM<'params, E>) -> Self {
+    pub(crate) fn with(msm_accumulator: DualMSM<'params, E>) -> Self {
         AccumulatorStrategy { msm_accumulator }
     }
 }

--- a/halo2_backend/src/poly/kzg/strategy.rs
+++ b/halo2_backend/src/poly/kzg/strategy.rs
@@ -73,7 +73,6 @@ where
     }
 
     /// Constructs and initialized new batch verifier
-    #[allow(unused)]
     pub(crate) fn with(msm_accumulator: DualMSM<'params, E>) -> Self {
         AccumulatorStrategy { msm_accumulator }
     }

--- a/halo2_backend/src/poly/kzg/strategy.rs
+++ b/halo2_backend/src/poly/kzg/strategy.rs
@@ -66,14 +66,14 @@ where
     E::G1: CurveExt<AffineExt = E::G1Affine>,
 {
     /// Constructs an empty batch verifier
-    pub(crate) fn new(params: &'params ParamsKZG<E>) -> Self {
+    pub fn new(params: &'params ParamsKZG<E>) -> Self {
         AccumulatorStrategy {
             msm_accumulator: DualMSM::new(params),
         }
     }
 
     /// Constructs and initialized new batch verifier
-    pub(crate) fn with(msm_accumulator: DualMSM<'params, E>) -> Self {
+    pub fn with(msm_accumulator: DualMSM<'params, E>) -> Self {
         AccumulatorStrategy { msm_accumulator }
     }
 }
@@ -85,7 +85,7 @@ where
     E::G1Affine: CurveAffine<ScalarExt = <E as Engine>::Fr, CurveExt = <E as Engine>::G1>,
     E::G1: CurveExt<AffineExt = E::G1Affine>,
 {
-    pub msm: DualMSM<'params, E>,
+    pub(crate) msm: DualMSM<'params, E>,
 }
 
 impl<'params, E: MultiMillerLoop + Debug> SingleStrategy<'params, E>

--- a/halo2_backend/src/poly/kzg/strategy.rs
+++ b/halo2_backend/src/poly/kzg/strategy.rs
@@ -73,6 +73,7 @@ where
     }
 
     /// Constructs and initialized new batch verifier
+    #[allow(unused)]
     pub(crate) fn with(msm_accumulator: DualMSM<'params, E>) -> Self {
         AccumulatorStrategy { msm_accumulator }
     }

--- a/halo2_backend/src/poly/query.rs
+++ b/halo2_backend/src/poly/query.rs
@@ -20,11 +20,11 @@ pub trait Query<F>: Sized + Clone + Send + Sync {
 #[derive(Debug, Clone, Copy)]
 pub struct ProverQuery<'com, C: CurveAffine> {
     /// Point at which polynomial is queried
-    pub point: C::Scalar,
+    pub(crate) point: C::Scalar,
     /// Coefficients of polynomial
-    pub poly: &'com Polynomial<C::Scalar, Coeff>,
+    pub(crate) poly: &'com Polynomial<C::Scalar, Coeff>,
     /// Blinding factor of polynomial
-    pub blind: Blind<C::Scalar>,
+    pub(crate) blind: Blind<C::Scalar>,
 }
 
 impl<'com, C> ProverQuery<'com, C>
@@ -44,8 +44,8 @@ where
 #[doc(hidden)]
 #[derive(Copy, Clone)]
 pub struct PolynomialPointer<'com, C: CurveAffine> {
-    pub poly: &'com Polynomial<C::Scalar, Coeff>,
-    pub blind: Blind<C::Scalar>,
+    pub(crate) poly: &'com Polynomial<C::Scalar, Coeff>,
+    pub(crate) blind: Blind<C::Scalar>,
 }
 
 impl<'com, C: CurveAffine> PartialEq for PolynomialPointer<'com, C> {
@@ -96,11 +96,11 @@ impl<'com, C: CurveAffine, M: MSM<C>> VerifierQuery<'com, C, M> {
 #[derive(Debug, Clone, Copy)]
 pub struct VerifierQuery<'com, C: CurveAffine, M: MSM<C>> {
     /// Point at which polynomial is queried
-    pub point: C::Scalar,
+    pub(crate) point: C::Scalar,
     /// Commitment to polynomial
-    pub commitment: CommitmentReference<'com, C, M>,
+    pub(crate) commitment: CommitmentReference<'com, C, M>,
     /// Evaluation of polynomial at query point
-    pub eval: C::Scalar,
+    pub(crate) eval: C::Scalar,
 }
 
 impl<'com, C, M> VerifierQuery<'com, C, M>

--- a/halo2_common/src/circuit/floor_planner/v1/strategy.rs
+++ b/halo2_common/src/circuit/floor_planner/v1/strategy.rs
@@ -30,7 +30,7 @@ impl PartialOrd for AllocatedRegion {
 }
 
 /// An area of empty space within a column.
-pub struct EmptySpace {
+pub(crate) struct EmptySpace {
     // The starting position (inclusive) of the empty space.
     start: usize,
     // The ending position (exclusive) of the empty space, or `None` if unbounded.
@@ -38,7 +38,7 @@ pub struct EmptySpace {
 }
 
 impl EmptySpace {
-    pub fn range(&self) -> Option<Range<usize>> {
+    pub(crate) fn range(&self) -> Option<Range<usize>> {
         self.end.map(|end| self.start..end)
     }
 }
@@ -51,7 +51,7 @@ pub struct Allocations(BTreeSet<AllocatedRegion>);
 
 impl Allocations {
     /// Returns the row that forms the unbounded unallocated interval [row, None).
-    pub fn unbounded_interval_start(&self) -> usize {
+    pub(crate) fn unbounded_interval_start(&self) -> usize {
         self.0
             .iter()
             .last()
@@ -62,7 +62,7 @@ impl Allocations {
     /// Return all the *unallocated* nonempty intervals intersecting [start, end).
     ///
     /// `end = None` represents an unbounded end.
-    pub fn free_intervals(
+    pub(crate) fn free_intervals(
         &self,
         start: usize,
         end: Option<usize>,

--- a/halo2_common/src/circuit/table_layouter.rs
+++ b/halo2_common/src/circuit/table_layouter.rs
@@ -118,7 +118,7 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> TableLayouter<F>
     }
 }
 
-pub fn compute_table_lengths<F: Debug>(
+pub(crate) fn compute_table_lengths<F: Debug>(
     default_and_assigned: &HashMap<TableColumn, (DefaultTableValue<F>, Vec<bool>)>,
 ) -> Result<usize, Error> {
     let column_lengths: Result<Vec<_>, Error> = default_and_assigned

--- a/halo2_common/src/lib.rs
+++ b/halo2_common/src/lib.rs
@@ -6,7 +6,6 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(unsafe_code)]
 
-pub mod arithmetic;
 pub mod circuit;
 pub use halo2curves;
 pub mod multicore;

--- a/halo2_common/src/plonk/circuit.rs
+++ b/halo2_common/src/plonk/circuit.rs
@@ -449,7 +449,7 @@ impl TableColumn {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct Challenge {
     pub index: usize,
-    pub phase: u8,
+    pub(crate) phase: u8,
 }
 
 impl Challenge {
@@ -1298,7 +1298,7 @@ impl<F: Field> Product<Self> for Expression<F> {
 /// Represents an index into a vector where each entry corresponds to a distinct
 /// point that polynomials are queried at.
 #[derive(Copy, Clone, Debug)]
-pub struct PointIndex(pub usize);
+pub(crate) struct PointIndex(pub usize);
 
 /// A "virtual cell" is a PLONK cell that has been queried at a particular relative offset
 /// within a custom gate.
@@ -2054,7 +2054,7 @@ impl<F: Field> ConstraintSystem<F> {
         index
     }
 
-    pub fn query_advice_index(&mut self, column: Column<Advice>, at: Rotation) -> usize {
+    pub(crate) fn query_advice_index(&mut self, column: Column<Advice>, at: Rotation) -> usize {
         // Return existing query, if it exists
         for (index, advice_query) in self.advice_queries.iter().enumerate() {
             if advice_query == &(column, at) {
@@ -2097,7 +2097,7 @@ impl<F: Field> ConstraintSystem<F> {
         }
     }
 
-    pub fn get_advice_query_index(&self, column: Column<Advice>, at: Rotation) -> usize {
+    pub(crate) fn get_advice_query_index(&self, column: Column<Advice>, at: Rotation) -> usize {
         for (index, advice_query) in self.advice_queries.iter().enumerate() {
             if advice_query == &(column, at) {
                 return index;
@@ -2107,7 +2107,7 @@ impl<F: Field> ConstraintSystem<F> {
         panic!("get_advice_query_index called for non-existent query");
     }
 
-    pub fn get_fixed_query_index(&self, column: Column<Fixed>, at: Rotation) -> usize {
+    pub(crate) fn get_fixed_query_index(&self, column: Column<Fixed>, at: Rotation) -> usize {
         for (index, fixed_query) in self.fixed_queries.iter().enumerate() {
             if fixed_query == &(column, at) {
                 return index;
@@ -2117,7 +2117,7 @@ impl<F: Field> ConstraintSystem<F> {
         panic!("get_fixed_query_index called for non-existent query");
     }
 
-    pub fn get_instance_query_index(&self, column: Column<Instance>, at: Rotation) -> usize {
+    pub(crate) fn get_instance_query_index(&self, column: Column<Instance>, at: Rotation) -> usize {
         for (index, instance_query) in self.instance_queries.iter().enumerate() {
             if instance_query == &(column, at) {
                 return index;

--- a/halo2_common/src/plonk/lookup.rs
+++ b/halo2_common/src/plonk/lookup.rs
@@ -3,6 +3,7 @@ use halo2_middleware::ff::Field;
 use std::fmt::{self, Debug};
 
 /// Expressions involved in a lookup argument, with a name as metadata.
+/// TODO: possible to move to "halo2_backend", if moved, pub(crate) fields.
 #[derive(Clone)]
 pub struct Argument<F: Field> {
     pub name: String,
@@ -32,7 +33,7 @@ impl<F: Field> Argument<F> {
         }
     }
 
-    pub fn required_degree(&self) -> usize {
+    pub(crate) fn required_degree(&self) -> usize {
         assert_eq!(self.input_expressions.len(), self.table_expressions.len());
 
         // The first value in the permutation poly should be one.

--- a/halo2_common/src/plonk/permutation.rs
+++ b/halo2_common/src/plonk/permutation.rs
@@ -23,7 +23,7 @@ impl Argument {
     /// Returns the minimum circuit degree required by the permutation argument.
     /// The argument may use larger degree gates depending on the actual
     /// circuit's degree and how many columns are involved in the permutation.
-    pub fn required_degree(&self) -> usize {
+    pub(crate) fn required_degree(&self) -> usize {
         // degree 2:
         // l_0(X) * (1 - z(X)) = 0
         //
@@ -58,7 +58,7 @@ impl Argument {
         3
     }
 
-    pub fn add_column(&mut self, column: Column<Any>) {
+    pub(crate) fn add_column(&mut self, column: Column<Any>) {
         if !self.columns.contains(&column) {
             self.columns.push(column);
         }

--- a/halo2_frontend/src/dev/cost.rs
+++ b/halo2_frontend/src/dev/cost.rs
@@ -58,44 +58,44 @@ pub struct CircuitCost<G: PrimeGroup, ConcreteCircuit: Circuit<G::Scalar>> {
 /// Region implementation used by Layout
 #[allow(dead_code)]
 #[derive(Debug)]
-pub struct LayoutRegion {
+pub(crate) struct LayoutRegion {
     /// The name of the region. Not required to be unique.
-    pub name: String,
+    pub(crate) name: String,
     /// The columns used by this region.
-    pub columns: HashSet<RegionColumn>,
+    pub(crate) columns: HashSet<RegionColumn>,
     /// The row that this region starts on, if known.
-    pub offset: Option<usize>,
+    pub(crate) offset: Option<usize>,
     /// The number of rows that this region takes up.
-    pub rows: usize,
+    pub(crate) rows: usize,
     /// The cells assigned in this region.
-    pub cells: Vec<(RegionColumn, usize)>,
+    pub(crate) cells: Vec<(RegionColumn, usize)>,
 }
 
 /// Cost and graphing layouter
 #[derive(Default, Debug)]
-pub struct Layout {
+pub(crate) struct Layout {
     /// k = 1 << n
-    pub k: u32,
+    pub(crate) k: u32,
     /// Regions of the layout
-    pub regions: Vec<LayoutRegion>,
+    pub(crate) regions: Vec<LayoutRegion>,
     current_region: Option<usize>,
     /// Total row count
-    pub total_rows: usize,
+    pub(crate) total_rows: usize,
     /// Total advice rows
-    pub total_advice_rows: usize,
+    pub(crate) total_advice_rows: usize,
     /// Total fixed rows
-    pub total_fixed_rows: usize,
+    pub(crate) total_fixed_rows: usize,
     /// Any cells assigned outside of a region.
-    pub loose_cells: Vec<(RegionColumn, usize)>,
+    pub(crate) loose_cells: Vec<(RegionColumn, usize)>,
     /// Pairs of cells between which we have equality constraints.
-    pub equality: Vec<(Column<Any>, usize, Column<Any>, usize)>,
+    pub(crate) equality: Vec<(Column<Any>, usize, Column<Any>, usize)>,
     /// Selector assignments used for optimization pass
-    pub selectors: Vec<Vec<bool>>,
+    pub(crate) selectors: Vec<Vec<bool>>,
 }
 
 impl Layout {
     /// Creates a empty layout
-    pub fn new(k: u32, n: usize, num_selectors: usize) -> Self {
+    pub(crate) fn new(k: u32, n: usize, num_selectors: usize) -> Self {
         Layout {
             k,
             regions: vec![],
@@ -113,7 +113,7 @@ impl Layout {
     }
 
     /// Update layout metadata
-    pub fn update(&mut self, column: RegionColumn, row: usize) {
+    pub(crate) fn update(&mut self, column: RegionColumn, row: usize) {
         self.total_rows = cmp::max(self.total_rows, row + 1);
 
         if let RegionColumn::Column(col) = column {

--- a/halo2_frontend/src/dev/metadata.rs
+++ b/halo2_frontend/src/dev/metadata.rs
@@ -207,7 +207,7 @@ impl Region {
     /// This function will return `None` if:
     /// - There's no annotation map generated for this `Region`.
     /// - There's no entry on the annotation map corresponding to the metadata provided.
-    pub fn get_column_annotation(&self, metadata: ColumnMetadata) -> Option<String> {
+    pub(crate) fn get_column_annotation(&self, metadata: ColumnMetadata) -> Option<String> {
         self.column_annotations
             .as_ref()
             .and_then(|map| map.get(&metadata).cloned())

--- a/halo2_frontend/src/dev/util.rs
+++ b/halo2_frontend/src/dev/util.rs
@@ -8,7 +8,7 @@ use halo2_common::plonk::{
 use halo2_middleware::circuit::{Advice, Any, ColumnType};
 use halo2_middleware::poly::Rotation;
 
-pub struct AnyQuery {
+pub(crate) struct AnyQuery {
     /// Query index
     pub index: Option<usize>,
     /// Column type

--- a/halo2_proofs/src/lib.rs
+++ b/halo2_proofs/src/lib.rs
@@ -23,7 +23,7 @@ pub mod circuit {
 ///! This module provides common utilities, traits and structures for group,
 ///! field and polynomial arithmetic.
 pub mod arithmetic {
-    pub use halo2_common::arithmetic::{
+    pub use halo2_backend::arithmetic::{
         best_fft, parallelize, small_multiexp, CurveAffine, CurveExt, Field,
     };
 }


### PR DESCRIPTION
## Description
- move the `halo2_common::arithmetic::*` to `halo2_backend` crate

## Related issues
- #266 

## Changes
- move the `arithmetic.rs` file to `halo2_backend` crate
- update the imports in related crates