### PR TITLE
improve: apply `tachyon` optimizations(2 & 5)

### DIFF
--- a/halo2_backend/src/plonk/lookup/prover.rs
+++ b/halo2_backend/src/plonk/lookup/prover.rs
@@ -131,18 +131,23 @@ where
         let poly = pk.vk.domain.lagrange_to_coeff(values.clone());
         let blind = Blind(C::Scalar::random(&mut rng));
         let commitment = params
-            .commit_lagrange(&engine.msm_backend, values, blind)
-            .to_affine();
+            .commit_lagrange(&engine.msm_backend, values, blind);
         (poly, blind, commitment)
     };
 
     // Commit to permuted input expression
-    let (permuted_input_poly, permuted_input_blind, permuted_input_commitment) =
+    let (permuted_input_poly, permuted_input_blind, permuted_input_commitment_projective) =
         commit_values(&permuted_input_expression);
 
     // Commit to permuted table expression
-    let (permuted_table_poly, permuted_table_blind, permuted_table_commitment) =
+    let (permuted_table_poly, permuted_table_blind, permuted_table_commitment_projective) =
         commit_values(&permuted_table_expression);
+
+    let [permuted_input_commitment, permuted_table_commitment] = {
+        let mut affines = [C::identity(); 2];
+        C::CurveExt::batch_normalize(&[permuted_input_commitment_projective, permuted_table_commitment_projective], &mut affines);
+        affines
+    };
 
     // Hash permuted input commitment
     transcript.write_point(permuted_input_commitment)?;

