### PR TITLE
feat: add assertion for dynamic lookup

### DIFF
--- a/.github/scripts/wasm-target-test-build.sh
+++ b/.github/scripts/wasm-target-test-build.sh
@@ -15,7 +15,7 @@ cp "${GIT_ROOT}/rust-toolchain" .
 rustup target add wasm32-unknown-unknown wasm32-wasi
 
 # add dependencies
-cargo add --path "${GIT_ROOT}/halo2_proofs" --features batch,dev-graph,gadget-traces
+cargo add --path "${GIT_ROOT}/halo2_proofs" --features batch,dev-graph,gadget-traces,lookup-any-sanity-checks
 cargo add getrandom --features js --target wasm32-unknown-unknown
 
 # test build for wasm32-* targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - feature_set: basic
             features: batch,dev-graph,gadget-traces
           - feature_set: all
-            features: batch,dev-graph,gadget-traces,test-dev-graph,thread-safe-region,sanity-checks,circuit-params
+            features: batch,dev-graph,gadget-traces,test-dev-graph,thread-safe-region,sanity-checks,circuit-params,lookup-any-sanity-checks
 
     steps:
       - uses: actions/checkout@v3

--- a/halo2_frontend/Cargo.toml
+++ b/halo2_frontend/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = "1"
 getrandom = { version = "0.2", features = ["js"] }
 
 [features]
