### PR TITLE
Use vectors instead of slices for PI

### DIFF
--- a/halo2_backend/src/plonk/prover.rs
+++ b/halo2_backend/src/plonk/prover.rs
@@ -68,9 +68,7 @@ impl<
         engine: PlonkEngine<Scheme::Curve, M>,
         params: &'params Scheme::ParamsProver,
         pk: &'a ProvingKey<Scheme::Curve>,
-        // TODO: If this was a vector the usage would be simpler
-        // https://github.com/privacy-scaling-explorations/halo2/issues/265
-        instance: &[&[Scheme::Scalar]],
+        instance: Vec<Vec<Scheme::Scalar>>,
         rng: R,
         transcript: &'a mut T,
     ) -> Result<Self, Error>
@@ -90,9 +88,7 @@ impl<
     pub fn new(
         params: &'params Scheme::ParamsProver,
         pk: &'a ProvingKey<Scheme::Curve>,
-        // TODO: If this was a vector the usage would be simpler
-        // https://github.com/privacy-scaling-explorations/halo2/issues/265
-        instance: &[&[Scheme::Scalar]],
+        instance: Vec<Vec<Scheme::Scalar>>,
         rng: R,
         transcript: &'a mut T,
     ) -> Result<ProverSingle<'a, 'params, Scheme, P, E, R, T, H2cEngine>, Error>
@@ -175,9 +171,7 @@ impl<
         engine: PlonkEngine<Scheme::Curve, M>,
         params: &'params Scheme::ParamsProver,
         pk: &'a ProvingKey<Scheme::Curve>,
-        // TODO: If this was a vector the usage would be simpler.
-        // https://github.com/privacy-scaling-explorations/halo2/issues/265
-        circuits_instances: &[&[&[Scheme::Scalar]]],
+        circuits_instances: &[Vec<Vec<Scheme::Scalar>>],
         rng: R,
         transcript: &'a mut T,
     ) -> Result<Self, Error>
@@ -201,7 +195,7 @@ impl<
         // commit_instance_fn is a helper function to return the polynomials (and its commitments) of
         // instance columns while updating the transcript.
         let mut commit_instance_fn =
-            |instance: &[&[Scheme::Scalar]]| -> Result<InstanceSingle<Scheme::Curve>, Error> {
+            |instance: &[Vec<Scheme::Scalar>]| -> Result<InstanceSingle<Scheme::Curve>, Error> {
                 // Create a lagrange polynomial for each instance column
 
                 let instance_values = instance
@@ -905,9 +899,7 @@ impl<
     pub fn new(
         params: &'params Scheme::ParamsProver,
         pk: &'a ProvingKey<Scheme::Curve>,
-        // TODO: If this was a vector the usage would be simpler.
-        // https://github.com/privacy-scaling-explorations/halo2/issues/265
-        circuits_instances: &[&[&[Scheme::Scalar]]],
+        circuits_instances: &[Vec<Vec<Scheme::Scalar>>],
         rng: R,
         transcript: &'a mut T,
     ) -> Result<Prover<'a, 'params, Scheme, P, E, R, T, H2cEngine>, Error>

--- a/halo2_backend/src/plonk/verifier.rs
+++ b/halo2_backend/src/plonk/verifier.rs
@@ -34,7 +34,7 @@ pub fn verify_proof_single<'params, Scheme, V, E, T, Strategy>(
     params: &'params Scheme::ParamsVerifier,
     vk: &VerifyingKey<Scheme::Curve>,
     strategy: Strategy,
-    instance: &[&[Scheme::Scalar]],
+    instance: Vec<Vec<Scheme::Scalar>>,
     transcript: &mut T,
 ) -> Result<Strategy::Output, Error>
 where
@@ -60,7 +60,7 @@ pub fn verify_proof<
     params: &'params Scheme::ParamsVerifier,
     vk: &VerifyingKey<Scheme::Curve>,
     strategy: Strategy,
-    instances: &[&[&[Scheme::Scalar]]],
+    instances: &[Vec<Vec<Scheme::Scalar>>],
     transcript: &mut T,
 ) -> Result<Strategy::Output, Error>
 where
@@ -301,9 +301,12 @@ where
                     .instance_queries
                     .iter()
                     .map(|(column, rotation)| {
-                        let instances = instances[column.index];
+                        let instances = &instances[column.index];
                         let offset = (max_rotation - rotation.0) as usize;
-                        compute_inner_product(instances, &l_i_s[offset..offset + instances.len()])
+                        compute_inner_product(
+                            instances.as_slice(),
+                            &l_i_s[offset..offset + instances.len()],
+                        )
                     })
                     .collect::<Vec<_>>()
             })

