### PR TITLE
Fix filthy doc warnings that pollutes our PR diffs

### DIFF
--- a/halo2_backend/src/plonk/evaluation.rs
+++ b/halo2_backend/src/plonk/evaluation.rs
@@ -188,7 +188,7 @@ pub struct Evaluator<C: CurveAffine> {
 /// Computations can be added in two ways:
 ///
 /// - using [`Self::add_expression`] where expressions are added and internally turned into a graph.
-///   A reference to the computation is returned in the form of [ `ValueSource::Itermediate`] reference
+///   A reference to the computation is returned in the form of [ `ValueSource::Intermediate`] reference
 ///   index.
 /// - using [`Self::add_calculation`] where you can add only a single operation or a
 ///   [Horner polynomial evaluation](https://en.wikipedia.org/wiki/Horner's_method) by using
@@ -217,7 +217,7 @@ struct EvaluationData<C: CurveAffine> {
     rotations: Vec<usize>,
 }
 
-/// CalculationInfo contains a calculation to perform and in [`target`] the [`EvaluationData::intermediate`] where the value is going to be stored.  
+/// CalculationInfo contains a calculation to perform and in [`Self::target`] the [`EvaluationData::intermediates`] where the value is going to be stored.  
 #[derive(Clone, Debug)]
 struct CalculationInfo {
     /// Calculation

--- a/halo2_backend/src/plonk/lookup/prover.rs
+++ b/halo2_backend/src/plonk/lookup/prover.rs
@@ -56,9 +56,9 @@ pub(in crate::plonk) struct Evaluated<C: CurveAffine> {
 ///   and S_compressed = \theta^{m-1} S_0 + theta^{m-2} S_1 + ... + \theta S_{m-2} + S_{m-1},
 /// - permutes A_compressed and S_compressed using permute_expression_pair() helper,
 ///   obtaining A' and S', and
-/// - constructs Permuted<C> struct using permuted_input_value = A', and
+/// - constructs  [`Permuted<C>`] struct using permuted_input_value = A', and
 ///   permuted_table_expression = S'.
-/// The Permuted<C> struct is used to update the Lookup, and is then returned.
+/// The [`Permuted<C>`] struct is used to update the Lookup, and is then returned.
 #[allow(clippy::too_many_arguments)]
 pub(in crate::plonk) fn lookup_commit_permuted<
     'a,
@@ -161,7 +161,7 @@ impl<C: CurveAffine> Permuted<C> {
     /// Given a Lookup with input expressions, table expressions, and the permuted
     /// input expression and permuted table expression, this method constructs the
     /// grand product polynomial over the lookup. The grand product polynomial
-    /// is used to populate the Product<C> struct. The Product<C> struct is
+    /// is used to populate the [`Committed<C>`] struct. The [`Committed<C>`] struct is
     /// added to the Lookup and finally returned by the method.
     pub(in crate::plonk) fn commit_product<
         'params,

--- a/halo2_backend/src/plonk/prover.rs
+++ b/halo2_backend/src/plonk/prover.rs
@@ -475,7 +475,7 @@ impl<
     /// - 10. Compute and hash instance evals for the circuit instance
     /// - 11. Compute and hash fixed evals
     /// - 12. Evaluate permutation, lookups and shuffles at x
-    /// - 13. Generate all queries ([`PowerQuery`])
+    /// - 13. Generate all queries ([`ProverQuery`])
     /// - 14. Send the queries to the [`Prover`]  
     pub fn create_proof(mut self) -> Result<(), Error>
     where
@@ -779,7 +779,7 @@ impl<
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
-        // 13. Generate all queries ([`PowerQuery`]) that needs to be sent to prover  --------------------
+        // 13. Generate all queries ([`ProverQuery`]) that needs to be sent to prover  --------------------
 
         let queries = instances
             // group the instance, advice, permutation, lookups and shuffles

--- a/halo2_backend/src/plonk/shuffle/prover.rs
+++ b/halo2_backend/src/plonk/shuffle/prover.rs
@@ -90,8 +90,8 @@ where
 
 /// Given a Shuffle with input expressions and table expressions this method
 /// constructs the grand product polynomial over the shuffle.
-/// The grand product polynomial is used to populate the Product<C> struct.
-/// The Product<C> struct is added to the Shuffle and finally returned by the method.
+/// The grand product polynomial is used to populate the [`Committed<C>`] struct.
+/// The [`Committed<C>`] struct is added to the Shuffle and finally returned by the method.
 #[allow(clippy::too_many_arguments)]
 pub(in crate::plonk) fn shuffle_commit_product<
     'a,

--- a/halo2_frontend/src/plonk/circuit/expression.rs
+++ b/halo2_frontend/src/plonk/circuit/expression.rs
@@ -372,7 +372,7 @@ impl InstanceQuery {
 ///
 /// A lookup table can be loaded into this column via [`Layouter::assign_table`]. Columns
 /// can currently only contain a single table, but they may be used in multiple lookup
-/// arguments via [`ConstraintSystem::lookup`].
+/// arguments via [`super::constraint_system::ConstraintSystem::lookup`].
 ///
 /// Lookup table columns are always "encumbered" by the lookup arguments they are used in;
 /// they cannot simultaneously be used as general fixed columns.


### PR DESCRIPTION
Fix filthy doc warnings that pollutes our PR diffs

Like this

<img width="938" alt="image" src="https://github.com/zcash/halo2/assets/5526331/c0e5b8d8-3d0d-415e-ac25-039e71a819e2">
