### PR TITLE
fix: bump nightly version to build docs in CI

### DIFF
--- a/.github/workflows/docs-ghpages.yml
+++ b/.github/workflows/docs-ghpages.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-10-05
+          toolchain: nightly-2024-05-17
           override: true
 
       - name: Copy the html file to workspace crates


### PR DESCRIPTION
In https://github.com/privacy-scaling-explorations/halo2/pull/306 we bumped the rust version to 1.78 and that broke the docs build which was using a nightly version from 2023.
Bumping the nightly version used to build the docs should fix the issue.