### PR TITLE
Typos check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,36 @@ on:
       - main
 
 jobs:
+
+  fmt:
+    name: Rustfmt
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          override: false
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  typos-check:
+    needs: [skip_check]
+    if: |
+      github.event.pull_request.draft == false &&
+      (github.event.action == 'ready_for_review' || needs.skip_check.outputs.should_skip != 'true')
+    name: TyposCheck
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@v1.22.7
+        with:
+          config: ./typos.toml
+          isolated: true
   test:
     name: Test on ${{ matrix.os }} with ${{ matrix.feature_set }} features
     runs-on: ${{ matrix.os }}
@@ -101,18 +131,4 @@ jobs:
           command: doc
           args: --all --document-private-items
 
-  fmt:
-    name: Rustfmt
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          override: false
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the [halo2](https://github.com/zcash/halo2) fork from
 PSE and includes contributions from the community.
 
 We use the `main` branch for development, which means it may contain
-unstable/unfinished features.  For end-users we recomend using the tag releases
+unstable/unfinished features.  For end-users we recommend using the tag releases
 which can be seen as curated checkpoints with some level of guarantee of
 stability.
 

--- a/book/src/user/experimental-features.md
+++ b/book/src/user/experimental-features.md
@@ -24,11 +24,11 @@ When using `create_proof` and `verify_proof`, we need to specify the commitment 
 create_proof<IPACommitmentScheme<_>, ProverIPA<_>, _, _, _, _>
 verify_proof<IPACommitmentScheme<_>, ProverIPA<_>, _, _, _>
 
-// Using KZG with GWC19 mutli-open strategy
+// Using KZG with GWC19 multi-open strategy
 create_proof<KZGCommitmentScheme<_>, ProverGWC<_>, _, _, _, _>
 verify_proof<KZGCommitmentScheme<_>, ProverGWC<_>, _, _, _>
 
-// Using KZG with BDFG20 mutli-open strategy
+// Using KZG with BDFG20 multi-open strategy
 create_proof<KZGCommitmentScheme<_>, ProverSHPLONK<_>, _, _, _, _>
 verify_proof<KZGCommitmentScheme<_>, ProverSHPLONK<_>, _, _, _>
 ```

--- a/halo2_backend/src/plonk.rs
+++ b/halo2_backend/src/plonk.rs
@@ -117,7 +117,7 @@ where
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
-                    "circuit size value (k): {} exceeds maxium: {}",
+                    "circuit size value (k): {} exceeds maximum: {}",
                     k,
                     C::Scalar::S
                 ),

--- a/halo2_backend/src/plonk/evaluation.rs
+++ b/halo2_backend/src/plonk/evaluation.rs
@@ -174,11 +174,11 @@ impl Calculation {
 /// Evaluator
 #[derive(Clone, Default, Debug)]
 pub(crate) struct Evaluator<C: CurveAffine> {
-    ///  Custom gates evalution
+    ///  Custom gates evaluation
     custom_gates: GraphEvaluator<C>,
-    ///  Lookups evalution
+    ///  Lookups evaluation
     lookups: Vec<GraphEvaluator<C>>,
-    ///  Shuffle evalution
+    ///  Shuffle evaluation
     shuffles: Vec<GraphEvaluator<C>>,
 }
 

--- a/halo2_backend/src/plonk/prover.rs
+++ b/halo2_backend/src/plonk/prover.rs
@@ -489,10 +489,10 @@ impl<
 
     /// Finalizes the proof creation.
     /// The following steps are performed:
-    /// - 1. Generate commited lookup polys
-    /// - 2. Generate commited permutation polys
-    /// - 3. Generate commited lookup polys
-    /// - 4. Generate commited shuffle polys
+    /// - 1. Generate committed lookup polys
+    /// - 2. Generate committed permutation polys
+    /// - 3. Generate committed lookup polys
+    /// - 4. Generate committed shuffle polys
     /// - 5. Commit to the vanishing argument's random polynomial
     /// - 6. Generate the advice polys
     /// - 7. Evaluate the h(X) polynomial
@@ -523,7 +523,7 @@ impl<
             .map(|index| challenges.remove(&index).unwrap())
             .collect::<Vec<_>>();
 
-        // 1. Generate commited ( added to transcript ) lookup polys  ---------------------------------------
+        // 1. Generate committed ( added to transcript ) lookup polys  ---------------------------------------
 
         // Sample theta challenge for keeping lookup columns linearly independent
         // [TRANSCRIPT-5]
@@ -574,9 +574,9 @@ impl<
         // [TRANSCRIPT-8]
         let gamma: ChallengeGamma<_> = self.transcript.squeeze_challenge_scalar();
 
-        // 2. Generate commited permutation polys  -----------------------------------------
+        // 2. Generate committed permutation polys  -----------------------------------------
         // [TRANSCRIPT-9]
-        let permutations_commited: Vec<permutation::prover::Committed<Scheme::Curve>> = instances
+        let permutations_committed: Vec<permutation::prover::Committed<Scheme::Curve>> = instances
             .iter()
             .zip(advices.iter())
             .map(|(instance, advice)| {
@@ -597,34 +597,35 @@ impl<
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        // 3. Generate commited lookup polys ----------------------------------------------------------
+        // 3. Generate committed lookup polys ----------------------------------------------------------
 
         // [TRANSCRIPT-10]
-        let lookups_commited: Vec<Vec<lookup::prover::Committed<Scheme::Curve>>> = permuted_lookups
-            .into_iter()
-            .map(|lookups| -> Result<Vec<_>, _> {
-                // Construct and commit to products for each lookup
-                lookups
-                    .into_iter()
-                    .map(|lookup| {
-                        lookup.commit_product(
-                            &self.engine,
-                            pk,
-                            params,
-                            beta,
-                            gamma,
-                            &mut rng,
-                            self.transcript,
-                        )
-                    })
-                    .collect::<Result<Vec<_>, _>>()
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let lookups_committed: Vec<Vec<lookup::prover::Committed<Scheme::Curve>>> =
+            permuted_lookups
+                .into_iter()
+                .map(|lookups| -> Result<Vec<_>, _> {
+                    // Construct and commit to products for each lookup
+                    lookups
+                        .into_iter()
+                        .map(|lookup| {
+                            lookup.commit_product(
+                                &self.engine,
+                                pk,
+                                params,
+                                beta,
+                                gamma,
+                                &mut rng,
+                                self.transcript,
+                            )
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .collect::<Result<Vec<_>, _>>()?;
 
-        // 4. Generate commited shuffle polys  -------------------------------------------------------
+        // 4. Generate committed shuffle polys  -------------------------------------------------------
 
         // [TRANSCRIPT-11]
-        let shuffles_commited: Vec<Vec<shuffle::prover::Committed<Scheme::Curve>>> = instances
+        let shuffles_committed: Vec<Vec<shuffle::prover::Committed<Scheme::Curve>>> = instances
             .iter()
             .zip(advices.iter())
             .map(|(instance, advice)| -> Result<Vec<_>, _> {
@@ -703,9 +704,9 @@ impl<
             *beta,
             *gamma,
             *theta,
-            &lookups_commited,
-            &shuffles_commited,
-            &permutations_commited,
+            &lookups_committed,
+            &shuffles_committed,
+            &permutations_committed,
         );
 
         // 8. Construct the vanishing argument's h(X) commitments --------------------------------------
@@ -796,7 +797,7 @@ impl<
         // Evaluate the permutations, if any, at omega^i x.
         // [TRANSCRIPT-21]
         let permutations_evaluated: Vec<permutation::prover::Evaluated<Scheme::Curve>> =
-            permutations_commited
+            permutations_committed
                 .into_iter()
                 .map(|permutation| -> Result<_, _> { permutation.evaluate(pk, x, self.transcript) })
                 .collect::<Result<Vec<_>, _>>()?;
@@ -804,7 +805,7 @@ impl<
         // Evaluate the lookups, if any, at omega^i x.
         // [TRANSCRIPT-22]
         let lookups_evaluated: Vec<Vec<lookup::prover::Evaluated<Scheme::Curve>>> =
-            lookups_commited
+            lookups_committed
                 .into_iter()
                 .map(|lookups| -> Result<Vec<_>, _> {
                     lookups
@@ -817,7 +818,7 @@ impl<
         // Evaluate the shuffles, if any, at omega^i x.
         // [TRANSCRIPT-23]
         let shuffles_evaluated: Vec<Vec<shuffle::prover::Evaluated<Scheme::Curve>>> =
-            shuffles_commited
+            shuffles_committed
                 .into_iter()
                 .map(|shuffles| -> Result<Vec<_>, _> {
                     shuffles

--- a/halo2_frontend/src/dev.rs
+++ b/halo2_frontend/src/dev.rs
@@ -1498,7 +1498,7 @@ mod tests {
     #[cfg(feature = "lookup-any-sanity-checks")]
     #[test]
     #[should_panic(
-        expected = "pair of tagging expressions(query of the tag columns or mutiple query combinations) should be included"
+        expected = "pair of tagging expressions(query of the tag columns or multiple query combinations) should be included"
     )]
     fn bad_lookup_any_not_add_tagging_pairs() {
         const K: u32 = 4;
@@ -1991,7 +1991,7 @@ mod tests {
     }
 
     #[test]
-    fn contraint_unsatisfied() {
+    fn constraint_unsatisfied() {
         const K: u32 = 4;
 
         #[derive(Clone)]
@@ -2234,7 +2234,7 @@ mod tests {
         instance[0] = InstanceValue::Assigned(Fp::from(11));
         assert_eq!(prover.verify(), Err(vec![err2.clone()]));
 
-        // then we modify the witness -> the contraint `squared` will fail
+        // then we modify the witness -> the constraint `squared` will fail
         let advice0 = prover.advice_mut(0);
         advice0[2] = CellValue::Assigned(Fp::from(10));
         assert_eq!(prover.verify(), Err(vec![err1, err2]));

--- a/halo2_frontend/src/dev/cost_model.rs
+++ b/halo2_frontend/src/dev/cost_model.rs
@@ -16,9 +16,9 @@ use super::MockProver;
 pub enum CommitmentScheme {
     /// Inner Product Argument commitment scheme
     IPA,
-    /// KZG with GWC19 mutli-open strategy
+    /// KZG with GWC19 multi-open strategy
     KZGGWC,
-    /// KZG with BDFG20 mutli-open strategy
+    /// KZG with BDFG20 multi-open strategy
     KZGSHPLONK,
 }
 

--- a/halo2_frontend/src/plonk/circuit/constraint_system.rs
+++ b/halo2_frontend/src/plonk/circuit/constraint_system.rs
@@ -445,7 +445,7 @@ impl<F: Field> ConstraintSystem<F> {
                 panic!("all table expressions need selector/fixed query for tagging");
             }
             if !is_tagging_exprs_pair_exists {
-                panic!("pair of tagging expressions(query of the tag columns or mutiple query combinations) should be included");
+                panic!("pair of tagging expressions(query of the tag columns or multiple query combinations) should be included");
             }
         }
 
@@ -953,7 +953,7 @@ impl<F: Field> ConstraintSystem<F> {
         tmp
     }
 
-    /// Helper funciotn to assert phase exists, to make sure phase-aware resources
+    /// Helper function to assert phase exists, to make sure phase-aware resources
     /// are allocated in order, and to avoid any phase to be skipped accidentally
     /// to cause unexpected issue in the future.
     fn assert_phase_exists(&self, phase: sealed::Phase, resource: &str) {

--- a/halo2_middleware/src/zal.rs
+++ b/halo2_middleware/src/zal.rs
@@ -71,7 +71,7 @@ pub mod traits {
         // Descriptors are opaque pointers that hold the input in a format suitable for the accelerator engine.
         // They may be:
         // - Input moved on accelerator device (only once for repeated calls)
-        // - Endianess conversion
+        // - Endianness conversion
         // - Converting from Montgomery to Canonical form
         // - Input changed from Projective to Jacobian coordinates or even to a Twisted Edwards curve.
         // - other form of expensive preprocessing

--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -132,7 +132,7 @@ All APIs that represented witnessed values as `Option<V>` now represent them as
     directly, and returns `VerificationStrategy::Output` instead of `Guard`.
   - `ConstraintSystem::enable_equality` and `ConstraintSystem::query_any` now
     take `Into<Column<Any>>` instead of `Column<Any>` as a parameter to avoid
-    excesive `.into()` usage.
+    excessive `.into()` usage.
   - `Error` has been overhauled:
     - `Error` now implements `std::fmt::Display` and `std::error::Error`.
     - `Error` no longer implements `PartialEq`. Tests can check for specific

--- a/halo2_proofs/tests/frontend_backend_split.rs
+++ b/halo2_proofs/tests/frontend_backend_split.rs
@@ -43,7 +43,7 @@ struct MyCircuitConfig {
     s_lookup: Column<Fixed>,
     s_ltable: Column<Fixed>,
 
-    // A shuffle: s_shufle * [1, a[0]] shuffle_of s_stable * [1, b[0]]
+    // A shuffle: s_shuffle * [1, a[0]] shuffle_of s_stable * [1, b[0]]
     s_shuffle: Column<Fixed>,
     s_stable: Column<Fixed>,
 

--- a/p3_frontend/src/fwrap.rs
+++ b/p3_frontend/src/fwrap.rs
@@ -239,7 +239,7 @@ impl<F: PrimeField + Hash + Ord> p3PrimeField for FWrap<F> {
 }
 
 // HACK: In general an `FWrap` will need more than 64 bits.  This trait is only implemented in
-// order to use `FWrap` with witness generation from plonky3 that requries this trait but doesn't
+// order to use `FWrap` with witness generation from plonky3 that requires this trait but doesn't
 // use the order.  Do not use an `ff::PrimeField` on a circuit that requires a 64 bit prime field
 // (i.e. relies on the `ORDER_U64` value), only use it on circuits that always assign less than 64
 // bit values on the field elements.

--- a/p3_frontend/src/lib.rs
+++ b/p3_frontend/src/lib.rs
@@ -144,7 +144,7 @@ where
 }
 
 // Check if the constraint is an equality against a public input and extract the copy constraint as
-// `(advice_column_index, Location)` and `public_index`.  If there's no copy constriant, return
+// `(advice_column_index, Location)` and `public_index`.  If there's no copy constraint, return
 // None.
 fn extract_copy_public<F: PrimeField + Hash>(
     e: &SymbolicExpression<FWrap<F>>,

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,7 @@
+[default]
+extend-ignore-re=[
+    "master-thm",
+    "[aA]dvices",
+    "projectives"
+]
+check-filename = true


### PR DESCRIPTION
Add typo check in CI.

To run it manually:

`cargo install typos-cli` then `typos`.
If you are ok with the suggestions, changes can be automatically written with `typos -w`

note: Seen in https://github.com/scroll-tech/zkevm-circuits/pull/1340/files#diff-3fb2332998c7a34b309e0c52c92bfa1f8e0c429ceec9fddba49834e15d3e0eb6