--- a/halo2_backend/src/plonk/verifier/batch.rs
+++ b/halo2_backend/src/plonk/verifier/batch.rs
@@ -99,7 +99,6 @@ where
             // `is_zero() == false` then this argument won't be able to interfere with it
             // to make it true, with high probability.
             acc.scale(C::Scalar::random(OsRng));
-
             acc.add_msm(&msm);
             acc
         }
@@ -109,16 +108,9 @@ where
             .into_par_iter()
             .enumerate()
             .map(|(i, item)| {
-                let instances: Vec<Vec<_>> = item
-                    .instances
-                    .iter()
-                    .map(|i| i.iter().map(|c| &c[..]).collect())
-                    .collect();
-                let instances: Vec<_> = instances.iter().map(|i| &i[..]).collect();
-
                 let strategy = BatchStrategy::new(params);
                 let mut transcript = Blake2bRead::init(&item.proof[..]);
-                verify_proof(params, vk, strategy, &instances, &mut transcript).map_err(|e| {
+                verify_proof(params, vk, strategy, &item.instances, &mut transcript).map_err(|e| {
                     tracing::debug!("Batch item {} failed verification: {}", i, e);
                     e
                 })

--- a/halo2_frontend/src/circuit.rs
+++ b/halo2_frontend/src/circuit.rs
@@ -117,7 +117,7 @@ struct WitnessCollection<'a, F: Field> {
     advice_column_phase: &'a Vec<sealed::Phase>,
     advice: Vec<Vec<Assigned<F>>>,
     challenges: &'a HashMap<usize, F>,
-    instances: &'a [&'a [F]],
+    instances: &'a [Vec<F>],
     usable_rows: RangeTo<usize>,
 }
 
@@ -259,7 +259,7 @@ pub struct WitnessCalculator<'a, F: Field, ConcreteCircuit: Circuit<F>> {
     circuit: &'a ConcreteCircuit,
     config: &'a ConcreteCircuit::Config,
     cs: &'a ConstraintSystem<F>,
-    instances: &'a [&'a [F]],
+    instances: &'a [Vec<F>],
     next_phase: u8,
 }
 
@@ -270,7 +270,7 @@ impl<'a, F: Field, ConcreteCircuit: Circuit<F>> WitnessCalculator<'a, F, Concret
         circuit: &'a ConcreteCircuit,
         config: &'a ConcreteCircuit::Config,
         cs: &'a ConstraintSystem<F>,
-        instances: &'a [&'a [F]],
+        instances: &'a [Vec<F>],
     ) -> Self {
         let n = 2usize.pow(k);
         let unusable_rows_start = n - (cs.blinding_factors() + 1);

--- a/halo2_proofs/benches/plonk.rs
+++ b/halo2_proofs/benches/plonk.rs
@@ -291,7 +291,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             params,
             pk,
             &[circuit],
-            &[&[]],
+            &[vec![vec![]]],
             rng,
             &mut transcript,
         )
@@ -302,7 +302,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     fn verifier(params: &ParamsIPA<EqAffine>, vk: &VerifyingKey<EqAffine>, proof: &[u8]) {
         let strategy = SingleStrategy::new(params);
         let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(proof);
-        assert!(verify_proof(params, vk, strategy, &[&[]], &mut transcript).is_ok());
+        assert!(verify_proof(params, vk, strategy, &[vec![vec![]]], &mut transcript).is_ok());
     }
 
     let k_range = 8..=16;

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -30,7 +30,7 @@ pub fn create_proof_with_engine<
     params: &'params Scheme::ParamsProver,
     pk: &ProvingKey<Scheme::Curve>,
     circuits: &[ConcreteCircuit],
-    instances: &[&[&[Scheme::Scalar]]],
+    instances: &[Vec<Vec<Scheme::Scalar>>],
     rng: R,
     transcript: &mut T,
 ) -> Result<(), Error>
@@ -51,7 +51,9 @@ where
     let mut witness_calcs: Vec<_> = circuits
         .iter()
         .enumerate()
