### PR TITLE
feat: refactor the verify api

### DIFF
--- a/halo2_backend/src/plonk/prover.rs
+++ b/halo2_backend/src/plonk/prover.rs
@@ -39,9 +39,9 @@ struct AdviceSingle<C: CurveAffine, B: Basis> {
 }
 
 /// The prover object used to create proofs interactively by passing the witnesses to commit at
-/// each phase.  This works for a single proof.  This is a wrapper over Prover.
+/// each phase.  This works for a single proof.  This is a wrapper over ProverMulti.
 #[derive(Debug)]
-pub struct ProverSingle<
+pub struct Prover<
     'a,
     'params,
     Scheme: CommitmentScheme,
@@ -50,7 +50,7 @@ pub struct ProverSingle<
     R: RngCore,
     T: TranscriptWrite<Scheme::Curve, E>,
     M: MsmAccel<Scheme::Curve>,
->(Prover<'a, 'params, Scheme, P, E, R, T, M>);
+>(ProverMulti<'a, 'params, Scheme, P, E, R, T, M>);
 
 impl<
         'a,
@@ -61,9 +61,9 @@ impl<
         R: RngCore,
         T: TranscriptWrite<Scheme::Curve, E>,
         M: MsmAccel<Scheme::Curve>,
-    > ProverSingle<'a, 'params, Scheme, P, E, R, T, M>
+    > Prover<'a, 'params, Scheme, P, E, R, T, M>
 {
-    /// Create a new prover object
+    /// Create a new ProverMulti object
     pub fn new_with_engine(
         engine: PlonkEngine<Scheme::Curve, M>,
         params: &'params Scheme::ParamsProver,
@@ -75,7 +75,7 @@ impl<
     where
         Scheme::Scalar: WithSmallOrderMulGroup<3> + FromUniformBytes<64>,
     {
-        Ok(Self(Prover::new_with_engine(
+        Ok(Self(ProverMulti::new_with_engine(
             engine,
             params,
             pk,
@@ -91,12 +91,12 @@ impl<
         instance: Vec<Vec<Scheme::Scalar>>,
         rng: R,
         transcript: &'a mut T,
-    ) -> Result<ProverSingle<'a, 'params, Scheme, P, E, R, T, H2cEngine>, Error>
+    ) -> Result<Prover<'a, 'params, Scheme, P, E, R, T, H2cEngine>, Error>
     where
         Scheme::Scalar: WithSmallOrderMulGroup<3> + FromUniformBytes<64>,
     {
         let engine = PlonkEngineConfig::build_default();
-        ProverSingle::new_with_engine(engine, params, pk, instance, rng, transcript)
+        Prover::new_with_engine(engine, params, pk, instance, rng, transcript)
     }
 
     /// Commit the `witness` at `phase` and return the challenges after `phase`.
@@ -123,7 +123,7 @@ impl<
 /// The prover object used to create proofs interactively by passing the witnesses to commit at
 /// each phase.  This supports batch proving.
 #[derive(Debug)]
-pub struct Prover<
+pub struct ProverMulti<
     'a,
     'params,
     Scheme: CommitmentScheme,
@@ -164,7 +164,7 @@ impl<
         R: RngCore,
         T: TranscriptWrite<Scheme::Curve, E>,
         M: MsmAccel<Scheme::Curve>,
-    > Prover<'a, 'params, Scheme, P, E, R, T, M>
+    > ProverMulti<'a, 'params, Scheme, P, E, R, T, M>
 {
     /// Create a new prover object
     pub fn new_with_engine(
@@ -283,7 +283,7 @@ impl<
 
         let challenges = HashMap::<usize, Scheme::Scalar>::with_capacity(meta.num_challenges);
 
-        Ok(Prover {
+        Ok(ProverMulti {
             engine,
             params,
             pk,
@@ -902,11 +902,11 @@ impl<
         circuits_instances: &[Vec<Vec<Scheme::Scalar>>],
         rng: R,
         transcript: &'a mut T,
-    ) -> Result<Prover<'a, 'params, Scheme, P, E, R, T, H2cEngine>, Error>
+    ) -> Result<ProverMulti<'a, 'params, Scheme, P, E, R, T, H2cEngine>, Error>
     where
         Scheme::Scalar: WithSmallOrderMulGroup<3> + FromUniformBytes<64>,
     {
         let engine = PlonkEngineConfig::build_default();
-        Prover::new_with_engine(engine, params, pk, circuits_instances, rng, transcript)
+        ProverMulti::new_with_engine(engine, params, pk, circuits_instances, rng, transcript)
     }
 }

--- a/halo2_backend/src/plonk/verifier.rs
+++ b/halo2_backend/src/plonk/verifier.rs
@@ -30,7 +30,7 @@ pub use batch::BatchVerifier;
 
 /// Returns a boolean indicating whether or not the proof is valid.  Verifies a single proof (not
 /// batched).
-pub fn verify_proof_single<'params, Scheme, V, E, T, Strategy>(
+pub fn verify_proof<'params, Scheme, V, E, T, Strategy>(
     params: &'params Scheme::ParamsVerifier,
     vk: &VerifyingKey<Scheme::Curve>,
     instance: Vec<Vec<Scheme::Scalar>>,
@@ -44,7 +44,7 @@ where
     T: TranscriptRead<Scheme::Curve, E>,
     Strategy: VerificationStrategy<'params, Scheme, V, Output = Strategy>,
 {
-    verify_proof::<Scheme, V, E, T, Strategy>(params, vk, &[instance], transcript)
+    verify_proof_multi::<Scheme, V, E, T, Strategy>(params, vk, &[instance], transcript)
 }
 
 /// Process the proof, checks that the proof is valid and returns the `Strategy` output.
@@ -520,7 +520,7 @@ where
 }
 
 /// Returns a boolean indicating whether or not the proof is valid
-pub fn verify_proof<
+pub fn verify_proof_multi<
     'params,
     Scheme: CommitmentScheme,
     V: Verifier<'params, Scheme>,

--- a/halo2_backend/src/plonk/verifier.rs
+++ b/halo2_backend/src/plonk/verifier.rs
@@ -33,29 +33,28 @@ pub use batch::BatchVerifier;
 pub fn verify_proof_single<'params, Scheme, V, E, T, Strategy>(
     params: &'params Scheme::ParamsVerifier,
     vk: &VerifyingKey<Scheme::Curve>,
-    strategy: Strategy,
     instance: Vec<Vec<Scheme::Scalar>>,
     transcript: &mut T,
-) -> Result<Strategy::Output, Error>
+) -> bool
 where
     Scheme::Scalar: WithSmallOrderMulGroup<3> + FromUniformBytes<64>,
     Scheme: CommitmentScheme,
     V: Verifier<'params, Scheme>,
     E: EncodedChallenge<Scheme::Curve>,
     T: TranscriptRead<Scheme::Curve, E>,
-    Strategy: VerificationStrategy<'params, Scheme, V>,
+    Strategy: VerificationStrategy<'params, Scheme, V, Output = Strategy>,
 {
-    verify_proof(params, vk, strategy, &[instance], transcript)
+    verify_proof::<Scheme, V, E, T, Strategy>(params, vk, &[instance], transcript)
 }
 
-/// Returns a boolean indicating whether or not the proof is valid
-pub fn verify_proof<
+/// Process the proof, checks that the proof is valid and returns the `Strategy` output.
+pub fn verify_proof_with_strategy<
     'params,
     Scheme: CommitmentScheme,
     V: Verifier<'params, Scheme>,
     E: EncodedChallenge<Scheme::Curve>,
     T: TranscriptRead<Scheme::Curve, E>,
-    Strategy: VerificationStrategy<'params, Scheme, V>,
+    Strategy: VerificationStrategy<'params, Scheme, V, Output = Strategy>,
 >(
     params: &'params Scheme::ParamsVerifier,
     vk: &VerifyingKey<Scheme::Curve>,
@@ -518,4 +517,29 @@ where
             .verify_proof(transcript, queries, msm)
             .map_err(|_| Error::Opening)
     })
+}
+
+/// Returns a boolean indicating whether or not the proof is valid
+pub fn verify_proof<
+    'params,
+    Scheme: CommitmentScheme,
+    V: Verifier<'params, Scheme>,
+    E: EncodedChallenge<Scheme::Curve>,
+    T: TranscriptRead<Scheme::Curve, E>,
+    Strategy: VerificationStrategy<'params, Scheme, V, Output = Strategy>,
+>(
+    params: &'params Scheme::ParamsVerifier,
+    vk: &VerifyingKey<Scheme::Curve>,
+    instances: &[Vec<Vec<Scheme::Scalar>>],
+    transcript: &mut T,
+) -> bool
+where
+    Scheme::Scalar: WithSmallOrderMulGroup<3> + FromUniformBytes<64>,
+{
+    let strategy = Strategy::new(params);
+    let strategy = match verify_proof_with_strategy(params, vk, strategy, instances, transcript) {
+        Ok(strategy) => strategy,
+        Err(_) => return false,
+    };
+    strategy.finalize()
 }

--- a/halo2_backend/src/plonk/verifier.rs
+++ b/halo2_backend/src/plonk/verifier.rs
@@ -42,7 +42,7 @@ where
     V: Verifier<'params, Scheme>,
     E: EncodedChallenge<Scheme::Curve>,
     T: TranscriptRead<Scheme::Curve, E>,
-    Strategy: VerificationStrategy<'params, Scheme, V, Output = Strategy>,
+    Strategy: VerificationStrategy<'params, Scheme, V>,
 {
     verify_proof_multi::<Scheme, V, E, T, Strategy>(params, vk, &[instance], transcript)
 }
@@ -54,14 +54,14 @@ pub fn verify_proof_with_strategy<
     V: Verifier<'params, Scheme>,
     E: EncodedChallenge<Scheme::Curve>,
     T: TranscriptRead<Scheme::Curve, E>,
-    Strategy: VerificationStrategy<'params, Scheme, V, Output = Strategy>,
+    Strategy: VerificationStrategy<'params, Scheme, V>,
 >(
     params: &'params Scheme::ParamsVerifier,
     vk: &VerifyingKey<Scheme::Curve>,
     strategy: Strategy,
     instances: &[Vec<Vec<Scheme::Scalar>>],
     transcript: &mut T,
-) -> Result<Strategy::Output, Error>
+) -> Result<Strategy, Error>
 where
     Scheme::Scalar: WithSmallOrderMulGroup<3> + FromUniformBytes<64>,
 {
@@ -526,7 +526,7 @@ pub fn verify_proof_multi<
     V: Verifier<'params, Scheme>,
     E: EncodedChallenge<Scheme::Curve>,
     T: TranscriptRead<Scheme::Curve, E>,
-    Strategy: VerificationStrategy<'params, Scheme, V, Output = Strategy>,
+    Strategy: VerificationStrategy<'params, Scheme, V>,
 >(
     params: &'params Scheme::ParamsVerifier,
     vk: &VerifyingKey<Scheme::Curve>,

--- a/halo2_backend/src/plonk/verifier/batch.rs
+++ b/halo2_backend/src/plonk/verifier/batch.rs
@@ -5,7 +5,7 @@ use halo2_middleware::zal::impls::H2cEngine;
 use halo2curves::CurveAffine;
 use rand_core::OsRng;
 
-use super::{verify_proof, VerificationStrategy};
+use super::{verify_proof_with_strategy, VerificationStrategy};
 use crate::{
     multicore::{
         IndexedParallelIterator, IntoParallelIterator, ParallelIterator, TryFoldAndReduce,
@@ -34,7 +34,7 @@ struct BatchStrategy<'params, C: CurveAffine> {
 impl<'params, C: CurveAffine> VerificationStrategy<'params, IPACommitmentScheme<C>, VerifierIPA<C>>
     for BatchStrategy<'params, C>
 {
-    type Output = MSMIPA<'params, C>;
+    type Output = Self;
 
     fn new(params: &'params ParamsVerifierIPA<C>) -> Self {
         BatchStrategy {
@@ -47,7 +47,9 @@ impl<'params, C: CurveAffine> VerificationStrategy<'params, IPACommitmentScheme<
         f: impl FnOnce(MSMIPA<'params, C>) -> Result<GuardIPA<'params, C>, Error>,
     ) -> Result<Self::Output, Error> {
         let guard = f(self.msm)?;
-        Ok(guard.use_challenges())
+        Ok(Self {
+            msm: guard.use_challenges(),
+        })
     }
 
     fn finalize(self) -> bool {
@@ -110,10 +112,12 @@ where
             .map(|(i, item)| {
                 let strategy = BatchStrategy::new(params);
                 let mut transcript = Blake2bRead::init(&item.proof[..]);
-                verify_proof(params, vk, strategy, &item.instances, &mut transcript).map_err(|e| {
-                    tracing::debug!("Batch item {} failed verification: {}", i, e);
-                    e
-                })
+                verify_proof_with_strategy(params, vk, strategy, &item.instances, &mut transcript)
+                    .map_err(|e| {
+                        tracing::debug!("Batch item {} failed verification: {}", i, e);
+                        e
+                    })
+                    .map(|st| st.msm)
             })
             .try_fold_and_reduce(
                 || ParamsVerifier::<'_, C>::empty_msm(params),

--- a/halo2_backend/src/plonk/verifier/batch.rs
+++ b/halo2_backend/src/plonk/verifier/batch.rs
@@ -34,8 +34,6 @@ struct BatchStrategy<'params, C: CurveAffine> {
 impl<'params, C: CurveAffine> VerificationStrategy<'params, IPACommitmentScheme<C>, VerifierIPA<C>>
     for BatchStrategy<'params, C>
 {
-    type Output = Self;
-
     fn new(params: &'params ParamsVerifierIPA<C>) -> Self {
         BatchStrategy {
             msm: MSMIPA::new(params),
@@ -45,7 +43,7 @@ impl<'params, C: CurveAffine> VerificationStrategy<'params, IPACommitmentScheme<
     fn process(
         self,
         f: impl FnOnce(MSMIPA<'params, C>) -> Result<GuardIPA<'params, C>, Error>,
-    ) -> Result<Self::Output, Error> {
+    ) -> Result<Self, Error> {
         let guard = f(self.msm)?;
         Ok(Self {
             msm: guard.use_challenges(),

--- a/halo2_backend/src/poly/ipa/strategy.rs
+++ b/halo2_backend/src/poly/ipa/strategy.rs
@@ -79,8 +79,6 @@ pub struct AccumulatorStrategy<'params, C: CurveAffine> {
 impl<'params, C: CurveAffine> VerificationStrategy<'params, IPACommitmentScheme<C>, VerifierIPA<C>>
     for AccumulatorStrategy<'params, C>
 {
-    type Output = Self;
-
     fn new(params: &'params ParamsIPA<C>) -> Self {
         AccumulatorStrategy {
             msm: MSMIPA::new(params),
@@ -90,7 +88,7 @@ impl<'params, C: CurveAffine> VerificationStrategy<'params, IPACommitmentScheme<
     fn process(
         mut self,
         f: impl FnOnce(MSMIPA<'params, C>) -> Result<GuardIPA<'params, C>, Error>,
-    ) -> Result<Self::Output, Error> {
+    ) -> Result<Self, Error> {
         self.msm.scale(C::Scalar::random(OsRng));
         let guard = f(self.msm)?;
 
@@ -119,8 +117,6 @@ pub struct SingleStrategy<'params, C: CurveAffine> {
 impl<'params, C: CurveAffine> VerificationStrategy<'params, IPACommitmentScheme<C>, VerifierIPA<C>>
     for SingleStrategy<'params, C>
 {
-    type Output = Self;
-
     fn new(params: &'params ParamsIPA<C>) -> Self {
         SingleStrategy {
             msm: MSMIPA::new(params),
@@ -130,7 +126,7 @@ impl<'params, C: CurveAffine> VerificationStrategy<'params, IPACommitmentScheme<
     fn process(
         self,
         f: impl FnOnce(MSMIPA<'params, C>) -> Result<GuardIPA<'params, C>, Error>,
-    ) -> Result<Self::Output, Error> {
+    ) -> Result<Self, Error> {
         let guard = f(self.msm)?;
         Ok(Self {
             msm: guard.use_challenges(),

--- a/halo2_backend/src/poly/kzg/strategy.rs
+++ b/halo2_backend/src/poly/kzg/strategy.rs
@@ -120,8 +120,6 @@ where
     E::G1: CurveExt<AffineExt = E::G1Affine>,
     E::G2Affine: SerdeCurveAffine,
 {
-    type Output = Self;
-
     fn new(params: &'params ParamsVerifierKZG<E>) -> Self {
         AccumulatorStrategy::new(params)
     }
@@ -129,7 +127,7 @@ where
     fn process(
         mut self,
         f: impl FnOnce(V::MSMAccumulator) -> Result<V::Guard, Error>,
-    ) -> Result<Self::Output, Error> {
+    ) -> Result<Self, Error> {
         self.msm_accumulator.scale(E::Fr::random(OsRng));
 
         // Guard is updated with new msm contributions
@@ -155,8 +153,6 @@ where
     E::G1: CurveExt<AffineExt = E::G1Affine>,
     E::G2Affine: SerdeCurveAffine,
 {
-    type Output = Self;
-
     fn new(params: &'params ParamsVerifierKZG<E>) -> Self {
         Self::new(params)
     }
@@ -164,7 +160,7 @@ where
     fn process(
         self,
         f: impl FnOnce(V::MSMAccumulator) -> Result<V::Guard, Error>,
-    ) -> Result<Self::Output, Error> {
+    ) -> Result<Self, Error> {
         // Guard is updated with new msm contributions
         let guard = f(self.msm)?;
         let msm = guard.msm_accumulator;

--- a/halo2_backend/src/poly/kzg/strategy.rs
+++ b/halo2_backend/src/poly/kzg/strategy.rs
@@ -155,7 +155,7 @@ where
     E::G1: CurveExt<AffineExt = E::G1Affine>,
     E::G2Affine: SerdeCurveAffine,
 {
-    type Output = ();
+    type Output = Self;
 
     fn new(params: &'params ParamsVerifierKZG<E>) -> Self {
         Self::new(params)
@@ -168,16 +168,15 @@ where
         // Guard is updated with new msm contributions
         let guard = f(self.msm)?;
         let msm = guard.msm_accumulator;
-        // Verification is (supposedly) cheap, hence we don't use an accelerator engine
-        let default_engine = H2cEngine::new();
-        if msm.check(&default_engine, &self.params) {
-            Ok(())
-        } else {
-            Err(Error::ConstraintSystemFailure)
-        }
+        Ok(Self {
+            msm,
+            params: self.params,
+        })
     }
 
     fn finalize(self) -> bool {
-        unreachable!();
+        // Verification is (supposedly) cheap, hence we don't use an accelerator engine
+        let default_engine = H2cEngine::new();
+        self.msm.check(&default_engine, &self.params)
     }
 }

--- a/halo2_backend/src/poly/multiopen_test.rs
+++ b/halo2_backend/src/poly/multiopen_test.rs
@@ -173,7 +173,7 @@ mod test {
         V: Verifier<'params, Scheme>,
         E: EncodedChallenge<Scheme::Curve>,
         T: TranscriptReadBuffer<&'a [u8], Scheme::Curve, E>,
-        Strategy: VerificationStrategy<'params, Scheme, V, Output = Strategy>,
+        Strategy: VerificationStrategy<'params, Scheme, V>,
     >(
         params: &'params Scheme::ParamsVerifier,
         proof: &'a [u8],

--- a/halo2_backend/src/poly/strategy.rs
+++ b/halo2_backend/src/poly/strategy.rs
@@ -10,18 +10,16 @@ pub trait Guard<Scheme: CommitmentScheme> {
 
 /// Trait representing a strategy for verifying Halo 2 proofs.
 pub trait VerificationStrategy<'params, Scheme: CommitmentScheme, V: Verifier<'params, Scheme>> {
-    /// The output type of this verification strategy after processing a proof.
-    type Output;
-
     /// Creates new verification strategy instance
     fn new(params: &'params Scheme::ParamsVerifier) -> Self;
 
-    /// Obtains an MSM from the verifier strategy and yields back the strategy's
-    /// output.
+    /// Obtains an MSM from the verifier strategy and yields back the strategy
     fn process(
         self,
         f: impl FnOnce(V::MSMAccumulator) -> Result<V::Guard, Error>,
-    ) -> Result<Self::Output, Error>;
+    ) -> Result<Self, Error>
+    where
+        Self: Sized;
 
     /// Finalizes the batch and checks its validity.
     ///

--- a/halo2_proofs/benches/plonk.rs
+++ b/halo2_proofs/benches/plonk.rs
@@ -298,7 +298,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     fn verifier(params: &ParamsIPA<EqAffine>, vk: &VerifyingKey<EqAffine>, proof: &[u8]) {
         let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(proof);
-        assert!(verify_proof::<_, _, _, _, SingleStrategy<_>>(
+        assert!(verify_proof_multi::<_, _, _, _, SingleStrategy<_>>(
             params,
             vk,
             &[vec![vec![]]],

--- a/halo2_proofs/benches/plonk.rs
+++ b/halo2_proofs/benches/plonk.rs
@@ -10,13 +10,10 @@ use halo2curves::pasta::{EqAffine, Fp};
 use rand_core::OsRng;
 
 use halo2_proofs::{
-    poly::{
-        ipa::{
-            commitment::{IPACommitmentScheme, ParamsIPA},
-            multiopen::ProverIPA,
-            strategy::SingleStrategy,
-        },
-        VerificationStrategy,
+    poly::ipa::{
+        commitment::{IPACommitmentScheme, ParamsIPA},
+        multiopen::ProverIPA,
+        strategy::SingleStrategy,
     },
     transcript::{TranscriptReadBuffer, TranscriptWriterBuffer},
 };

--- a/halo2_proofs/benches/plonk.rs
+++ b/halo2_proofs/benches/plonk.rs
@@ -300,9 +300,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     }
 
     fn verifier(params: &ParamsIPA<EqAffine>, vk: &VerifyingKey<EqAffine>, proof: &[u8]) {
-        let strategy = SingleStrategy::new(params);
         let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(proof);
-        assert!(verify_proof(params, vk, strategy, &[vec![vec![]]], &mut transcript).is_ok());
+        assert!(verify_proof::<_, _, _, _, SingleStrategy<_>>(
+            params,
+            vk,
+            &[vec![vec![]]],
+            &mut transcript
+        ));
     }
 
     let k_range = 8..=16;

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -9,14 +9,14 @@ mod error;
 mod keygen;
 mod prover;
 mod verifier {
-    pub use halo2_backend::plonk::verifier::verify_proof;
+    pub use halo2_backend::plonk::verifier::verify_proof_multi;
 }
 
 use halo2_frontend::circuit::compile_circuit;
 pub use keygen::{keygen_pk, keygen_pk_custom, keygen_vk, keygen_vk_custom};
 
 pub use prover::{create_proof, create_proof_with_engine};
-pub use verifier::verify_proof;
+pub use verifier::verify_proof_multi;
 
 pub use error::Error;
 pub use halo2_backend::plonk::{Error as ErrorBack, ProvingKey, VerifyingKey};

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -1,7 +1,7 @@
 use crate::plonk::{Error, ErrorBack};
 use crate::poly::commitment::{self, CommitmentScheme, Params};
 use crate::transcript::{EncodedChallenge, TranscriptWrite};
-use halo2_backend::plonk::{prover::Prover, ProvingKey};
+use halo2_backend::plonk::{prover::ProverMulti, ProvingKey};
 use halo2_frontend::circuit::WitnessCalculator;
 use halo2_frontend::plonk::{Circuit, ConstraintSystem};
 use halo2_middleware::ff::{FromUniformBytes, WithSmallOrderMulGroup};
@@ -55,7 +55,7 @@ where
             WitnessCalculator::new(params.k(), circuit, &config, &cs, instances[i].as_slice())
         })
         .collect();
-    let mut prover = Prover::<Scheme, P, _, _, _, _>::new_with_engine(
+    let mut prover = ProverMulti::<Scheme, P, _, _, _, _>::new_with_engine(
         engine, params, pk, instances, rng, transcript,
     )?;
     let mut challenges = HashMap::new();

--- a/halo2_proofs/tests/compress_selectors.rs
+++ b/halo2_proofs/tests/compress_selectors.rs
@@ -375,16 +375,14 @@ fn test_mycircuit(
     // Verify
     let mut verifier_transcript =
         Blake2bRead::<_, G1Affine, Challenge255<_>>::init(proof.as_slice());
-    let strategy = SingleStrategy::new(&verifier_params);
-
-    verify_proof::<KZGCommitmentScheme<Bn256>, VerifierSHPLONK<Bn256>, _, _, _>(
-        &verifier_params,
-        &vk,
-        strategy,
-        instances.as_slice(),
-        &mut verifier_transcript,
-    )
-    .map_err(halo2_proofs::plonk::Error::Backend)?;
+    if !verify_proof::<KZGCommitmentScheme<Bn256>, VerifierSHPLONK<Bn256>, _, _, SingleStrategy<_>>(
+            &verifier_params,
+            &vk,
+            instances.as_slice(),
+            &mut verifier_transcript,
+    ) {
+       return Err(halo2_proofs::plonk::Error::Backend(halo2_backend::plonk::Error::Opening));
+    };
 
     Ok(proof)
 }

--- a/halo2_proofs/tests/compress_selectors.rs
+++ b/halo2_proofs/tests/compress_selectors.rs
@@ -376,12 +376,14 @@ fn test_mycircuit(
     let mut verifier_transcript =
         Blake2bRead::<_, G1Affine, Challenge255<_>>::init(proof.as_slice());
     if !verify_proof::<KZGCommitmentScheme<Bn256>, VerifierSHPLONK<Bn256>, _, _, SingleStrategy<_>>(
-            &verifier_params,
-            &vk,
-            instances.as_slice(),
-            &mut verifier_transcript,
+        &verifier_params,
+        &vk,
+        instances.as_slice(),
+        &mut verifier_transcript,
     ) {
-       return Err(halo2_proofs::plonk::Error::Backend(halo2_backend::plonk::Error::Opening));
+        return Err(halo2_proofs::plonk::Error::Backend(
+            halo2_backend::plonk::Error::Opening,
+        ));
     };
 
     Ok(proof)

--- a/halo2_proofs/tests/compress_selectors.rs
+++ b/halo2_proofs/tests/compress_selectors.rs
@@ -17,8 +17,8 @@ use halo2_middleware::circuit::{Any, ColumnMid};
 use halo2_middleware::zal::impls::{H2cEngine, PlonkEngineConfig};
 use halo2_proofs::arithmetic::Field;
 use halo2_proofs::plonk::{
-    create_proof_with_engine, keygen_pk_custom, keygen_vk_custom, verify_proof, Advice, Assigned,
-    Circuit, Column, ConstraintSystem, Instance, Selector,
+    create_proof_with_engine, keygen_pk_custom, keygen_vk_custom, verify_proof_multi, Advice,
+    Assigned, Circuit, Column, ConstraintSystem, Instance, Selector,
 };
 use halo2_proofs::poly::kzg::commitment::{KZGCommitmentScheme, ParamsKZG};
 use halo2_proofs::poly::kzg::multiopen::{ProverSHPLONK, VerifierSHPLONK};
@@ -375,7 +375,13 @@ fn test_mycircuit(
     // Verify
     let mut verifier_transcript =
         Blake2bRead::<_, G1Affine, Challenge255<_>>::init(proof.as_slice());
-    if !verify_proof::<KZGCommitmentScheme<Bn256>, VerifierSHPLONK<Bn256>, _, _, SingleStrategy<_>>(
+    if !verify_proof_multi::<
+        KZGCommitmentScheme<Bn256>,
+        VerifierSHPLONK<Bn256>,
+        _,
+        _,
+        SingleStrategy<_>,
+    >(
         &verifier_params,
         &vk,
         instances.as_slice(),

--- a/halo2_proofs/tests/frontend_backend_split.rs
+++ b/halo2_proofs/tests/frontend_backend_split.rs
@@ -4,7 +4,7 @@
 use halo2_backend::{
     plonk::{
         keygen::{keygen_pk, keygen_vk},
-        prover::ProverSingle,
+        prover::Prover,
         verifier::{verify_proof, verify_proof_multi},
     },
     transcript::{
@@ -579,7 +579,7 @@ fn test_mycircuit_full_split() {
             let start = Instant::now();
             let mut witness_calc = WitnessCalculator::new(k, &circuit, &config, &cs, &instances);
             let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
-            let mut prover = ProverSingle::<
+            let mut prover = Prover::<
                 KZGCommitmentScheme<Bn256>,
                 ProverSHPLONK<'_, Bn256>,
                 _,

--- a/halo2_proofs/tests/frontend_backend_split.rs
+++ b/halo2_proofs/tests/frontend_backend_split.rs
@@ -525,16 +525,22 @@ fn test_mycircuit_full_legacy() {
             let mut verifier_transcript =
                 Blake2bRead::<_, G1Affine, Challenge255<_>>::init(proof.as_slice());
             let verifier_params = params.verifier_params();
-            let strategy = SingleStrategy::new(&verifier_params);
 
-            verify_proof::<KZGCommitmentScheme<Bn256>, VerifierSHPLONK<Bn256>, _, _, _>(
-                &verifier_params,
-                &vk,
-                strategy,
-                instances.as_slice(),
-                &mut verifier_transcript,
-            )
-            .expect("verify succeeds");
+            assert!(
+                verify_proof::<
+                    KZGCommitmentScheme<Bn256>,
+                    VerifierSHPLONK<Bn256>,
+                    _,
+                    _,
+                    SingleStrategy<_>,
+                >(
+                    &verifier_params,
+                    &vk,
+                    instances.as_slice(),
+                    &mut verifier_transcript,
+                ),
+                "failed to verify proof"
+            );
             println!("Verify: {:?}", start.elapsed());
 
             proof
@@ -605,16 +611,17 @@ fn test_mycircuit_full_split() {
             let mut verifier_transcript =
                 Blake2bRead::<_, G1Affine, Challenge255<_>>::init(proof.as_slice());
             let verifier_params = params.verifier_params();
-            let strategy = SingleStrategy::new(&verifier_params);
 
-            verify_proof_single::<KZGCommitmentScheme<Bn256>, VerifierSHPLONK<Bn256>, _, _, _>(
-                &verifier_params,
-                &vk,
-                strategy,
-                instances,
-                &mut verifier_transcript,
-            )
-            .expect("verify succeeds");
+            assert!(
+                verify_proof_single::<
+                    KZGCommitmentScheme<Bn256>,
+                    VerifierSHPLONK<Bn256>,
+                    _,
+                    _,
+                    SingleStrategy<_>,
+                >(&verifier_params, &vk, instances, &mut verifier_transcript,),
+                "failed to verify proof"
+            );
             println!("Verify: {:?}", start.elapsed());
 
             proof

--- a/halo2_proofs/tests/frontend_backend_split.rs
+++ b/halo2_proofs/tests/frontend_backend_split.rs
@@ -5,7 +5,7 @@ use halo2_backend::{
     plonk::{
         keygen::{keygen_pk, keygen_vk},
         prover::ProverSingle,
-        verifier::{verify_proof, verify_proof_single},
+        verifier::{verify_proof, verify_proof_multi},
     },
     transcript::{
         Blake2bRead, Blake2bWrite, Challenge255, TranscriptReadBuffer, TranscriptWriterBuffer,
@@ -527,7 +527,7 @@ fn test_mycircuit_full_legacy() {
             let verifier_params = params.verifier_params();
 
             assert!(
-                verify_proof::<
+                verify_proof_multi::<
                     KZGCommitmentScheme<Bn256>,
                     VerifierSHPLONK<Bn256>,
                     _,
@@ -613,7 +613,7 @@ fn test_mycircuit_full_split() {
             let verifier_params = params.verifier_params();
 
             assert!(
-                verify_proof_single::<
+                verify_proof::<
                     KZGCommitmentScheme<Bn256>,
                     VerifierSHPLONK<Bn256>,
                     _,

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -560,11 +560,12 @@ fn plonk_api() {
         let mut transcript = T::init(proof);
         let instance = [vec![vec![instance_val]], vec![vec![instance_val]]];
 
-        let strategy = Strategy::new(params_verifier);
-        let strategy =
-            verify_plonk_proof(params_verifier, vk, strategy, &instance, &mut transcript).unwrap();
-
-        assert!(strategy.finalize());
+        assert!(verify_plonk_proof::<_, _, _, _, Strategy>(
+            params_verifier,
+            vk,
+            &instance,
+            &mut transcript
+        ));
     }
 
     fn test_plonk_api_gwc() {

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -547,7 +547,7 @@ fn plonk_api() {
         V: Verifier<'params, Scheme>,
         E: EncodedChallenge<Scheme::Curve>,
         T: TranscriptReadBuffer<&'a [u8], Scheme::Curve, E>,
-        Strategy: VerificationStrategy<'params, Scheme, V, Output = Strategy>,
+        Strategy: VerificationStrategy<'params, Scheme, V>,
     >(
         params_verifier: &'params Scheme::ParamsVerifier,
         vk: &VerifyingKey<Scheme::Curve>,

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -13,8 +13,8 @@ use halo2_proofs::circuit::{Cell, Layouter, SimpleFloorPlanner, Value};
 use halo2_proofs::dev::MockProver;
 use halo2_proofs::plonk::{
     create_proof_with_engine as create_plonk_proof_with_engine, keygen_pk, keygen_vk,
-    verify_proof as verify_plonk_proof, Advice, Assigned, Circuit, Column, ConstraintSystem, Error,
-    ErrorFront, Fixed, ProvingKey, TableColumn, VerifyingKey,
+    verify_proof_multi as verify_multi_plonk_proof, Advice, Assigned, Circuit, Column,
+    ConstraintSystem, Error, ErrorFront, Fixed, ProvingKey, TableColumn, VerifyingKey,
 };
 use halo2_proofs::poly::commitment::{CommitmentScheme, ParamsProver, Prover, Verifier};
 use halo2_proofs::poly::Rotation;
@@ -560,7 +560,7 @@ fn plonk_api() {
         let mut transcript = T::init(proof);
         let instance = [vec![vec![instance_val]], vec![vec![instance_val]]];
 
-        assert!(verify_plonk_proof::<_, _, _, _, Strategy>(
+        assert!(verify_multi_plonk_proof::<_, _, _, _, Strategy>(
             params_verifier,
             vk,
             &instance,

--- a/halo2_proofs/tests/serialization.rs
+++ b/halo2_proofs/tests/serialization.rs
@@ -8,8 +8,8 @@ use halo2_debug::test_rng;
 use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
     plonk::{
-        create_proof, keygen_pk, keygen_vk_custom, pk_read, verify_proof, Advice, Circuit, Column,
-        ConstraintSystem, ErrorFront, Fixed, Instance,
+        create_proof, keygen_pk, keygen_vk_custom, pk_read, verify_proof_multi, Advice, Circuit,
+        Column, ConstraintSystem, ErrorFront, Fixed, Instance,
     },
     poly::{
         kzg::{
@@ -185,7 +185,7 @@ fn test_serialization() {
             let verifier_params = params.verifier_params();
             let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
             assert!(
-                verify_proof::<
+                verify_proof_multi::<
                     KZGCommitmentScheme<Bn256>,
                     VerifierGWC<Bn256>,
                     Challenge255<G1Affine>,

--- a/halo2_proofs/tests/serialization.rs
+++ b/halo2_proofs/tests/serialization.rs
@@ -183,22 +183,22 @@ fn test_serialization() {
             let proof = transcript.finalize();
 
             let verifier_params = params.verifier_params();
-            let strategy = SingleStrategy::new(&verifier_params);
             let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
-            assert!(verify_proof::<
-                KZGCommitmentScheme<Bn256>,
-                VerifierGWC<Bn256>,
-                Challenge255<G1Affine>,
-                Blake2bRead<&[u8], G1Affine, Challenge255<G1Affine>>,
-                SingleStrategy<Bn256>,
-            >(
-                &verifier_params,
-                pk.get_vk(),
-                strategy,
-                instances.as_slice(),
-                &mut transcript
-            )
-            .is_ok());
+            assert!(
+                verify_proof::<
+                    KZGCommitmentScheme<Bn256>,
+                    VerifierGWC<Bn256>,
+                    Challenge255<G1Affine>,
+                    Blake2bRead<&[u8], G1Affine, Challenge255<G1Affine>>,
+                    SingleStrategy<Bn256>,
+                >(
+                    &verifier_params,
+                    pk.get_vk(),
+                    instances.as_slice(),
+                    &mut transcript
+                ),
+                "failed to verify proof"
+            );
 
             proof
         },

--- a/halo2_proofs/tests/shuffle.rs
+++ b/halo2_proofs/tests/shuffle.rs
@@ -301,18 +301,14 @@ where
     };
 
     let accepted = {
-        let strategy = AccumulatorStrategy::new(&params);
         let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
 
-        verify_proof::<IPACommitmentScheme<C>, VerifierIPA<C>, _, _, _>(
+        verify_proof::<IPACommitmentScheme<C>, VerifierIPA<C>, _, _, AccumulatorStrategy<C>>(
             &params,
             pk.get_vk(),
-            strategy,
             &[vec![]],
             &mut transcript,
         )
-        .map(|strategy| strategy.finalize())
-        .unwrap_or_default()
     };
 
     assert_eq!(accepted, expected);

--- a/halo2_proofs/tests/shuffle.rs
+++ b/halo2_proofs/tests/shuffle.rs
@@ -302,7 +302,7 @@ where
     let accepted = {
         let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
 
-        verify_proof::<IPACommitmentScheme<C>, VerifierIPA<C>, _, _, AccumulatorStrategy<C>>(
+        verify_proof_multi::<IPACommitmentScheme<C>, VerifierIPA<C>, _, _, AccumulatorStrategy<C>>(
             &params,
             pk.get_vk(),
             &[vec![]],

--- a/halo2_proofs/tests/shuffle.rs
+++ b/halo2_proofs/tests/shuffle.rs
@@ -13,7 +13,6 @@ use halo2_proofs::{
             multiopen::{ProverIPA, VerifierIPA},
             strategy::AccumulatorStrategy,
         },
-        VerificationStrategy,
     },
     transcript::{
         Blake2bRead, Blake2bWrite, Challenge255, TranscriptReadBuffer, TranscriptWriterBuffer,

--- a/halo2_proofs/tests/shuffle_api.rs
+++ b/halo2_proofs/tests/shuffle_api.rs
@@ -175,18 +175,14 @@ where
     };
 
     let accepted = {
-        let strategy = AccumulatorStrategy::new(&params);
         let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
 
-        verify_proof::<IPACommitmentScheme<C>, VerifierIPA<C>, _, _, _>(
+        verify_proof::<IPACommitmentScheme<C>, VerifierIPA<C>, _, _, AccumulatorStrategy<_>>(
             &params,
             pk.get_vk(),
-            strategy,
             &[vec![]],
             &mut transcript,
         )
-        .map(|strategy| strategy.finalize())
-        .unwrap_or_default()
     };
 
     assert_eq!(accepted, expected);

--- a/halo2_proofs/tests/shuffle_api.rs
+++ b/halo2_proofs/tests/shuffle_api.rs
@@ -10,15 +10,12 @@ use halo2_proofs::{
         create_proof, keygen_pk, keygen_vk, verify_proof, Advice, Circuit, Column,
         ConstraintSystem, ErrorFront, Fixed, Selector,
     },
-    poly::Rotation,
-    poly::{
-        ipa::{
-            commitment::{IPACommitmentScheme, ParamsIPA},
-            multiopen::{ProverIPA, VerifierIPA},
-            strategy::AccumulatorStrategy,
-        },
-        VerificationStrategy,
+    poly::ipa::{
+        commitment::{IPACommitmentScheme, ParamsIPA},
+        multiopen::{ProverIPA, VerifierIPA},
+        strategy::AccumulatorStrategy,
     },
+    poly::Rotation,
     transcript::{
         Blake2bRead, Blake2bWrite, Challenge255, TranscriptReadBuffer, TranscriptWriterBuffer,
     },

--- a/halo2_proofs/tests/shuffle_api.rs
+++ b/halo2_proofs/tests/shuffle_api.rs
@@ -7,7 +7,7 @@ use halo2_proofs::{
     arithmetic::Field,
     circuit::{Layouter, SimpleFloorPlanner, Value},
     plonk::{
-        create_proof, keygen_pk, keygen_vk, verify_proof, Advice, Circuit, Column,
+        create_proof, keygen_pk, keygen_vk, verify_proof_multi, Advice, Circuit, Column,
         ConstraintSystem, ErrorFront, Fixed, Selector,
     },
     poly::ipa::{
@@ -174,7 +174,7 @@ where
     let accepted = {
         let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
 
-        verify_proof::<IPACommitmentScheme<C>, VerifierIPA<C>, _, _, AccumulatorStrategy<_>>(
+        verify_proof_multi::<IPACommitmentScheme<C>, VerifierIPA<C>, _, _, AccumulatorStrategy<_>>(
             &params,
             pk.get_vk(),
             &[vec![]],

--- a/halo2_proofs/tests/vector-ops-unblinded.rs
+++ b/halo2_proofs/tests/vector-ops-unblinded.rs
@@ -499,18 +499,14 @@ where
     };
 
     let accepted = {
-        let strategy = AccumulatorStrategy::new(&params);
         let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
 
-        verify_proof::<IPACommitmentScheme<C>, VerifierIPA<C>, _, _, _>(
+        verify_proof::<IPACommitmentScheme<C>, VerifierIPA<C>, _, _, AccumulatorStrategy<_>>(
             &params,
             pk.get_vk(),
-            strategy,
             &instances,
             &mut transcript,
         )
-        .map(|strategy| strategy.finalize())
-        .unwrap_or_default()
     };
 
     assert_eq!(accepted, expected);

--- a/halo2_proofs/tests/vector-ops-unblinded.rs
+++ b/halo2_proofs/tests/vector-ops-unblinded.rs
@@ -16,7 +16,7 @@ use halo2_proofs::{
             multiopen::{ProverIPA, VerifierIPA},
             strategy::AccumulatorStrategy,
         },
-        Rotation, VerificationStrategy,
+        Rotation,
     },
     transcript::{
         Blake2bRead, Blake2bWrite, Challenge255, TranscriptReadBuffer, TranscriptWriterBuffer,

--- a/halo2_proofs/tests/vector-ops-unblinded.rs
+++ b/halo2_proofs/tests/vector-ops-unblinded.rs
@@ -501,7 +501,7 @@ where
     let accepted = {
         let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
 
-        verify_proof::<IPACommitmentScheme<C>, VerifierIPA<C>, _, _, AccumulatorStrategy<_>>(
+        verify_proof_multi::<IPACommitmentScheme<C>, VerifierIPA<C>, _, _, AccumulatorStrategy<_>>(
             &params,
             pk.get_vk(),
             &instances,

--- a/p3_frontend/tests/common/mod.rs
+++ b/p3_frontend/tests/common/mod.rs
@@ -93,15 +93,21 @@ pub(crate) fn setup_prove_verify(
     println!("Verifying...");
     let mut verifier_transcript =
         Blake2bRead::<_, G1Affine, Challenge255<_>>::init(proof.as_slice());
-    let strategy = SingleStrategy::new(&verifier_params);
 
-    verify_proof_single::<KZGCommitmentScheme<Bn256>, VerifierSHPLONK<Bn256>, _, _, _>(
-        &verifier_params,
-        &vk,
-        strategy,
-        pis.to_vec(),
-        &mut verifier_transcript,
-    )
-    .expect("verify succeeds");
+    assert!(
+        verify_proof_single::<
+            KZGCommitmentScheme<Bn256>,
+            VerifierSHPLONK<Bn256>,
+            _,
+            _,
+            SingleStrategy<_>,
+        >(
+            &verifier_params,
+            &vk,
+            pis.to_vec(),
+            &mut verifier_transcript,
+        ),
+        "failed to verify proof"
+    );
     println!("Verify: {:?}", start.elapsed());
 }

--- a/p3_frontend/tests/common/mod.rs
+++ b/p3_frontend/tests/common/mod.rs
@@ -4,7 +4,7 @@ use halo2_backend::poly::kzg::strategy::SingleStrategy;
 use halo2_backend::{
     plonk::{
         keygen::{keygen_pk, keygen_vk},
-        prover::ProverSingle,
+        prover::Prover,
         verifier::verify_proof,
     },
     transcript::{
@@ -73,7 +73,7 @@ pub(crate) fn setup_prove_verify(
     println!("Proving...");
     let start = Instant::now();
     let mut transcript = Blake2bWrite::<_, G1Affine, Challenge255<_>>::init(vec![]);
-    let mut prover = ProverSingle::<
+    let mut prover = Prover::<
         KZGCommitmentScheme<Bn256>,
         ProverSHPLONK<'_, Bn256>,
         _,

--- a/p3_frontend/tests/common/mod.rs
+++ b/p3_frontend/tests/common/mod.rs
@@ -5,7 +5,7 @@ use halo2_backend::{
     plonk::{
         keygen::{keygen_pk, keygen_vk},
         prover::ProverSingle,
-        verifier::verify_proof_single,
+        verifier::verify_proof,
     },
     transcript::{
         Blake2bRead, Blake2bWrite, Challenge255, TranscriptReadBuffer, TranscriptWriterBuffer,
@@ -95,13 +95,7 @@ pub(crate) fn setup_prove_verify(
         Blake2bRead::<_, G1Affine, Challenge255<_>>::init(proof.as_slice());
 
     assert!(
-        verify_proof_single::<
-            KZGCommitmentScheme<Bn256>,
-            VerifierSHPLONK<Bn256>,
-            _,
-            _,
-            SingleStrategy<_>,
-        >(
+        verify_proof::<KZGCommitmentScheme<Bn256>, VerifierSHPLONK<Bn256>, _, _, SingleStrategy<_>>(
             &verifier_params,
             &vk,
             pis.to_vec(),


### PR DESCRIPTION
## Description
Improve the verify api - `verify_proof`, in a way that it does return the `bool` value indicating proof is valid or not.
This way, we remove the confusion or misuse, related to `verify_proof` api.

## Related issues
- Resolve #184 

## Changes
- Update several `VerificationStrategy` impls 
- Update the `verify_proof` so that it returns the `bool` 
- Update the related tests