### PR TITLE
fix: make lookup-any-sanity-checks optional in halo2_proofs

### DIFF
--- a/halo2_frontend/src/dev.rs
+++ b/halo2_frontend/src/dev.rs
@@ -1495,6 +1495,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "lookup-any-sanity-checks")]
     #[test]
     #[should_panic(
         expected = "pair of tagging expressions(query of the tag columns or mutiple query combinations) should be included"
@@ -1578,6 +1579,7 @@ mod tests {
         .unwrap();
     }
 
+    #[cfg(feature = "lookup-any-sanity-checks")]
     #[test]
     #[should_panic(expected = "all table expressions need selector/fixed query for tagging")]
     fn bad_lookup_any_no_fixed_col_or_selector() {
@@ -1652,6 +1654,7 @@ mod tests {
         .unwrap();
     }
 
+    #[cfg(feature = "lookup-any-sanity-checks")]
     #[test]
     #[should_panic(
         expected = "all table expressions contain only fixed query, should use `lookup` api instead of `lookup_any`"

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -42,8 +42,8 @@ harness = false
 
 [dependencies]
 halo2_middleware = { path = "../halo2_middleware" }
-halo2_backend = { path = "../halo2_backend" }
-halo2_frontend = { path = "../halo2_frontend" }
+halo2_backend = { path = "../halo2_backend", default-features = false }
+halo2_frontend = { path = "../halo2_frontend", default-features = false }
 halo2curves = { version = "0.6.1", default-features = false }
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 plotters = { version = "0.3.0", default-features = false, optional = true }


### PR DESCRIPTION
`halo2_proofs` was importing `halo2_frontend` with the default features, so there was no way to disable `lookup-any-sanity-checks` when using `halo2_proofs`.

Now `halo2_proofs` imports `halo2_frontend` without default features, and the dependencies features are completely controlled by the user via the `halo2_proofs` features.  I did the same for `halo2_backend` to achieve the same level of control.