### PR TITLE
chore: remove V2 from type names

### DIFF
--- a/halo2_backend/src/plonk/keygen.rs
+++ b/halo2_backend/src/plonk/keygen.rs
@@ -21,7 +21,7 @@ use crate::{
     },
 };
 use halo2_middleware::circuit::{
-    Any, ColumnMid, CompiledCircuitV2, ConstraintSystemMid, ExpressionMid, VarMid,
+    Any, ColumnMid, CompiledCircuit, ConstraintSystemMid, ExpressionMid, VarMid,
 };
 use halo2_middleware::{lookup, poly::Rotation, shuffle};
 use std::collections::HashMap;
@@ -41,7 +41,7 @@ where
 /// Generate a `VerifyingKey` from an instance of `CompiledCircuit`.
 pub fn keygen_vk_v2<'params, C, P>(
     params: &P,
-    circuit: &CompiledCircuitV2<C::Scalar>,
+    circuit: &CompiledCircuit<C::Scalar>,
 ) -> Result<VerifyingKey<C>, Error>
 where
     C: CurveAffine,
@@ -89,7 +89,7 @@ where
 pub fn keygen_pk_v2<'params, C, P>(
     params: &P,
     vk: VerifyingKey<C>,
-    circuit: &CompiledCircuitV2<C::Scalar>,
+    circuit: &CompiledCircuit<C::Scalar>,
 ) -> Result<ProvingKey<C>, Error>
 where
     C: CurveAffine,

--- a/halo2_backend/src/plonk/keygen.rs
+++ b/halo2_backend/src/plonk/keygen.rs
@@ -39,7 +39,7 @@ where
 }
 
 /// Generate a `VerifyingKey` from an instance of `CompiledCircuit`.
-pub fn keygen_vk_v2<'params, C, P>(
+pub fn keygen_vk<'params, C, P>(
     params: &P,
     circuit: &CompiledCircuit<C::Scalar>,
 ) -> Result<VerifyingKey<C>, Error>
@@ -86,7 +86,7 @@ where
 }
 
 /// Generate a `ProvingKey` from a `VerifyingKey` and an instance of `CompiledCircuit`.
-pub fn keygen_pk_v2<'params, C, P>(
+pub fn keygen_pk<'params, C, P>(
     params: &P,
     vk: VerifyingKey<C>,
     circuit: &CompiledCircuit<C::Scalar>,

--- a/halo2_frontend/src/circuit.rs
+++ b/halo2_frontend/src/circuit.rs
@@ -7,7 +7,7 @@ use crate::plonk::{
     Advice, Assignment, Circuit, ConstraintSystem, FirstPhase, Fixed, FloorPlanner, Instance,
     SecondPhase, SelectorsToFixed, ThirdPhase,
 };
-use halo2_middleware::circuit::{Any, CompiledCircuitV2, PreprocessingV2};
+use halo2_middleware::circuit::{Any, CompiledCircuit, Preprocessing};
 use halo2_middleware::ff::{BatchInvert, Field};
 use std::collections::BTreeSet;
 use std::collections::HashMap;
@@ -73,7 +73,7 @@ pub fn compile_circuit<F: Field, ConcreteCircuit: Circuit<F>>(
     compress_selectors: bool,
 ) -> Result<
     (
-        CompiledCircuitV2<F>,
+        CompiledCircuit<F>,
         ConcreteCircuit::Config,
         ConstraintSystem<F>,
     ),