--- a/halo2_backend/src/plonk/lookup/prover.rs
+++ b/halo2_backend/src/plonk/lookup/prover.rs
@@ -91,19 +91,22 @@ where
 {
     // Closure to get values of expressions and compress them
     let compress_expressions = |expressions: &[ExpressionBack<C::Scalar>]| {
-        let mut compressed_expression = domain.empty_lagrange();
-        for expression in expressions.iter() {
-            let expression = pk.vk.domain.lagrange_from_vec(evaluate(
-                expression,
-                params.n() as usize,
-                1,
-                fixed_values,
-                advice_values,
-                instance_values,
-                challenges,
-            ));
-            compressed_expression = compressed_expression * *theta + &expression;
-        }
+        let compressed_expression = expressions
+            .iter()
+            .map(|expression| {
+                pk.vk.domain.lagrange_from_vec(evaluate(
+                    expression,
+                    params.n() as usize,
+                    1,
+                    fixed_values,
+                    advice_values,
+                    instance_values,
+                    challenges,
+                ))
+            })
+            .fold(domain.empty_lagrange(), |acc, expression| {
+                acc * *theta + &expression
+            });
         compressed_expression
     };
 

--- a/halo2_backend/src/plonk/lookup/prover.rs
+++ b/halo2_backend/src/plonk/lookup/prover.rs
@@ -91,22 +91,19 @@ where
 {
     // Closure to get values of expressions and compress them
     let compress_expressions = |expressions: &[ExpressionBack<C::Scalar>]| {
-        let compressed_expression = expressions
-            .iter()
-            .map(|expression| {
-                pk.vk.domain.lagrange_from_vec(evaluate(
-                    expression,
-                    params.n() as usize,
-                    1,
-                    fixed_values,
-                    advice_values,
-                    instance_values,
-                    challenges,
-                ))
-            })
-            .fold(domain.empty_lagrange(), |acc, expression| {
-                acc * *theta + &expression
-            });
+        let mut compressed_expression = domain.empty_lagrange();
+        for expression in expressions.iter() {
+            let expression = pk.vk.domain.lagrange_from_vec(evaluate(
+                expression,
+                params.n() as usize,
+                1,
+                fixed_values,
+                advice_values,
+                instance_values,
+                challenges,
+            ));
+            compressed_expression = compressed_expression * *theta + &expression;
+        }
         compressed_expression
     };
 

--- a/halo2_backend/src/plonk/lookup/prover.rs
+++ b/halo2_backend/src/plonk/lookup/prover.rs
@@ -130,8 +130,7 @@ where
     let mut commit_values = |values: &Polynomial<C::Scalar, LagrangeCoeff>| {
         let poly = pk.vk.domain.lagrange_to_coeff(values.clone());
         let blind = Blind(C::Scalar::random(&mut rng));
-        let commitment = params
-            .commit_lagrange(&engine.msm_backend, values, blind);
+        let commitment = params.commit_lagrange(&engine.msm_backend, values, blind);
         (poly, blind, commitment)
     };
 
@@ -145,7 +144,13 @@ where
 
     let [permuted_input_commitment, permuted_table_commitment] = {
         let mut affines = [C::identity(); 2];
-        C::CurveExt::batch_normalize(&[permuted_input_commitment_projective, permuted_table_commitment_projective], &mut affines);
+        C::CurveExt::batch_normalize(
+            &[
+                permuted_input_commitment_projective,
+                permuted_table_commitment_projective,
+            ],
+            &mut affines,
+        );
         affines
     };
 

--- a/halo2_backend/src/plonk/permutation/prover.rs
+++ b/halo2_backend/src/plonk/permutation/prover.rs
@@ -174,15 +174,13 @@ pub(in crate::plonk) fn permutation_commit<
 
         let blind = Blind(C::Scalar::random(&mut rng));
 
-        let permutation_product_commitment_projective =
-            params.commit_lagrange(&engine.msm_backend, &z, blind);
+        let permutation_product_commitment =
+            params.commit_lagrange(&engine.msm_backend, &z, blind).to_affine();
         let permutation_product_blind = blind;
         let z = domain.lagrange_to_coeff(z);
         let permutation_product_poly = z.clone();
 
         let permutation_product_coset = domain.coeff_to_extended(z);
-
-        let permutation_product_commitment = permutation_product_commitment_projective.to_affine();
 
         // Hash the permutation product commitment
         transcript.write_point(permutation_product_commitment)?;

--- a/halo2_backend/src/plonk/permutation/prover.rs
+++ b/halo2_backend/src/plonk/permutation/prover.rs
@@ -180,7 +180,7 @@ pub(in crate::plonk) fn permutation_commit<
         let z = domain.lagrange_to_coeff(z);
         let permutation_product_poly = z.clone();
 
-        let permutation_product_coset = domain.coeff_to_extended(z.clone());
+        let permutation_product_coset = domain.coeff_to_extended(z);
 
         let permutation_product_commitment = permutation_product_commitment_projective.to_affine();
 

--- a/halo2_backend/src/plonk/permutation/prover.rs
+++ b/halo2_backend/src/plonk/permutation/prover.rs
@@ -174,8 +174,9 @@ pub(in crate::plonk) fn permutation_commit<
 
         let blind = Blind(C::Scalar::random(&mut rng));
 
-        let permutation_product_commitment =
-            params.commit_lagrange(&engine.msm_backend, &z, blind).to_affine();
+        let permutation_product_commitment = params
+            .commit_lagrange(&engine.msm_backend, &z, blind)
+            .to_affine();
         let permutation_product_blind = blind;
         let z = domain.lagrange_to_coeff(z);
         let permutation_product_poly = z.clone();

--- a/halo2_backend/src/plonk/verifier.rs
+++ b/halo2_backend/src/plonk/verifier.rs
@@ -1,9 +1,11 @@
 //! Verify a plonk proof
 
+use group::prime::PrimeCurveAffine;
 use group::Curve;
 use halo2_middleware::circuit::Any;
 use halo2_middleware::ff::{Field, FromUniformBytes, WithSmallOrderMulGroup};
 use halo2_middleware::zal::impls::H2cEngine;
+use halo2curves::CurveAffine;
 use std::iter;
 
 use super::{vanishing, VerifyingKey};
@@ -78,7 +80,9 @@ where
     // 1. Get the commitments of the instance polynomials. ----------------------------------------
 
     let instance_commitments = if V::QUERY_INSTANCE {
-        instances
+        let mut instance_commitments = Vec::with_capacity(instances.len());
+
+        let instances_projective = instances
             .iter()
             .map(|instance| {
                 instance
@@ -91,13 +95,24 @@ where
                         poly.resize(params.n() as usize, Scheme::Scalar::ZERO);
                         let poly = vk.domain.lagrange_from_vec(poly);
 
-                        Ok(params
-                            .commit_lagrange(&default_engine, &poly, Blind::default())
-                            .to_affine())
+                        Ok(params.commit_lagrange(&default_engine, &poly, Blind::default()))
                     })
                     .collect::<Result<Vec<_>, _>>()
             })
-            .collect::<Result<Vec<_>, _>>()?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        for i in 0..instances.len() {
+            let mut affines = vec![
+                <Scheme as CommitmentScheme>::Curve::identity();
+                instances_projective[i].len()
+            ];
+            <<Scheme as CommitmentScheme>::Curve as CurveAffine>::CurveExt::batch_normalize(
+                &instances_projective[i],
+                &mut affines,
+            );
+            instance_commitments.push(affines);
+        }
+        instance_commitments
     } else {
         vec![vec![]; instances.len()]
     };

