### PR TITLE
Tight k on lookups

### DIFF
--- a/halo2_frontend/src/plonk/keygen.rs
+++ b/halo2_frontend/src/plonk/keygen.rs
@@ -86,10 +86,6 @@ impl<F: Field> Assignment<F> for Assembly<F> {
         A: FnOnce() -> AR,
         AR: Into<String>,
     {
-        if !self.usable_rows.contains(&row) {
-            return Err(Error::not_enough_rows_available(self.k));
-        }
-
         *self
             .fixed
             .get_mut(column.index())
@@ -120,10 +116,6 @@ impl<F: Field> Assignment<F> for Assembly<F> {
         from_row: usize,
         to: Value<Assigned<F>>,
     ) -> Result<(), Error> {
-        if !self.usable_rows.contains(&from_row) {
-            return Err(Error::not_enough_rows_available(self.k));
-        }
-
         let col = self
             .fixed
             .get_mut(column.index())


### PR DESCRIPTION
CLOSING THIS AT IT REQUIRES MORE CHANGES.

We disable two checks on key generation that made sure the row being filled was within the usable rows.

These checks are not necessary for fixed columns (where we disabled them), because fixed columns are public and are not blinded. Indeed, they are computed at setup time.

These checks served as a sanity check though, because in general one would not want to assign values at unusable offsets. On exception is the case of lookups. Thanks to this change, we can now run circuits with `2^k` lookup tables on a `k`-domain. Before this change, a `(k+1)`-domain was needed.

This solution is good IMHO, but I suggest opening a GitHub issue to revisit this problem in the future to possibly enable/disable the check via an additional argument to the `assign_fixed` function.