@@ -116,7 +116,7 @@ pub fn compile_circuit<F: Field, ConcreteCircuit: Circuit<F>>(
     #[cfg(feature = "thread-safe-region")]
     assembly.permutation.copies.sort();
 
-    let preprocessing = PreprocessingV2 {
+    let preprocessing = Preprocessing {
         permutation: halo2_middleware::permutation::AssemblyMid {
             copies: assembly.permutation.copies,
         },
@@ -124,7 +124,7 @@ pub fn compile_circuit<F: Field, ConcreteCircuit: Circuit<F>>(
     };
 
     Ok((
-        CompiledCircuitV2 {
+        CompiledCircuit {
             cs: cs.clone().into(),
             preprocessing,
         },

--- a/halo2_middleware/src/circuit.rs
+++ b/halo2_middleware/src/circuit.rs
@@ -138,7 +138,7 @@ pub struct ConstraintSystemMid<F: Field> {
 
 /// Data that needs to be preprocessed from a circuit
 #[derive(Debug, Clone)]
-pub struct PreprocessingV2<F: Field> {
+pub struct Preprocessing<F: Field> {
     pub permutation: permutation::AssemblyMid,
     pub fixed: Vec<Vec<F>>,
 }
@@ -146,8 +146,8 @@ pub struct PreprocessingV2<F: Field> {
 /// This is a description of a low level Plonkish compiled circuit. Contains the Constraint System
 /// as well as the fixed columns and copy constraints information.
 #[derive(Debug, Clone)]
-pub struct CompiledCircuitV2<F: Field> {
-    pub preprocessing: PreprocessingV2<F>,
+pub struct CompiledCircuit<F: Field> {
+    pub preprocessing: Preprocessing<F>,
     pub cs: ConstraintSystemMid<F>,
 }
 

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -1,6 +1,6 @@
 use crate::plonk::Error;
 use halo2_backend::plonk::{
-    keygen::{keygen_pk_v2, keygen_vk_v2},
+    keygen::{keygen_pk as backend_keygen_pk, keygen_vk as backend_keygen_vk},
     ProvingKey, VerifyingKey,
 };
 use halo2_backend::{arithmetic::CurveAffine, poly::commitment::Params};
@@ -38,7 +38,7 @@ where
     C::Scalar: FromUniformBytes<64>,
 {
     let (compiled_circuit, _, _) = compile_circuit(params.k(), circuit, compress_selectors)?;
-    let mut vk = keygen_vk_v2(params, &compiled_circuit)?;
+    let mut vk = backend_keygen_vk(params, &compiled_circuit)?;
     vk.compress_selectors = Some(compress_selectors);
     Ok(vk)
 }
@@ -59,5 +59,5 @@ where
         circuit,
         vk.compress_selectors.unwrap_or_default(),
     )?;
-    Ok(keygen_pk_v2(params, vk, &compiled_circuit)?)
+    Ok(backend_keygen_pk(params, vk, &compiled_circuit)?)
 }

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -1,7 +1,7 @@
 use crate::plonk::{Error, ErrorBack};
-use crate::poly::commitment::{CommitmentScheme, Params, Prover};
+use crate::poly::commitment::{self, CommitmentScheme, Params};
 use crate::transcript::{EncodedChallenge, TranscriptWrite};
-use halo2_backend::plonk::{prover::ProverV2, ProvingKey};
+use halo2_backend::plonk::{prover::Prover, ProvingKey};
 use halo2_frontend::circuit::{compile_circuit_cs, WitnessCalculator};
 use halo2_frontend::plonk::Circuit;
 use halo2_middleware::ff::{FromUniformBytes, WithSmallOrderMulGroup};
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 pub fn create_proof<
     'params,
     Scheme: CommitmentScheme,
-    P: Prover<'params, Scheme>,
+    P: commitment::Prover<'params, Scheme>,
     E: EncodedChallenge<Scheme::Curve>,
     R: RngCore,
     T: TranscriptWrite<Scheme::Curve, E>,
@@ -44,7 +44,7 @@ where
         .enumerate()
         .map(|(i, circuit)| WitnessCalculator::new(params.k(), circuit, &config, &cs, instances[i]))
         .collect();
-    let mut prover = ProverV2::<Scheme, P, _, _, _>::new(params, pk, instances, rng, transcript)?;
+    let mut prover = Prover::<Scheme, P, _, _, _>::new(params, pk, instances, rng, transcript)?;
     let mut challenges = HashMap::new();
     let phases = prover.phases().to_vec();
     for phase in phases.iter() {

--- a/halo2_proofs/tests/frontend_backend_split.rs
+++ b/halo2_proofs/tests/frontend_backend_split.rs
@@ -8,7 +8,7 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 use halo2_backend::{
     plonk::{
         keygen::{keygen_pk_v2, keygen_vk_v2},
-        prover::ProverV2Single,
+        prover::ProverSingle,
         verifier::{verify_proof, verify_proof_single},
     },
     transcript::{
@@ -592,7 +592,7 @@ fn test_mycircuit_full_split() {
     let mut witness_calc = WitnessCalculator::new(k, &circuit, &config, &cs, instances_slice);
     let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
     let mut prover =
-        ProverV2Single::<KZGCommitmentScheme<Bn256>, ProverSHPLONK<'_, Bn256>, _, _, _>::new(
+        ProverSingle::<KZGCommitmentScheme<Bn256>, ProverSHPLONK<'_, Bn256>, _, _, _>::new(
             &params,
             &pk,
             instances_slice,

--- a/halo2_proofs/tests/frontend_backend_split.rs
+++ b/halo2_proofs/tests/frontend_backend_split.rs
@@ -7,7 +7,7 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 
 use halo2_backend::{
     plonk::{
-        keygen::{keygen_pk_v2, keygen_vk_v2},
+        keygen::{keygen_pk, keygen_vk},
         prover::ProverSingle,
         verifier::{verify_proof, verify_proof_single},
     },
@@ -508,7 +508,9 @@ fn test_mycircuit_full_legacy() {
     #[cfg(feature = "heap-profiling")]
     let _profiler = dhat::Profiler::new_heap();
 
-    use halo2_proofs::plonk::{create_proof, keygen_pk, keygen_vk};
+    use halo2_proofs::plonk::{
+        create_proof, keygen_pk as keygen_pk_legacy, keygen_vk as keygen_vk_legacy,
+    };
 
     let k = K;
     let circuit: MyCircuit<Fr, WIDTH_FACTOR> = MyCircuit::new(k, 42);
@@ -518,8 +520,8 @@ fn test_mycircuit_full_legacy() {
     let params = ParamsKZG::<Bn256>::setup(k, &mut rng);
     let verifier_params = params.verifier_params();
     let start = Instant::now();
-    let vk = keygen_vk(&params, &circuit).expect("keygen_vk should not fail");
-    let pk = keygen_pk(&params, vk.clone(), &circuit).expect("keygen_pk should not fail");
+    let vk = keygen_vk_legacy(&params, &circuit).expect("keygen_vk should not fail");
+    let pk = keygen_pk_legacy(&params, vk.clone(), &circuit).expect("keygen_pk should not fail");
     println!("Keygen: {:?}", start.elapsed());
 
     // Proving
@@ -574,9 +576,8 @@ fn test_mycircuit_full_split() {
     let params = ParamsKZG::<Bn256>::setup(k, &mut rng);
     let verifier_params = params.verifier_params();
     let start = Instant::now();
-    let vk = keygen_vk_v2(&params, &compiled_circuit).expect("keygen_vk should not fail");
-    let pk =
-        keygen_pk_v2(&params, vk.clone(), &compiled_circuit).expect("keygen_pk should not fail");
+    let vk = keygen_vk(&params, &compiled_circuit).expect("keygen_vk should not fail");
+    let pk = keygen_pk(&params, vk.clone(), &compiled_circuit).expect("keygen_pk should not fail");
     println!("Keygen: {:?}", start.elapsed());
     drop(compiled_circuit);
 


### PR DESCRIPTION
There were a few type names that included "V2" after the frontend-backend split but they don't collide between frontend-middleware-backend so the "V2" was unneeded.  With this PR the names after the frontend-backend split will be uniform.

Resolve https://github.com/privacy-scaling-explorations/halo2/issues/263