### PR TITLE
fix: reset the changes introduced in `getrandom` import as dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,3 @@ members = [
     "halo2_backend",
     "halo2_common",
 ]
-resolver = "2"

--- a/halo2_backend/Cargo.toml
+++ b/halo2_backend/Cargo.toml
@@ -48,7 +48,7 @@ proptest = "1"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 serde_json = "1"
 
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 
 [features]

--- a/halo2_common/Cargo.toml
+++ b/halo2_common/Cargo.toml
@@ -44,7 +44,7 @@ proptest = "1"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 serde_json = "1"
 
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 
 [features]

--- a/halo2_frontend/Cargo.toml
+++ b/halo2_frontend/Cargo.toml
@@ -45,7 +45,7 @@ proptest = "1"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 serde_json = "1"
 
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 
 [features]

--- a/halo2_middleware/Cargo.toml
+++ b/halo2_middleware/Cargo.toml
@@ -35,7 +35,7 @@ proptest = "1"
 group = "0.13"
 halo2curves = { version = "0.6.0", default-features = false }
 
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 
 [lib]

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -70,7 +70,7 @@ proptest = "1"
 dhat = "0.3.2"
 serde_json = "1"
 
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 
 [features]


### PR DESCRIPTION
## Description
- roll back the `getrandom` crate import change caused by #281 

## Related issues
- Close #285 

## Changes
- set the `getrandom` crate as `dev-dependency` for `wasm32-*` target build CI
- remove the `resolver = "2"` option from workspace cargo.toml 