### PR TITLE
patch: include more fields to transcript

### DIFF
--- a/halo2_backend/src/plonk/circuit.rs
+++ b/halo2_backend/src/plonk/circuit.rs
@@ -261,15 +261,10 @@ impl<'a, F: Field> std::fmt::Debug for PinnedConstraintSystem<'a, F> {
         debug_struct
             .field("num_fixed_columns", self.num_fixed_columns)
             .field("num_advice_columns", self.num_advice_columns)
-            .field("num_instance_columns", self.num_instance_columns);
-        // Only show multi-phase related fields if it's used.
-        if *self.num_challenges > 0 {
-            debug_struct
-                .field("num_challenges", self.num_challenges)
-                .field("advice_column_phase", self.advice_column_phase)
-                .field("challenge_phase", self.challenge_phase);
-        }
-        debug_struct
+            .field("num_instance_columns", self.num_instance_columns)
+            .field("num_challenges", self.num_challenges)
+            .field("advice_column_phase", self.advice_column_phase)
+            .field("challenge_phase", self.challenge_phase)
             .field("gates", &self.gates)
             .field("advice_queries", self.advice_queries)
             .field("instance_queries", self.instance_queries)

--- a/halo2_backend/src/plonk/circuit.rs
+++ b/halo2_backend/src/plonk/circuit.rs
@@ -238,6 +238,8 @@ impl<'a, F: Field> std::fmt::Debug for PinnedGates<'a, F> {
 }
 
 /// Represents the minimal parameters that determine a `ConstraintSystem`.
+#[allow(dead_code)]
+#[derive(Debug)]
 pub(crate) struct PinnedConstraintSystem<'a, F: Field> {
     num_fixed_columns: &'a usize,
     num_advice_columns: &'a usize,
@@ -253,28 +255,6 @@ pub(crate) struct PinnedConstraintSystem<'a, F: Field> {
     lookups: &'a Vec<LookupArgumentBack<F>>,
     shuffles: &'a Vec<ShuffleArgumentBack<F>>,
     minimum_degree: &'a Option<usize>,
-}
-
-impl<'a, F: Field> std::fmt::Debug for PinnedConstraintSystem<'a, F> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut debug_struct = f.debug_struct("PinnedConstraintSystem");
-        debug_struct
-            .field("num_fixed_columns", self.num_fixed_columns)
-            .field("num_advice_columns", self.num_advice_columns)
-            .field("num_instance_columns", self.num_instance_columns)
-            .field("num_challenges", self.num_challenges)
-            .field("advice_column_phase", self.advice_column_phase)
-            .field("challenge_phase", self.challenge_phase)
-            .field("gates", &self.gates)
-            .field("advice_queries", self.advice_queries)
-            .field("instance_queries", self.instance_queries)
-            .field("fixed_queries", self.fixed_queries)
-            .field("permutation", self.permutation)
-            .field("lookups", self.lookups)
-            .field("shuffles", self.shuffles)
-            .field("minimum_degree", self.minimum_degree);
-        debug_struct.finish()
-    }
 }
 
 // Cost functions: arguments required degree

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -674,6 +674,15 @@ fn plonk_api() {
         num_fixed_columns: 7,
         num_advice_columns: 5,
         num_instance_columns: 1,
+        num_challenges: 0,
+        advice_column_phase: [
+            0,
+            0,
+            0,
+            0,
+            0,
+        ],
+        challenge_phase: [],
         gates: [
             Sum(
                 Sum(


### PR DESCRIPTION
## Description
- Add more conditionally-debugged fields to `transcript_repr`

## Related issues
- Resolve #350 

## Changes
- add multi-phase related challenge fields to `PinnedConstraintSystem::fmt`
- update the `plonk_api` test