### PR TITLE
minor: upgrade the `halo2curves` dep to 0.6.1

### DIFF
--- a/halo2_backend/Cargo.toml
+++ b/halo2_backend/Cargo.toml
@@ -28,7 +28,7 @@ rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "katex-header.html"]
 backtrace = { version = "0.3", optional = true }
 ff = "0.13"
 group = "0.13"
-halo2curves = { version = "0.6.0", default-features = false }
+halo2curves = { version = "0.6.1", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 tracing = "0.1"
 blake2b_simd = "1" # MSRV 1.66.0

--- a/halo2_frontend/Cargo.toml
+++ b/halo2_frontend/Cargo.toml
@@ -28,7 +28,7 @@ rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "katex-header.html"]
 backtrace = { version = "0.3", optional = true }
 ff = "0.13"
 group = "0.13"
-halo2curves = { version = "0.6.0", default-features = false }
+halo2curves = { version = "0.6.1", default-features = false }
 tracing = "0.1"
 blake2b_simd = "1" # MSRV 1.66.0
 serde = { version = "1", optional = true, features = ["derive"] }

--- a/halo2_middleware/Cargo.toml
+++ b/halo2_middleware/Cargo.toml
@@ -26,7 +26,7 @@ rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "katex-header.html"]
 
 [dependencies]
 ff = "0.13"
-halo2curves = { version = "0.6.0", default-features = false }
+halo2curves = { version = "0.6.1", default-features = false }
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_derive = { version = "1", optional = true}
 rayon = "1.8"

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -44,7 +44,7 @@ harness = false
 halo2_middleware = { path = "../halo2_middleware" }
 halo2_backend = { path = "../halo2_backend" }
 halo2_frontend = { path = "../halo2_frontend" }
-halo2curves = { version = "0.6.0", default-features = false }
+halo2curves = { version = "0.6.1", default-features = false }
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 plotters = { version = "0.3.0", default-features = false, optional = true }
 group = "0.13"


### PR DESCRIPTION
## Description
Upgrade the `halo2cuves` dep to `0.6.1`

## Related issues
- Resolve #326 

