### PR TITLE
fix: enable the features in `halo2_proofs` crate

### DIFF
--- a/halo2_backend/Cargo.toml
+++ b/halo2_backend/Cargo.toml
@@ -53,10 +53,8 @@ getrandom = { version = "0.2", features = ["js"] }
 [features]
 default = ["batch", "bits"]
 bits = ["halo2curves/bits"]
-gadget-traces = ["backtrace"]
 sanity-checks = []
 batch = ["rand_core/getrandom"]
-cost-estimator = ["serde", "serde_derive"]
 derive_serde = ["halo2curves/derive_serde"]
 
 [lib]

--- a/halo2_frontend/Cargo.toml
+++ b/halo2_frontend/Cargo.toml
@@ -59,7 +59,6 @@ test-dev-graph = [
 bits = ["halo2curves/bits"]
 gadget-traces = ["backtrace"]
 thread-safe-region = []
-sanity-checks = []
 circuit-params = []
 heap-profiling = []
 cost-estimator = ["serde", "serde_derive"]

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -66,7 +66,7 @@ serde_json = "1"
 getrandom = { version = "0.2", features = ["js"] }
 
 [features]
-default = ["batch", "bits"]
+default = ["batch", "bits", "halo2_frontend/default", "halo2_backend/default"]
 dev-graph = ["halo2_frontend/dev-graph", "plotters"]
 test-dev-graph = [
     "halo2_frontend/test-dev-graph",
@@ -75,15 +75,15 @@ test-dev-graph = [
     "plotters/bitmap_encoder",
     "plotters/ttf"
 ]
-bits = ["halo2curves/bits"]
-gadget-traces = []
-thread-safe-region = []
-sanity-checks = []
-batch = ["rand_core/getrandom"]
+bits = ["halo2curves/bits", "halo2_frontend/bits", "halo2_backend/bits"]
+gadget-traces = ["halo2_frontend/gadget-traces"]
+thread-safe-region = ["halo2_frontend/thread-safe-region"]
+sanity-checks = ["halo2_backend/sanity-checks"]
+batch = ["rand_core/getrandom", "halo2_backend/batch"]
 circuit-params = ["halo2_frontend/circuit-params"]
-heap-profiling = []
+heap-profiling = ["halo2_frontend/heap-profiling"]
 cost-estimator = ["halo2_frontend/cost-estimator"]
-derive_serde = ["halo2curves/derive_serde"]
+derive_serde = ["halo2curves/derive_serde", "halo2_frontend/derive_serde", "halo2_backend/derive_serde"]
 
 [lib]
 bench = false


### PR DESCRIPTION
## Description
Check & enable the `halo2_backend` & `halo2_frontend` features in `halo2_proofs` crate features

## Related issues
- None

## Changes
- remove `gadget-traces` & `cost-estimator` feature from `halo2_backend` crate features
- remove `sanity-checks` feature from `halo2_frontend` crate features
- enable the necessary features in `halo2_proofs` crate features