--- a/halo2_backend/src/plonk/verifier.rs
+++ b/halo2_backend/src/plonk/verifier.rs
@@ -101,13 +101,11 @@ where
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        for i in 0..instances.len() {
-            let mut affines = vec![
-                <Scheme as CommitmentScheme>::Curve::identity();
-                instances_projective[i].len()
-            ];
+        for instance_projective in instances_projective {
+            let mut affines =
+                vec![<Scheme as CommitmentScheme>::Curve::identity(); instance_projective.len()];
             <<Scheme as CommitmentScheme>::Curve as CurveAffine>::CurveExt::batch_normalize(
-                &instances_projective[i],
+                &instance_projective,
                 &mut affines,
             );
             instance_commitments.push(affines);

--- a/halo2_backend/src/poly/ipa/commitment.rs
+++ b/halo2_backend/src/poly/ipa/commitment.rs
@@ -195,8 +195,13 @@ impl<'params, C: CurveAffine> ParamsProver<'params, C> for ParamsIPA<C> {
         let g_lagrange = g_to_lagrange(g_projective, k);
 
         let hasher = C::CurveExt::hash_to_curve("Halo2-Parameters");
-        let w = hasher(&[1]).to_affine();
-        let u = hasher(&[2]).to_affine();
+
+        let [w, u] = {
+            let projectives = vec![hasher(&[1]), hasher(&[2])];
+            let mut affines = [C::identity(); 2];
+            C::CurveExt::batch_normalize(&projectives, &mut affines);
+            affines
+        };
 
         ParamsIPA {
             k,

--- a/halo2_backend/src/poly/ipa/commitment/prover.rs
+++ b/halo2_backend/src/poly/ipa/commitment/prover.rs
@@ -114,8 +114,11 @@ pub fn create_proof_with_engine<
         let r_j_randomness = C::Scalar::random(&mut rng);
         let l_j = l_j + engine.msm(&[value_l_j * z, l_j_randomness], &[params.u, params.w]);
         let r_j = r_j + engine.msm(&[value_r_j * z, r_j_randomness], &[params.u, params.w]);
-        let l_j = l_j.to_affine();
-        let r_j = r_j.to_affine();
+        let [l_j, r_j] = {
+            let mut affines = [C::identity(); 2];
+            C::CurveExt::batch_normalize(&[l_j, r_j], &mut affines);
+            affines
+        };
 
         // Feed L and R into the real transcript
         transcript.write_point(l_j)?;


### PR DESCRIPTION
## Description
Analyze and apply the `tachyon` optimizations - **2(batch normalize)** & **5(save heap allocations)**

## Related issues
  - #293 

## Changes
  - apply the `batch_normalize` in everywhere possible of `halo2_backend` crate 
 
## NOTE
1. `batch_normalize`
In order to apply the `batch_normalize` optimization, the algorithm of `batch_normalize` & `batch_inverse` should be implemented for elliptic curves. It is already implemented in [pse/halo2curves](https://github.com/privacy-scaling-explorations/halo2curves/blob/main/src/derive/curve.rs#L775-L806) repo.

2. `save heap allocations`
For this optimization, I just apply one - remove unnecessary "clone" op in ["permutation_commit"](halo2_backend/src/plonk/permutation/prover.rs).
The reason is that other optimizations needless in Rust project. 
Also, the `Polynomial` implementation has big diff between projects.