-        .map(|(i, circuit)| WitnessCalculator::new(params.k(), circuit, &config, &cs, instances[i]))
+        .map(|(i, circuit)| {
+            WitnessCalculator::new(params.k(), circuit, &config, &cs, instances[i].as_slice())
+        })
         .collect();
     let mut prover = Prover::<Scheme, P, _, _, _, _>::new_with_engine(
         engine, params, pk, instances, rng, transcript,
@@ -84,7 +86,7 @@ pub fn create_proof<
     params: &'params Scheme::ParamsProver,
     pk: &ProvingKey<Scheme::Curve>,
     circuits: &[ConcreteCircuit],
-    instances: &[&[&[Scheme::Scalar]]],
+    instances: &[Vec<Vec<Scheme::Scalar>>],
     rng: R,
     transcript: &mut T,
 ) -> Result<(), Error>
@@ -160,7 +162,7 @@ fn test_create_proof() {
         &params,
         &pk,
         &[MyCircuit, MyCircuit],
-        &[&[], &[]],
+        &[vec![], vec![]],
         OsRng,
         &mut transcript,
     )
@@ -220,7 +222,7 @@ fn test_create_proof_custom() {
         &params,
         &pk,
         &[MyCircuit, MyCircuit],
-        &[&[], &[]],
+        &[vec![], vec![]],
         OsRng,
         &mut transcript,
     )

--- a/halo2_proofs/tests/compress_selectors.rs
+++ b/halo2_proofs/tests/compress_selectors.rs
@@ -365,11 +365,7 @@ fn test_mycircuit(
 
     // Proving
     #[allow(clippy::useless_vec)]
-    let instances = vec![vec![Fr::one(), Fr::from_u128(3)]];
-    let instances_slice: &[&[Fr]] = &(instances
-        .iter()
-        .map(|instance| instance.as_slice())
-        .collect::<Vec<_>>());
+    let instances = vec![vec![vec![Fr::one(), Fr::from_u128(3)]]];
 
     let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
     create_proof_with_engine::<KZGCommitmentScheme<Bn256>, ProverSHPLONK<'_, Bn256>, _, _, _, _, _>(
@@ -377,7 +373,7 @@ fn test_mycircuit(
         &params,
         &pk,
         &[circuit],
-        &[instances_slice],
+        instances.as_slice(),
         &mut rng,
         &mut transcript,
     )?;
@@ -392,7 +388,7 @@ fn test_mycircuit(
         &verifier_params,
         &vk,
         strategy,
-        &[instances_slice],
+        instances.as_slice(),
         &mut verifier_transcript,
     )
     .map_err(halo2_proofs::plonk::Error::Backend)

--- a/halo2_proofs/tests/frontend_backend_split.rs
+++ b/halo2_proofs/tests/frontend_backend_split.rs
@@ -523,11 +523,7 @@ fn test_mycircuit_full_legacy() {
     println!("Keygen: {:?}", start.elapsed());
 
     // Proving
-    let instances = circuit.instances();
-    let instances_slice: &[&[Fr]] = &(instances
-        .iter()
-        .map(|instance| instance.as_slice())
-        .collect::<Vec<_>>());
+    let instances = vec![circuit.instances()];
 
     let start = Instant::now();
     let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
@@ -535,7 +531,7 @@ fn test_mycircuit_full_legacy() {
         &params,
         &pk,
         &[circuit],
-        &[instances_slice],
+        instances.as_slice(),
         &mut rng,
         &mut transcript,
     )
@@ -554,7 +550,7 @@ fn test_mycircuit_full_legacy() {
         &verifier_params,
         &vk,
         strategy,
-        &[instances_slice],
+        instances.as_slice(),
         &mut verifier_transcript,
     )
     .expect("verify succeeds");
@@ -585,16 +581,11 @@ fn test_mycircuit_full_split() {
     println!("Keygen: {:?}", start.elapsed());
     drop(compiled_circuit);
 
+    let instances = circuit.instances();
     // Proving
     println!("Proving...");
-    let instances = circuit.instances();
-    let instances_slice: &[&[Fr]] = &(instances
-        .iter()
-        .map(|instance| instance.as_slice())
-        .collect::<Vec<_>>());
-
     let start = Instant::now();
-    let mut witness_calc = WitnessCalculator::new(k, &circuit, &config, &cs, instances_slice);
+    let mut witness_calc = WitnessCalculator::new(k, &circuit, &config, &cs, &instances);
     let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
     let mut prover = ProverSingle::<
         KZGCommitmentScheme<Bn256>,
@@ -607,7 +598,7 @@ fn test_mycircuit_full_split() {
         engine,
         &params,
         &pk,
-        instances_slice,
+instances.clone(),
         &mut rng,
         &mut transcript,
     )
@@ -634,7 +625,7 @@ fn test_mycircuit_full_split() {
         &verifier_params,
         &vk,
         strategy,
-        instances_slice,
+        instances,
         &mut verifier_transcript,
     )
     .expect("verify succeeds");

--- a/halo2_proofs/tests/serialization.rs
+++ b/halo2_proofs/tests/serialization.rs
@@ -156,7 +156,7 @@ fn test_serialization() {
 
     std::fs::remove_file("serialization-test.pk").unwrap();
 
-    let instances: &[&[Fr]] = &[&[circuit.0]];
+    let instances: Vec<Vec<Vec<Fr>>> = vec![vec![vec![circuit.0]]];
     let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
     create_proof::<
         KZGCommitmentScheme<Bn256>,
@@ -169,7 +169,7 @@ fn test_serialization() {
         &params,
         &pk,
         &[circuit],
-        &[instances],
+        instances.as_slice(),
         OsRng,
         &mut transcript,
     )
@@ -189,7 +189,7 @@ fn test_serialization() {
         &verifier_params,
         pk.get_vk(),
         strategy,
-        &[instances],
+        instances.as_slice(),
         &mut transcript
     )
     .is_ok());

--- a/halo2_proofs/tests/shuffle.rs
+++ b/halo2_proofs/tests/shuffle.rs
@@ -287,7 +287,7 @@ fn test_prover<C: CurveAffine, const W: usize, const H: usize>(
             &params,
             &pk,
             &[circuit],
-            &[&[]],
+            &[vec![]],
             OsRng,
             &mut transcript,
         )
@@ -304,7 +304,7 @@ fn test_prover<C: CurveAffine, const W: usize, const H: usize>(
             &params,
             pk.get_vk(),
             strategy,
-            &[&[]],
+            &[vec![]],
             &mut transcript,
         )
         .map(|strategy| strategy.finalize())

--- a/halo2_proofs/tests/shuffle_api.rs
+++ b/halo2_proofs/tests/shuffle_api.rs
@@ -163,7 +163,7 @@ where
             &params,
             &pk,
             &[circuit],
-            &[&[]],
+            &[vec![]],
             OsRng,
             &mut transcript,
         )
@@ -180,7 +180,7 @@ where
             &params,
             pk.get_vk(),
             strategy,
-            &[&[]],
+            &[vec![]],
             &mut transcript,
         )
         .map(|strategy| strategy.finalize())

--- a/halo2_proofs/tests/vector-ops-unblinded.rs
+++ b/halo2_proofs/tests/vector-ops-unblinded.rs
@@ -479,6 +479,7 @@ where
     let vk = keygen_vk(&params, &circuit).unwrap();
     let pk = keygen_pk(&params, vk, &circuit).unwrap();
 
+    let instances = vec![vec![instances]];
     let proof = {
         let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
 
@@ -486,7 +487,7 @@ where
             &params,
             &pk,
             &[circuit],
-            &[&[&instances]],
+            &instances,
             OsRng,
             &mut transcript,
         )
@@ -503,7 +504,7 @@ where
             &params,
             pk.get_vk(),
             strategy,
-            &[&[&instances]],
+            &instances,
             &mut transcript,
         )
         .map(|strategy| strategy.finalize())