-default = ["bits"]
+default = ["bits", "lookup-any-sanity-checks"]
 dev-graph = ["plotters", "tabbycat"]
 test-dev-graph = [
     "dev-graph",
@@ -63,6 +63,7 @@ circuit-params = []
 heap-profiling = []
 cost-estimator = ["serde", "serde_derive"]
 derive_serde = ["halo2curves/derive_serde"]
+lookup-any-sanity-checks = []
 
 [lib]
 bench = false

--- a/halo2_frontend/src/dev.rs
+++ b/halo2_frontend/src/dev.rs
@@ -1566,9 +1566,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "pair of selector/fixed queries(querying the tag columns) should be included, otherwise we have soundness error"
-    )]
+    #[should_panic(expected = "all table expressions need selector/fixed query for tagging")]
     fn bad_lookup_any_no_fixed_col_or_selector() {
         const K: u32 = 4;
 

--- a/halo2_frontend/src/dev.rs
+++ b/halo2_frontend/src/dev.rs
@@ -1490,7 +1490,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "table expression supplied to lookup_any argument must include fixed column or selector"
+        expected = "none of table expressions contain only fixed column, could lead to soundness error"
     )]
     fn bad_lookup_any_no_fixed_col_or_selector() {
         const K: u32 = 4;
@@ -1575,7 +1575,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "table expression containing only fixed column supplied to lookup_any argument, should use `lookup` api instead of `lookup_any`"
+        expected = "all table expressions contain only fixed column, should use `lookup` api instead of `lookup_any`"
     )]
     fn bad_lookup_any_use_only_fixed_col() {
         const K: u32 = 4;

--- a/halo2_frontend/src/dev.rs
+++ b/halo2_frontend/src/dev.rs
@@ -1345,6 +1345,223 @@ mod tests {
             table: Column<Instance>,
             advice_table: Column<Advice>,
             q: Selector,
+            s_ltable: Selector,
+        }
+
+        struct FaultyCircuit {}
+
+        impl Circuit<Fp> for FaultyCircuit {
+            type Config = FaultyCircuitConfig;
+            type FloorPlanner = SimpleFloorPlanner;
+            #[cfg(feature = "circuit-params")]
+            type Params = ();
+
+            fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+                let a = meta.advice_column();
+                let q = meta.complex_selector();
+                let table = meta.instance_column();
+                let advice_table = meta.advice_column();
+                let s_ltable = meta.complex_selector();
+
+                meta.annotate_lookup_any_column(table, || "Inst-Table");
+                meta.enable_equality(table);
+                meta.annotate_lookup_any_column(advice_table, || "Adv-Table");
+                meta.enable_equality(advice_table);
+
+                meta.lookup_any("lookup", |cells| {
+                    //
+                    // NOTE: When using `lookup_any` in circuit, the `Fixed` column or
+                    //      `Selector` is required to be enabled for the lookup table values.
+                    // 
+                    //  The following diagram shows the example circuit.
+                    //  (This is NOT a real `FaultyCircuit` instantiation we have in this test.)
+                    //  The `table`(instance) column has many zeros at the end.
+                    //  Those values are all copied into `advice_table` column.(Assuming we copy 5 rows)
+                    //  But, the only rows where `s_ltable` are enabled, for the lookup table values.
+                    //  Similarly, the only rows of `a` column where `q` is enabled, are used for lookup.
+                    //
+                    //  |---------|---------|-----|----------------|------------|
+                    //  |  table  |  q      |  a  |  advice_table  | s_ltable   |
+                    //  |---------|---------|-----|----------------|------------|
+                    //  |    1    |  1      |  1  |       1        |        1   |
+                    //  |    2    |  0      |  2  |       2        |        1   |
+                    //  |    3    |  1      |  3  |       3        |        1   |
+                    //  |    0    |  0      | 100 |       0        |        0   |
+                    //  |    0    |  1      |  2  |       0        |        0   |
+                    //  |    ..   |  0      | 67  |       ..       |       ..   |
+                    //  |---------|---------|-----|----------------|------------|
+                    //
+
+                    let a = cells.query_advice(a, Rotation::cur());
+                    let q = cells.query_selector(q);
+                    let advice_table = cells.query_advice(advice_table, Rotation::cur());
+                    let table = cells.query_instance(table, Rotation::cur());
+                    let s_ltable = cells.query_selector(s_ltable);
+
+                    // If q is enabled, a must be in the table.
+                    // When q is not enabled, lookup the default value instead.
+                    // If `s_ltable` is enabled, then the value of `advice_table` & `table` is used as lookup table.
+                    // When `s_ltable` is not enabled, the value of `advice_table` & `table` is NOT used as lookup table.
+                    let not_q = Expression::Constant(Fp::one()) - q.clone();
+                    let default = Expression::Constant(Fp::from(2));
+                    vec![
+                        (
+                            q.clone() * a.clone() + not_q.clone() * default.clone(),
+                            table * s_ltable.clone(),
+                        ),
+                        (q * a + not_q * default, advice_table * s_ltable),
+                    ]
+                });
+
+                FaultyCircuitConfig {
+                    a,
+                    q,
+                    table,
+                    advice_table,
+                    s_ltable,
+                }
+            }
+
+            fn without_witnesses(&self) -> Self {
+                Self {}
+            }
+
+            fn synthesize(
+                &self,
+                config: Self::Config,
+                mut layouter: impl Layouter<Fp>,
+            ) -> Result<(), Error> {
+                // No assignment needed for the table as is an Instance Column.
+
+                layouter.assign_region(
+                    || "Good synthesis",
+                    |mut region| {
+                        // Enable the lookup on rows 0 and 1.
+                        config.q.enable(&mut region, 0)?;
+                        config.q.enable(&mut region, 1)?;
+
+                        for i in 0..4 {
+                            // Load Advice lookup table with Instance lookup table values.
+                            region.assign_advice_from_instance(
+                                || "Advice from instance tables",
+                                config.table,
+                                i,
+                                config.advice_table,
+                                i,
+                            )?;
+
+                            // Enable the table row on rows, which used for lookup table.
+                            region.enable_selector(
+                                || format!("enabling table row {}", i),
+                                &config.s_ltable,
+                                i,
+                            )?;
+                        }
+
+                        // Assign a = 2 and a = 6.
+                        region.assign_advice(
+                            || "a = 2",
+                            config.a,
+                            0,
+                            || Value::known(Fp::from(2)),
+                        )?;
+                        region.assign_advice(
+                            || "a = 6",
+                            config.a,
+                            1,
+                            || Value::known(Fp::from(6)),
+                        )?;
+
+                        Ok(())
+                    },
+                )?;
+
+                layouter.assign_region(
+                    || "Faulty synthesis",
+                    |mut region| {
+                        // Enable the lookup on rows 0 and 1.
+                        config.q.enable(&mut region, 0)?;
+                        config.q.enable(&mut region, 1)?;
+
+                        for i in 0..4 {
+                            // Load Advice lookup table with Instance lookup table values.
+                            region.assign_advice_from_instance(
+                                || "Advice from instance tables",
+                                config.table,
+                                i,
+                                config.advice_table,
+                                i,
+                            )?;
+                            // Enable the table row on rows, which used for lookup table.
+                            region.enable_selector(
+                                || format!("enabling table row {}", i),
+                                &config.s_ltable,
+                                i,
+                            )?;
+                        }
+
+                        // Assign a = 4.
+                        region.assign_advice(
+                            || "a = 4",
+                            config.a,
+                            0,
+                            || Value::known(Fp::from(4)),
+                        )?;
+
+                        // BUG: Assign a = 5, which doesn't exist in the table!
+                        region.assign_advice(
+                            || "a = 5",
+                            config.a,
+                            1,
+                            || Value::known(Fp::from(5)),
+                        )?;
+
+                        region.name_column(|| "Witness example", config.a);
+
+                        Ok(())
+                    },
+                )
+            }
+        }
+
+        let prover = MockProver::run(
+            K,
+            &FaultyCircuit {},
+            // This is our "lookup table".
+            vec![vec![
+                Fp::from(1u64),
+                Fp::from(2u64),
+                Fp::from(4u64),
+                Fp::from(6u64),
+            ]],
+        )
+        .unwrap();
+        assert_eq!(
+            prover.verify(),
+            Err(vec![VerifyFailure::Lookup {
+                name: "lookup".to_string(),
+                lookup_index: 0,
+                location: FailureLocation::InRegion {
+                    region: (1, "Faulty synthesis").into(),
+                    offset: 1,
+                }
+            }])
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "table expression supplied to lookup_any argument must have degree >= 2"
+    )]
+    fn bad_lookup_any_no_fixed_col_or_selector() {
+        const K: u32 = 4;
+
+        #[derive(Clone)]
+        struct FaultyCircuitConfig {
+            a: Column<Advice>,
+            table: Column<Instance>,
+            advice_table: Column<Advice>,
+            q: Selector,
         }
 
         struct FaultyCircuit {}
@@ -1482,7 +1699,7 @@ mod tests {
             }
         }
 
-        let prover = MockProver::run(
+        let _ = MockProver::run(
             K,
             &FaultyCircuit {},
             // This is our "lookup table".
@@ -1494,17 +1711,6 @@ mod tests {
             ]],
         )
         .unwrap();
