### PR TITLE
feat: split `create_proof` 

### DIFF
--- a/halo2_backend/src/plonk/prover.rs
+++ b/halo2_backend/src/plonk/prover.rs
@@ -535,7 +535,7 @@ impl<
         // [TRANSCRIPT-9]
         let permutations_committed = self.gen_committed_permutation_polys(beta, gamma)?;
 
-        // 3. Generate commited lookup polys ----------------------------------------------------------
+        // 3. Generate committed lookup polys ----------------------------------------------------------
         // [TRANSCRIPT-10]
         let lookups_committed = self.gen_committed_lookups_polys(permuted_lookups, beta, gamma)?;
 

--- a/halo2_backend/src/plonk/prover.rs
+++ b/halo2_backend/src/plonk/prover.rs
@@ -539,7 +539,7 @@ impl<
         // [TRANSCRIPT-10]
         let lookups_committed = self.gen_committed_lookups_polys(permuted_lookups, beta, gamma)?;
 
-        // 4. Generate commited shuffle polys  -------------------------------------------------------
+        // 4. Generate committed shuffle polys  -------------------------------------------------------
         // [TRANSCRIPT-11]
         let shuffles_committed = self.gen_committed_shuffles(theta, gamma, &challenges)?;
 

--- a/halo2_backend/src/plonk/prover.rs
+++ b/halo2_backend/src/plonk/prover.rs
@@ -538,13 +538,13 @@ impl<
         // 3. Generate commited lookup polys ----------------------------------------------------------
         // [TRANSCRIPT-10]
         let lookups_committed = self.gen_committed_lookups_polys(permuted_lookups, beta, gamma)?;
-        
+
         // 4. Generate commited shuffle polys  -------------------------------------------------------
         // [TRANSCRIPT-11]
         let shuffles_committed = self.gen_committed_shuffles(theta, gamma, &challenges)?;
 
         // 5. Commit to the vanishing argument's random polynomial for blinding h(x_3) -------------------
-        // [TRANSCRIPT-12]        
+        // [TRANSCRIPT-12]
         let vanishing_committed = self.gen_committed_vanishing()?;
 
         // 6. Generate the advice polys ------------------------------------------------------------------
@@ -595,7 +595,7 @@ impl<
         self.write_advice_evals(x, &advice)?;
 
         // 11. Compute and hash fixed evals -----------------------------------------------------------
-        
+
         // Hash each fixed column evaluation
         // [TRANSCRIPT-18]
         self.write_fixed_evals(x)?;
@@ -612,11 +612,11 @@ impl<
         // Evaluate the permutations, if any, at omega^i x.
         // [TRANSCRIPT-21]
         let permutations_evaluated = self.evaluate_permutations(x, permutations_committed)?;
-            
+
         // Evaluate the lookups, if any, at omega^i x.
         // [TRANSCRIPT-22]
         let lookups_evaluated = self.evaluate_lookups(x, lookups_committed)?;
-        
+
         // Evaluate the shuffles, if any, at omega^i x.
         // [TRANSCRIPT-23]
         let shuffles_evaluated = self.evaluate_shuffles(x, shuffles_committed)?;

--- a/halo2_backend/src/plonk/vanishing.rs
+++ b/halo2_backend/src/plonk/vanishing.rs
@@ -2,8 +2,8 @@ use std::marker::PhantomData;
 
 use crate::arithmetic::CurveAffine;
 
-mod prover;
-mod verifier;
+pub(crate) mod prover;
+pub(crate) mod verifier;
 
 /// A vanishing argument.
 pub(crate) struct Argument<C: CurveAffine> {

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -67,7 +67,7 @@ where
         }
         challenges = prover.commit_phase(*phase, witnesses).unwrap();
     }
-    Ok(prover.create_proof_split()?)
+    Ok(prover.create_proof()?)
 }
 /// This creates a proof for the provided `circuit` when given the public
 /// parameters `params` and the proving key [`ProvingKey`] that was

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -67,7 +67,7 @@ where
         }
         challenges = prover.commit_phase(*phase, witnesses).unwrap();
     }
-    Ok(prover.create_proof()?)
+    Ok(prover.create_proof_split()?)
 }
 /// This creates a proof for the provided `circuit` when given the public
 /// parameters `params` and the proving key [`ProvingKey`] that was


### PR DESCRIPTION
## Description
- Split the `create_proof` function into focused/stage functions

## Related issues
- Resolve #247 

## Changes
- create new focused/stage functions in `Prover` struct, like `gen_permuted_lookups`, ...
- refactor the `create_proof` so that it uses the stage functions