### PR TITLE
Make `VerifyFailure::emit` public

### DIFF
--- a/halo2_frontend/src/dev/failure.rs
+++ b/halo2_frontend/src/dev/failure.rs
@@ -836,7 +836,7 @@ fn render_shuffle<F: Field>(
 
 impl VerifyFailure {
     /// Emits this failure in pretty-printed format to stderr.
-    pub(super) fn emit<F: Field>(&self, prover: &MockProver<F>) {
+    pub fn emit<F: Field>(&self, prover: &MockProver<F>) {
         match self {
             Self::CellNotAssigned {
                 gate,


### PR DESCRIPTION
This way, users can pretty-print the error while still catching the verification failure. As far as I can see, printing the error is otherwise only exposed via `MockProver::assert_satisfied`.