-        assert_eq!(
-            prover.verify(),
-            Err(vec![VerifyFailure::Lookup {
-                name: "lookup".to_string(),
-                lookup_index: 0,
-                location: FailureLocation::InRegion {
-                    region: (1, "Faulty synthesis").into(),
-                    offset: 1,
-                }
-            }])
-        );
     }
 
     #[test]

--- a/halo2_frontend/src/dev.rs
+++ b/halo2_frontend/src/dev.rs
@@ -1336,7 +1336,7 @@ mod tests {
     }
 
     #[test]
-    fn bad_lookup_any() {
+    fn bad_lookup_any_faulty_synthesis() {
         const K: u32 = 4;
 
         #[derive(Clone)]
@@ -1578,7 +1578,7 @@ mod tests {
         const K: u32 = 4;
 
         #[derive(Clone)]
-        struct FaultyCircuitConfig {
+        struct GoodLookupAnyCircuitConfig {
             a: Column<Advice>,
             table: Column<Instance>,
             advice_table: Column<Advice>,
@@ -1586,10 +1586,10 @@ mod tests {
             s_ltable: Selector,
         }
 
-        struct FaultyCircuit {}
+        struct GoodLookupAnyCircuit {}
 
-        impl Circuit<Fp> for FaultyCircuit {
-            type Config = FaultyCircuitConfig;
+        impl Circuit<Fp> for GoodLookupAnyCircuit {
+            type Config = GoodLookupAnyCircuitConfig;
             type FloorPlanner = SimpleFloorPlanner;
             #[cfg(feature = "circuit-params")]
             type Params = ();
@@ -1628,7 +1628,7 @@ mod tests {
                     ]
                 });
 
-                FaultyCircuitConfig {
+                GoodLookupAnyCircuitConfig {
                     a,
                     q,
                     table,
@@ -1701,7 +1701,7 @@ mod tests {
 
         let prover = MockProver::run(
             K,
-            &FaultyCircuit {},
+            &GoodLookupAnyCircuit {},
             // This is our "lookup table".
             vec![vec![
                 Fp::from(1u64),

--- a/halo2_frontend/src/dev.rs
+++ b/halo2_frontend/src/dev.rs
@@ -1378,11 +1378,8 @@ mod tests {
                     // If q is enabled, a must be in the table.
                     // If `s_ltable` is enabled, the value of `advice_table` & `table` is used as lookup table.
                     vec![
-                        (
-                            q.clone() * a.clone(),
-                            table * s_ltable.clone(),
-                        ),
-                        (q.clone() * a , advice_table * s_ltable.clone()),
+                        (q.clone() * a.clone(), table * s_ltable.clone()),
+                        (q.clone() * a, advice_table * s_ltable.clone()),
                         (q, s_ltable),
                     ]
                 });
@@ -1531,10 +1528,7 @@ mod tests {
 
                     // If q is enabled, a must be in the table.
                     vec![
-                        (
-                            q.clone() * a.clone(),
-                            s_ltable.clone() * table,
-                        ),
+                        (q.clone() * a.clone(), s_ltable.clone() * table),
                         (q * a, s_ltable * advice_table),
                     ]
                 });
@@ -1572,9 +1566,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "table expression need selector/fixed query(column) for tagging"
-    )]
+    #[should_panic(expected = "table expression need selector/fixed query(column) for tagging")]
     fn bad_lookup_any_no_fixed_col_or_selector() {
         const K: u32 = 4;
 
@@ -1613,13 +1605,7 @@ mod tests {
                     let table = cells.query_instance(table, Rotation::cur());
 
                     // If q is enabled, a must be in the table.
-                    vec![
-                        (
-                            q.clone() * a.clone(),
-                            table,
-                        ),
-                        (q * a, advice_table),
-                    ]
+                    vec![(q.clone() * a.clone(), table), (q * a, advice_table)]
                 });
 
                 FaultyCircuitConfig {
@@ -1700,11 +1686,7 @@ mod tests {
                 Self {}
             }
 
-            fn synthesize(
-                &self,
-                _: Self::Config,
-                _: impl Layouter<Fp>,
-            ) -> Result<(), Error> {
+            fn synthesize(&self, _: Self::Config, _: impl Layouter<Fp>) -> Result<(), Error> {
                 unreachable!("Should not be called because of configuration error");
             }
         }
@@ -1766,10 +1748,7 @@ mod tests {
                     // If q is enabled, a must be in the table.
                     // If `s_ltable` is enabled, the value of `advice_table` & `table` is used as lookup table.
                     vec![
-                        (
-                            q.clone() * a.clone(),
-                            table * s_ltable.clone(),
-                        ),
+                        (q.clone() * a.clone(), table * s_ltable.clone()),
                         (q.clone() * a, advice_table * s_ltable.clone()),
                         (q, s_ltable),
                     ]

--- a/halo2_frontend/src/dev.rs
+++ b/halo2_frontend/src/dev.rs
@@ -1484,7 +1484,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "pair of selector/fixed queries(querying the tag columns) should be included, otherwise we have soundness error"
+        expected = "pair of tagging expressions(query of the tag columns or mutiple query combinations) should be included"
     )]
     fn bad_lookup_any_not_add_tagging_pairs() {
         const K: u32 = 4;

--- a/halo2_frontend/src/dev.rs
+++ b/halo2_frontend/src/dev.rs
@@ -1450,7 +1450,7 @@ mod tests {
                                 i,
                             )?;
 
-                            // Enable the table row on rows, which used for lookup table.
+                            // Enable the rows, which are used for lookup table values.
                             region.enable_selector(
                                 || format!("enabling table row {}", i),
                                 &config.s_ltable,
@@ -1492,7 +1492,8 @@ mod tests {
                                 config.advice_table,
                                 i,
                             )?;
-                            // Enable the table row on rows, which used for lookup table.
+
+                            // Enable the rows, which are used for lookup table values.
                             region.enable_selector(
                                 || format!("enabling table row {}", i),
                                 &config.s_ltable,

--- a/halo2_frontend/src/dev.rs
+++ b/halo2_frontend/src/dev.rs
@@ -1372,7 +1372,7 @@ mod tests {
                     //
                     // NOTE: When using `lookup_any` in circuit, the `Fixed` column or
                     //      `Selector` is required to be enabled for the lookup table values.
-                    // 
+                    //
                     //  The following diagram shows the example circuit.
                     //  (This is NOT a real `FaultyCircuit` instantiation we have in this test.)
                     //  The `table`(instance) column has many zeros at the end.

--- a/halo2_frontend/src/dev.rs
+++ b/halo2_frontend/src/dev.rs
@@ -1370,15 +1370,14 @@ mod tests {
 
                 meta.lookup_any("lookup", |cells| {
                     //
-                    // NOTE: When using `lookup_any` in circuit, the `Fixed` column or
-                    //      `Selector` is required to be enabled for the lookup table values.
+                    // NOTE: When using `lookup_any` in circuit, the extra `Fixed` column or
+                    //      `Selector` is required to be enabled, in order to indicate the lookup table values.
                     //
                     //  The following diagram shows the example circuit.
-                    //  (This is NOT a real `FaultyCircuit` instantiation we have in this test.)
-                    //  The `table`(instance) column has many zeros at the end.
-                    //  Those values are all copied into `advice_table` column.(Assuming we copy 5 rows)
-                    //  But, the only rows where `s_ltable` are enabled, for the lookup table values.
-                    //  Similarly, the only rows of `a` column where `q` is enabled, are used for lookup.
+                    //  (This is NOT a real `FaultyCircuit` instantiation we have in this test. Just borrow of its config.)
+                    //  Here, only the rows where `s_ltable` are enabled(row 0, 1, 2), are used as the lookup table values.
+                    //  In this way, only the values 1, 2, 3 are used as lookup table values, not unwanted 0.
+                    //  Similarly, only the rows of `a` column where `q` is enabled(row 0, 2, 4), are used for lookup.
                     //
                     //  |---------|---------|-----|----------------|------------|
                     //  |  table  |  q      |  a  |  advice_table  | s_ltable   |

--- a/halo2_frontend/src/dev.rs
+++ b/halo2_frontend/src/dev.rs
@@ -1484,7 +1484,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "pair of selector/fixed queries(columns) used for tagging should be included, otherwise we have soundness error"
+        expected = "pair of selector/fixed queries(querying the tag columns) should be included, otherwise we have soundness error"
     )]
     fn bad_lookup_any_not_add_tagging_pairs() {
         const K: u32 = 4;
@@ -1566,7 +1566,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "table expression need selector/fixed query(column) for tagging")]
+    #[should_panic(
+        expected = "pair of selector/fixed queries(querying the tag columns) should be included, otherwise we have soundness error"
+    )]
     fn bad_lookup_any_no_fixed_col_or_selector() {
         const K: u32 = 4;
 
@@ -1641,7 +1643,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "all table expressions contain only fixed query(column), should use `lookup` api instead of `lookup_any`"
+        expected = "all table expressions contain only fixed query, should use `lookup` api instead of `lookup_any`"
     )]
     fn bad_lookup_any_use_only_fixed_col() {
         const K: u32 = 4;

--- a/halo2_frontend/src/plonk/circuit/constraint_system.rs
+++ b/halo2_frontend/src/plonk/circuit/constraint_system.rs
@@ -389,6 +389,12 @@ impl<F: Field> ConstraintSystem<F> {
     ///
     /// `table_map` returns a map between input expressions and the table expressions
     /// they need to match.
+    /// 
+    /// NOTE:   
+    ///   The `table_expression`(right hand side) should be degree >= 2.  
+    ///   In other words, its table value rows should be explicitly enabled by use of `Fixed` column or `Selector`.  
+    ///   Otherwise, we have soundness error.(See https://github.com/privacy-scaling-explorations/halo2/issues/335)  
+    ///   Usage example: https://github.com/privacy-scaling-explorations/halo2/blob/main/halo2_proofs/tests/frontend_backend_split.rs
     pub fn lookup_any<S: AsRef<str>>(
         &mut self,
         name: S,

--- a/halo2_frontend/src/plonk/circuit/constraint_system.rs
+++ b/halo2_frontend/src/plonk/circuit/constraint_system.rs
@@ -402,50 +402,81 @@ impl<F: Field> ConstraintSystem<F> {
         name: S,
         table_map: impl FnOnce(&mut VirtualCells<'_, F>) -> Vec<(Expression<F>, Expression<F>)>,
     ) -> usize {
-        let mut cells = VirtualCells::new(self);
+        #[cfg(feature = "lookup-any-sanity-checks")]
+        {
+            let mut cells = VirtualCells::new(self);
 
-        let mut is_all_table_expr_single_fixed = true;
-        let mut is_all_table_expr_contain_fixed_or_selector = true;
-        let mut is_tagging_exprs_pair_exists = false;
+            let mut is_all_table_expr_single_fixed = true;
+            let mut is_all_table_expr_contain_fixed_or_selector = true;
+            let mut is_tagging_exprs_pair_exists = false;
 
-        let table_map = table_map(&mut cells)
-            .into_iter()
-            .map(|(mut input, mut table)| {
-                if input.contains_simple_selector() {
-                    panic!("expression containing simple selector supplied to lookup argument");
-                }
-                if table.contains_simple_selector() {
-                    panic!("expression containing simple selector supplied to lookup argument");
-                }
+            let table_map = table_map(&mut cells)
+                .into_iter()
+                .map(|(mut input, mut table)| {
+                    if input.contains_simple_selector() {
+                        panic!("expression containing simple selector supplied to lookup argument");
+                    }
+                    if table.contains_simple_selector() {
+                        panic!("expression containing simple selector supplied to lookup argument");
+                    }
 
-                is_all_table_expr_single_fixed &= table.degree() == 1 && table.contains_fixed_col();
-                is_all_table_expr_contain_fixed_or_selector &=
-                    table.contains_fixed_col_or_selector();
-                is_tagging_exprs_pair_exists |=
-                    table.contains_fixed_col_or_selector() && table.degree() == 1;
+                    is_all_table_expr_single_fixed &=
+                        table.degree() == 1 && table.contains_fixed_col();
+                    is_all_table_expr_contain_fixed_or_selector &=
+                        table.contains_fixed_col_or_selector();
+                    is_tagging_exprs_pair_exists |=
+                        table.contains_fixed_col_or_selector() && table.degree() == 1;
 
-                input.query_cells(&mut cells);
-                table.query_cells(&mut cells);
-                (input, table)
-            })
-            .collect();
+                    input.query_cells(&mut cells);
+                    table.query_cells(&mut cells);
+                    (input, table)
+                })
+                .collect();
 
-        if is_all_table_expr_single_fixed {
-            panic!("all table expressions contain only fixed query, should use `lookup` api instead of `lookup_any`");
+            if is_all_table_expr_single_fixed {
+                panic!("all table expressions contain only fixed query, should use `lookup` api instead of `lookup_any`");
+            }
+            if !is_all_table_expr_contain_fixed_or_selector {
+                panic!("all table expressions need selector/fixed query for tagging");
+            }
+            if !is_tagging_exprs_pair_exists {
+                panic!("pair of tagging expressions(query of the tag columns or mutiple query combinations) should be included");
+            }
+
+            let index = self.lookups.len();
+
+            self.lookups
+                .push(lookup::Argument::new(name.as_ref(), table_map));
+
+            index
         }
-        if !is_all_table_expr_contain_fixed_or_selector {
-            panic!("all table expressions need selector/fixed query for tagging");
+        #[cfg(not(feature = "lookup-any-sanity-checks"))]
+        {
+            let mut cells = VirtualCells::new(self);
+
+            let table_map = table_map(&mut cells)
+                .into_iter()
+                .map(|(mut input, mut table)| {
+                    if input.contains_simple_selector() {
+                        panic!("expression containing simple selector supplied to lookup argument");
+                    }
+                    if table.contains_simple_selector() {
+                        panic!("expression containing simple selector supplied to lookup argument");
+                    }
+
+                    input.query_cells(&mut cells);
+                    table.query_cells(&mut cells);
+                    (input, table)
+                })
+                .collect();
+
+            let index = self.lookups.len();
+
+            self.lookups
+                .push(lookup::Argument::new(name.as_ref(), table_map));
+
+            index
         }
-        if !is_tagging_exprs_pair_exists {
-            panic!("pair of tagging expressions(query of the tag columns or mutiple query combinations) should be included");
-        }
-
-        let index = self.lookups.len();
-
-        self.lookups
-            .push(lookup::Argument::new(name.as_ref(), table_map));
-
-        index
     }
 
     /// Add a shuffle argument for some input expressions and table expressions.

--- a/halo2_frontend/src/plonk/circuit/constraint_system.rs
+++ b/halo2_frontend/src/plonk/circuit/constraint_system.rs
@@ -402,6 +402,8 @@ impl<F: Field> ConstraintSystem<F> {
         let mut cells = VirtualCells::new(self);
 
         let mut is_all_table_expr_fixed_or_selector = true;
+        let mut is_all_input_expr_contains_fixed_or_selector = true;
+        let mut is_all_table_expr_contains_fixed_or_selector = true;
         let mut is_tagging_cols_pair_exists = false;
 
         let table_map = table_map(&mut cells)
@@ -416,6 +418,12 @@ impl<F: Field> ConstraintSystem<F> {
 
                 is_all_table_expr_fixed_or_selector &=
                     table.degree() == 1 && table.contains_fixed_col_or_selector();
+
+                is_all_input_expr_contains_fixed_or_selector &=
+                    input.contains_fixed_col_or_selector();
+                is_all_table_expr_contains_fixed_or_selector &=
+                    table.contains_fixed_col_or_selector();
+
                 is_tagging_cols_pair_exists |= (input.contains_fixed_col_or_selector()
                     && input.degree() == 1)
                     && (table.contains_fixed_col_or_selector() && table.degree() == 1);
@@ -428,6 +436,12 @@ impl<F: Field> ConstraintSystem<F> {
 
         if is_all_table_expr_fixed_or_selector {
             panic!("all table expressions contain only fixed query, should use `lookup` api instead of `lookup_any`");
+        }
+        if !is_all_input_expr_contains_fixed_or_selector {
+            panic!("all input expressions need selector/fixed query for tagging");
+        }
+        if !is_all_table_expr_contains_fixed_or_selector {
+            panic!("all table expressions need selector/fixed query for tagging");
         }
         if !is_tagging_cols_pair_exists {
             panic!("pair of selector/fixed queries(querying the tag columns) should be included, otherwise we have soundness error");

--- a/halo2_frontend/src/plonk/circuit/constraint_system.rs
+++ b/halo2_frontend/src/plonk/circuit/constraint_system.rs
@@ -389,7 +389,7 @@ impl<F: Field> ConstraintSystem<F> {
     ///
     /// `table_map` returns a map between input expressions and the table expressions
     /// they need to match.
-    /// 
+    ///
     /// NOTE:   
     ///   The `table_expression`(right hand side) should be degree >= 2.  
     ///   In other words, its table value rows should be explicitly enabled by use of `Fixed` column or `Selector`.  

--- a/halo2_frontend/src/plonk/circuit/constraint_system.rs
+++ b/halo2_frontend/src/plonk/circuit/constraint_system.rs
@@ -390,9 +390,9 @@ impl<F: Field> ConstraintSystem<F> {
     /// `table_map` returns a map between input expressions and the table expressions
     /// they need to match.
     ///
-    /// NOTE:   
-    ///   The `table_expression`(right hand side) should be degree >= 2.  
-    ///   In other words, its table value rows should be explicitly enabled by use of `Fixed` column or `Selector`.  
+    /// **NOTE:**   
+    ///   If we want to use `Advice` or `Instance` column as `TableColumn` in lookup argument,   
+    ///   we need to use extra `Fixed` column or `Selector` for tagging purpose.  
     ///   Otherwise, we have soundness error.(See https://github.com/privacy-scaling-explorations/halo2/issues/335)  
     ///   Usage example: https://github.com/privacy-scaling-explorations/halo2/blob/main/halo2_proofs/tests/frontend_backend_split.rs
     pub fn lookup_any<S: AsRef<str>>(
@@ -410,12 +410,9 @@ impl<F: Field> ConstraintSystem<F> {
                 if table.contains_simple_selector() {
                     panic!("expression containing simple selector supplied to lookup argument");
                 }
-                // this check ensures that one extra, dedicated `Fixed` column or `Selector` is used
-                // for enabling the real table rows of the column, which is used as `TableColumn`.
-                // otherwise, we get the soundness error, like https://github.com/privacy-scaling-explorations/halo2/issues/335
-                if table.degree() < 2 {
+                if !table.contains_fixed_col_or_selector() {
                     panic!(
-                        "table expression supplied to lookup_any argument must have degree >= 2"
+                        "table expression supplied to lookup_any argument must include fixed column or selector"
                     );
                 }
                 input.query_cells(&mut cells);

--- a/halo2_frontend/src/plonk/circuit/constraint_system.rs
+++ b/halo2_frontend/src/plonk/circuit/constraint_system.rs
@@ -410,8 +410,8 @@ impl<F: Field> ConstraintSystem<F> {
                 if table.contains_simple_selector() {
                     panic!("expression containing simple selector supplied to lookup argument");
                 }
-                // this check ensures that one dedicated `Fixed` column or `Selector` is used
-                // for enabling the real table rows of the column, which is used as `TableColumn` role.
+                // this check ensures that one extra, dedicated `Fixed` column or `Selector` is used
+                // for enabling the real table rows of the column, which is used as `TableColumn`.
                 // otherwise, we get the soundness error, like https://github.com/privacy-scaling-explorations/halo2/issues/335
                 if table.degree() < 2 {
                     panic!(

--- a/halo2_frontend/src/plonk/circuit/constraint_system.rs
+++ b/halo2_frontend/src/plonk/circuit/constraint_system.rs
@@ -440,12 +440,10 @@ impl<F: Field> ConstraintSystem<F> {
         if is_all_table_expr_fixed_or_selector {
             panic!("all table expressions contain only fixed query(column), should use `lookup` api instead of `lookup_any`");
         }
-        if !is_all_input_expr_contains_fixed_or_selector
-        {
+        if !is_all_input_expr_contains_fixed_or_selector {
             panic!("input expression need selector/fixed query(column) for tagging");
         }
-        if !is_all_table_expr_contains_fixed_or_selector
-        {
+        if !is_all_table_expr_contains_fixed_or_selector {
             panic!("table expression need selector/fixed query(column) for tagging");
         }
         if !is_selector_pair_exists {

--- a/halo2_frontend/src/plonk/circuit/constraint_system.rs
+++ b/halo2_frontend/src/plonk/circuit/constraint_system.rs
@@ -404,6 +404,14 @@ impl<F: Field> ConstraintSystem<F> {
                 if table.contains_simple_selector() {
                     panic!("expression containing simple selector supplied to lookup argument");
                 }
+                // this check ensures that one dedicated `Fixed` column or `Selector` is used
+                // for enabling the real table rows of the column, which is used as `TableColumn` role.
+                // otherwise, we get the soundness error, like https://github.com/privacy-scaling-explorations/halo2/issues/335
+                if table.degree() < 2 {
+                    panic!(
+                        "table expression supplied to lookup_any argument must have degree >= 2"
+                    );
+                }
                 input.query_cells(&mut cells);
                 table.query_cells(&mut cells);
                 (input, table)

--- a/halo2_frontend/src/plonk/circuit/constraint_system.rs
+++ b/halo2_frontend/src/plonk/circuit/constraint_system.rs
@@ -415,6 +415,9 @@ impl<F: Field> ConstraintSystem<F> {
                         "table expression supplied to lookup_any argument must include fixed column or selector"
                     );
                 }
+                if table.degree() == 1 {
+                    panic!("table expression containing only fixed column supplied to lookup_any argument, should use `lookup` api instead of `lookup_any`");
+                }
                 input.query_cells(&mut cells);
                 table.query_cells(&mut cells);
                 (input, table)

--- a/halo2_frontend/src/plonk/circuit/expression.rs
+++ b/halo2_frontend/src/plonk/circuit/expression.rs
@@ -976,6 +976,22 @@ impl<F: Field> Expression<F> {
 
         is_fixed_col_exists || is_selector_exists
     }
+
+    /// Returns whether or not this expression contains a `Advice` column.
+    pub(super) fn contains_advice_col(&self) -> bool {
+        self.evaluate(
+            &|_| false,
+            &|_| false,
+            &|_| false,
+            &|_| true,
+            &|_| false,
+            &|_| false,
+            &|a| a,
+            &|a, b| a || b,
+            &|a, b| a || b,
+            &|a, _| a,
+        )
+    }
 }
 
 impl<F: std::fmt::Debug> std::fmt::Debug for Expression<F> {

--- a/halo2_frontend/src/plonk/circuit/expression.rs
+++ b/halo2_frontend/src/plonk/circuit/expression.rs
@@ -947,43 +947,13 @@ impl<F: Field> Expression<F> {
         )
     }
 
-    /// Returns whether or not this expression contains a `Selector` or `Fixed` column.
-    pub(super) fn contains_fixed_col_or_selector(&self) -> bool {
-        let is_fixed_col_exists = self.evaluate(
-            &|_| false,
-            &|_| false,
-            &|_| true,
-            &|_| false,
-            &|_| false,
-            &|_| false,
-            &|a| a,
-            &|a, b| a || b,
-            &|a, b| a || b,
-            &|a, _| a,
-        );
-        let is_selector_exists = self.evaluate(
-            &|_| false,
-            &|_| true,
-            &|_| false,
-            &|_| false,
-            &|_| false,
-            &|_| false,
-            &|a| a,
-            &|a, b| a || b,
-            &|a, b| a || b,
-            &|a, _| a,
-        );
-
-        is_fixed_col_exists || is_selector_exists
-    }
-
-    /// Returns whether or not this expression contains a `Advice` column.
-    pub(super) fn contains_advice_col(&self) -> bool {
+    /// Returns whether or not this expression contains a `Fixed` column.
+    pub(super) fn contains_fixed_col(&self) -> bool {
         self.evaluate(
             &|_| false,
             &|_| false,
-            &|_| false,
             &|_| true,
+            &|_| false,
             &|_| false,
             &|_| false,
             &|a| a,
@@ -991,6 +961,27 @@ impl<F: Field> Expression<F> {
             &|a, b| a || b,
             &|a, _| a,
         )
+    }
+
+    /// Returns whether or not this expression contains a `Selector`.
+    pub(super) fn contains_selector(&self) -> bool {
+        self.evaluate(
+            &|_| false,
+            &|_| true,
+            &|_| false,
+            &|_| false,
+            &|_| false,
+            &|_| false,
+            &|a| a,
+            &|a, b| a || b,
+            &|a, b| a || b,
+            &|a, _| a,
+        )
+    }
+
+    /// Returns whether or not this expression contains a `Selector` or `Fixed` column.
+    pub(super) fn contains_fixed_col_or_selector(&self) -> bool {
+        self.contains_fixed_col() || self.contains_selector()
     }
 }
 

--- a/halo2_frontend/src/plonk/circuit/expression.rs
+++ b/halo2_frontend/src/plonk/circuit/expression.rs
@@ -946,6 +946,36 @@ impl<F: Field> Expression<F> {
             &|a, _| a,
         )
     }
+
+    /// Returns whether or not this expression contains a `Selector` or `Fixed` column.
+    pub(super) fn contains_fixed_col_or_selector(&self) -> bool {
+        let is_fixed_col_exists = self.evaluate(
+            &|_| false,
+            &|_| false,
+            &|_| true,
+            &|_| false,
+            &|_| false,
+            &|_| false,
+            &|a| a,
+            &|a, b| a || b,
+            &|a, b| a || b,
+            &|a, _| a,
+        );
+        let is_selector_exists = self.evaluate(
+            &|_| false,
+            &|_| true,
+            &|_| false,
+            &|_| false,
+            &|_| false,
+            &|_| false,
+            &|a| a,
+            &|a, b| a || b,
+            &|a, b| a || b,
+            &|a, _| a,
+        );
+
+        is_fixed_col_exists || is_selector_exists
+    }
 }
 
 impl<F: std::fmt::Debug> std::fmt::Debug for Expression<F> {

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -66,7 +66,7 @@ serde_json = "1"
 getrandom = { version = "0.2", features = ["js"] }
 
 [features]
-default = ["batch", "bits", "halo2_frontend/default", "halo2_backend/default"]
+default = ["batch", "bits", "halo2_frontend/default", "halo2_backend/default", "lookup-any-sanity-checks"]
 dev-graph = ["halo2_frontend/dev-graph", "plotters"]
 test-dev-graph = [
     "halo2_frontend/test-dev-graph",
@@ -84,6 +84,7 @@ circuit-params = ["halo2_frontend/circuit-params"]
 heap-profiling = ["halo2_frontend/heap-profiling"]
 cost-estimator = ["halo2_frontend/cost-estimator"]
 derive_serde = ["halo2curves/derive_serde", "halo2_frontend/derive_serde", "halo2_backend/derive_serde"]
+lookup-any-sanity-checks = ["halo2_frontend/lookup-any-sanity-checks"]
 
 [lib]
 bench = false

--- a/halo2_proofs/tests/frontend_backend_split.rs
+++ b/halo2_proofs/tests/frontend_backend_split.rs
@@ -365,6 +365,10 @@ impl<F: Field + From<u64>, const WIDTH_FACTOR: usize> MyCircuit<F, WIDTH_FACTOR>
                         .expect("todo");
                     offset += 1;
                 }
+                region
+                    .assign_fixed(|| "", config.s_lookup, offset, || Value::known(F::ONE))
+                    .expect("todo");
+                offset += 1;
 
                 // Enable RLC gate 3 times
                 for abcd in [[3, 5, 3, 5], [8, 9, 8, 9], [111, 222, 111, 222]] {

--- a/halo2_proofs/tests/frontend_backend_split.rs
+++ b/halo2_proofs/tests/frontend_backend_split.rs
@@ -28,7 +28,7 @@ use halo2_frontend::{
     },
 };
 use halo2_middleware::{ff::Field, poly::Rotation};
-use std::{collections::HashMap, iter::zip};
+use std::collections::HashMap;
 
 #[derive(Clone)]
 struct MyCircuitConfig {
@@ -182,7 +182,7 @@ impl<F: Field + From<u64>, const WIDTH_FACTOR: usize> MyCircuit<F, WIDTH_FACTOR>
             let d = meta.query_fixed(d, Rotation::cur());
             let lhs = [one.clone(), a, b].map(|c| c * s_lookup.clone());
             let rhs = [one.clone(), d, c].map(|c| c * s_ltable.clone());
-            zip(lhs, rhs).chain([(s_lookup, s_ltable)]).collect()
+            lhs.into_iter().zip(rhs).collect()
         });
 
         meta.shuffle(format!("shuffle.{id}"), |meta| {
@@ -365,7 +365,6 @@ impl<F: Field + From<u64>, const WIDTH_FACTOR: usize> MyCircuit<F, WIDTH_FACTOR>
                         .expect("todo");
                     offset += 1;
                 }
-                offset += 1;
 
                 // Enable RLC gate 3 times
                 for abcd in [[3, 5, 3, 5], [8, 9, 8, 9], [111, 222, 111, 222]] {

--- a/halo2_proofs/tests/frontend_backend_split.rs
+++ b/halo2_proofs/tests/frontend_backend_split.rs
@@ -42,7 +42,7 @@ struct MyCircuitConfig {
 
     // Copy constraints between columns (a, b) and (a, d)
 
-    // A dynamic lookup: s_lookup * [1, a[0], b[0]] in s_ltable * [1, d[0], c[0]]
+    // A dynamic lookup: s_lookup * [a[0], b[0]] in s_ltable * [d[0], c[0]]
     s_lookup: Column<Fixed>,
     s_ltable: Column<Fixed>,
 
@@ -180,8 +180,8 @@ impl<F: Field + From<u64>, const WIDTH_FACTOR: usize> MyCircuit<F, WIDTH_FACTOR>
             let b = meta.query_advice(b, Rotation::cur());
             let c = meta.query_advice(c, Rotation::cur());
             let d = meta.query_fixed(d, Rotation::cur());
-            let lhs = [one.clone(), a, b].map(|c| c * s_lookup.clone());
-            let rhs = [one.clone(), d, c].map(|c| c * s_ltable.clone());
+            let lhs = [a, b].map(|c| c * s_lookup.clone());
+            let rhs = [d, c].map(|c| c * s_ltable.clone());
             lhs.into_iter().zip(rhs).collect()
         });
 


### PR DESCRIPTION
## Description
Dynamic lookup, which uses the `lookup_any`, should have the assertion to prevent use of `Advice/Instance` column without extra `Fixed` column or `Selector`.
This PR adds assertion to `lookup_any` api.

## Related issues
- Resolve #224 #335 

## Changes
- add assertion of `table_expression` containing `fixed` col or `selector` in `lookup_any` api
- add extra check that `table_expression` should NOT be one simple `fixed` col, in `lookup_any` api
- update/add the unit tests