--- a/p3_frontend/tests/common/mod.rs
+++ b/p3_frontend/tests/common/mod.rs
@@ -87,7 +87,6 @@ pub(crate) fn setup_prove_verify(
     // Proving
     println!("Proving...");
     let start = Instant::now();
-    let vec_slices: Vec<&[Fr]> = pis.iter().map(|pi| &pi[..]).collect();
     let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
     let mut prover = ProverSingle::<
         KZGCommitmentScheme<Bn256>,
@@ -96,7 +95,7 @@ pub(crate) fn setup_prove_verify(
         _,
         _,
         H2cEngine,
-    >::new(&params, &pk, &vec_slices, &mut rng, &mut transcript)
+    >::new(&params, &pk, pis.to_vec(), &mut rng, &mut transcript)
     .unwrap();
     println!("phase 0");
     prover.commit_phase(0, witness).unwrap();
@@ -115,7 +114,7 @@ pub(crate) fn setup_prove_verify(
         &verifier_params,
         &vk,
         strategy,
-        &vec_slices,
+        pis.to_vec(),
         &mut verifier_transcript,
     )
     .expect("verify succeeds");


### PR DESCRIPTION
## Description
Instances were being passed as a triple slice of field elements: `&[&[&[F]]]` in many functions. 
It has been replaced for `&[Vec<Vec<F>>]`.

# Related issues
Closes #265 