### PR TITLE
chore: remove generic Expression::Scaled in favor of Product

### DIFF
--- a/halo2_backend/src/plonk/evaluation.rs
+++ b/halo2_backend/src/plonk/evaluation.rs
@@ -769,17 +769,6 @@ impl<C: CurveAffine> GraphEvaluator<C> {
                     self.add_calculation(Calculation::Mul(result_b, result_a))
                 }
             }
-            ExpressionBack::Scaled(a, f) => {
-                if *f == C::ScalarExt::ZERO {
-                    ValueSource::Constant(0)
-                } else if *f == C::ScalarExt::ONE {
-                    self.add_expression(a)
-                } else {
-                    let cst = self.add_constant(f);
-                    let result_a = self.add_expression(a);
-                    self.add_calculation(Calculation::Mul(result_a, cst))
-                }
-            }
         }
     }
 
@@ -875,7 +864,6 @@ pub fn evaluate<F: Field, B: LagrangeBasis>(
                 &|a| -a,
                 &|a, b| a + b,
                 &|a, b| a * b,
-                &|a, scalar| a * scalar,
             );
         }
     });
@@ -1027,7 +1015,6 @@ mod test {
 
         check_expr(ExpressionBack::Sum(two(), three()), 5);
         check_expr(ExpressionBack::Product(two(), three()), 6);
-        check_expr(ExpressionBack::Scaled(two(), Scalar::from(5)), 10);
         check_expr(
             ExpressionBack::Sum(ExpressionBack::Negated(two()).into(), three()),
             1,

--- a/halo2_backend/src/plonk/keygen.rs
+++ b/halo2_backend/src/plonk/keygen.rs
@@ -238,9 +238,6 @@ impl QueriesMap {
                 Box::new(self.as_expression(lhs)),
                 Box::new(self.as_expression(rhs)),
             ),
-            ExpressionMid::Scaled(e, c) => {
-                ExpressionBack::Scaled(Box::new(self.as_expression(e)), *c)
-            }
         }
     }
 }

--- a/halo2_backend/src/plonk/lookup/verifier.rs
+++ b/halo2_backend/src/plonk/lookup/verifier.rs
@@ -130,7 +130,6 @@ impl<C: CurveAffine> Evaluated<C> {
                             &|a| -a,
                             &|a, b| a + b,
                             &|a, b| a * b,
-                            &|a, scalar| a * scalar,
                         )
                     })
                     .fold(C::Scalar::ZERO, |acc, eval| acc * *theta + eval)

--- a/halo2_backend/src/plonk/shuffle/verifier.rs
+++ b/halo2_backend/src/plonk/shuffle/verifier.rs
@@ -89,7 +89,6 @@ impl<C: CurveAffine> Evaluated<C> {
                             &|a| -a,
                             &|a, b| a + b,
                             &|a, b| a * b,
-                            &|a, scalar| a * scalar,
                         )
                     })
                     .fold(C::Scalar::ZERO, |acc, eval| acc * *theta + eval)

--- a/halo2_backend/src/plonk/verifier.rs
+++ b/halo2_backend/src/plonk/verifier.rs
@@ -371,7 +371,6 @@ where
                                 &|a| -a,
                                 &|a, b| a + b,
                                 &|a, b| a * b,
-                                &|a, scalar| a * scalar,
                             )
                         }))
                         .chain(permutation.expressions(

--- a/halo2_frontend/src/plonk/circuit/expression.rs
+++ b/halo2_frontend/src/plonk/circuit/expression.rs
@@ -548,7 +548,9 @@ impl<F> From<Expression<F>> for ExpressionMid<F> {
             Expression::Product(lhs, rhs) => {
                 ExpressionMid::Product(Box::new((*lhs).into()), Box::new((*rhs).into()))
             }
-            Expression::Scaled(e, c) => ExpressionMid::Scaled(Box::new((*e).into()), c),
+            Expression::Scaled(e, c) => {
+                ExpressionMid::Product(Box::new((*e).into()), Box::new(ExpressionMid::Constant(c)))
+            }
         }
     }
 }


### PR DESCRIPTION
This simplifies the code a bit.  I've only applied this change in the middleware and backend.  The frontend `Expression` stays intact in order to not break the frontend public API.

The proposal behind this change is to simplify the handling of Expression at a negligible cost.  The only benefit I saw from the `Expression::Scaled` case was avoiding a heap allocation; but I don't think heap allocations from expressions have any impact on the memory usage and performance because:
- In a circuit the number of expressions is small, compared to other things like witness size
- When calculating a proof, the expression is not traversed many times

I can only imagine this could affect the performance if the expression is traversed many times (although probably the performance impact is really small); and this would be the case of the MockProver; but the MockPorver uses the frontend Expression which is untouched in this PR.