### PR TITLE
fix: expose more types for external projects

### DIFF
--- a/halo2_proofs/src/lib.rs
+++ b/halo2_proofs/src/lib.rs
@@ -17,7 +17,8 @@ pub mod plonk;
 pub mod circuit {
     pub use halo2_frontend::circuit::floor_planner;
     pub use halo2_frontend::circuit::{
-        AssignedCell, Cell, Chip, Layouter, Region, SimpleFloorPlanner, Value,
+        AssignedCell, Cell, Chip, Layouter, NamespacedLayouter, Region, RegionIndex,
+        SimpleFloorPlanner, Table, Value,
     };
 }
 /// This module provides common utilities, traits and structures for group,
@@ -40,14 +41,14 @@ pub mod dev {
 /// the committed polynomials at arbitrary points.
 pub mod poly {
     pub use halo2_backend::poly::VerificationStrategy;
-    pub use halo2_backend::poly::{commitment, ipa, kzg};
+    pub use halo2_backend::poly::{commitment, ipa, kzg, EvaluationDomain};
     pub use halo2_middleware::poly::Rotation;
 }
 /// This module contains utilities and traits for dealing with Fiat-Shamir
 /// transcripts.
 pub mod transcript {
     pub use halo2_backend::transcript::{
-        Blake2bRead, Blake2bWrite, Challenge255, EncodedChallenge, TranscriptRead,
+        Blake2bRead, Blake2bWrite, Challenge255, EncodedChallenge, Transcript, TranscriptRead,
         TranscriptReadBuffer, TranscriptWrite, TranscriptWriterBuffer,
     };
 }

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -20,8 +20,9 @@ pub use verifier::verify_proof;
 pub use error::Error;
 pub use halo2_backend::plonk::{Error as ErrorBack, ProvingKey, VerifyingKey};
 pub use halo2_frontend::plonk::{
-    Advice, Assigned, Challenge, Circuit, Column, ConstraintSystem, Error as ErrorFront,
-    Expression, FirstPhase, Fixed, Instance, SecondPhase, Selector, TableColumn, ThirdPhase,
+    Advice, Assigned, Assignment, Challenge, Circuit, Column, ColumnType, ConstraintSystem,
+    Constraints, Error as ErrorFront, Expression, FirstPhase, Fixed, FixedQuery, FloorPlanner,
+    Instance, Phase, SecondPhase, Selector, TableColumn, ThirdPhase, VirtualCells,
 };
 pub use halo2_middleware::circuit::{Any, ConstraintSystemMid};
 


### PR DESCRIPTION
## Description
Check & expose more types in `halo2_proofs` crate for compatibility of external projects.
The list of external projects used for checking is this one - https://hackmd.io/6baAR-NpScWscDmmTRvocQ#Extended-details.

## Related issues
- Resolve #260 

## Changes
This PR exposes:  
- halo2_frontend::circuit::{NameSpacedLayouter, RegionIndex, Table}
- halo2_backend::poly::EvaluationDomain
- halo2_backend::transcript::Transcript
- halo2_frontend::plonk::{Assignment, ColumnType, FixedQuery, Floorplanner, Phase, VirtualCells}

## NOTE
In addition to newly-exposed types, there is one more - `halo2_proofs::arithmetic::FieldExt`.
Originally, this one is the re-export of `pasta_curves::FieldExt` in `halo2curves` crate.
This re-export was removed in this commit.
https://github.com/privacy-scaling-explorations/halo2curves/commit/ce743c09e516cbc1cc8cb6da3cf6d420e914bc6a#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L15
