### PR TITLE
chore: remove some TODOs from codebase

### DIFF
--- a/halo2_backend/src/arithmetic.rs
+++ b/halo2_backend/src/arithmetic.rs
@@ -100,8 +100,7 @@ pub(crate) fn compute_inner_product<F: Field>(a: &[F], b: &[F]) -> F {
         let chunk_size = (n + num_threads - 1) / num_threads;
         let mut parts = vec![F::ZERO; num_threads];
         multicore::scope(|scope| {
-            for (chunk_idx, (out, a)) in parts.chunks_mut(1).zip(a.chunks(chunk_size)).enumerate()
-            {
+            for (chunk_idx, (out, a)) in parts.chunks_mut(1).zip(a.chunks(chunk_size)).enumerate() {
                 scope.spawn(move |_| {
                     let mut acc = F::ZERO;
                     for (a, b) in a.iter().zip(&b[chunk_idx * chunk_size..]) {

--- a/halo2_backend/src/arithmetic.rs
+++ b/halo2_backend/src/arithmetic.rs
@@ -88,30 +88,12 @@ pub(crate) fn eval_polynomial<F: Field>(poly: &[F], point: F) -> F {
 pub(crate) fn compute_inner_product<F: Field>(a: &[F], b: &[F]) -> F {
     assert_eq!(a.len(), b.len());
 
-    let n = a.len();
-    let num_threads = multicore::current_num_threads();
-    if n * 2 < num_threads {
-        let mut acc = F::ZERO;
-        for (a, b) in a.iter().zip(b.iter()) {
-            acc += (*a) * (*b);
-        }
-        acc
-    } else {
-        let chunk_size = (n + num_threads - 1) / num_threads;
-        let mut parts = vec![F::ZERO; num_threads];
-        multicore::scope(|scope| {
-            for (chunk_idx, (out, a)) in parts.chunks_mut(1).zip(a.chunks(chunk_size)).enumerate() {
-                scope.spawn(move |_| {
-                    let mut acc = F::ZERO;
-                    for (a, b) in a.iter().zip(&b[chunk_idx * chunk_size..]) {
-                        acc += (*a) * (*b);
-                    }
-                    out[0] = acc;
-                });
-            }
-        });
-        parts.iter().fold(F::ZERO, |acc, coeff| acc + coeff)
+    let mut acc = F::ZERO;
+    for (a, b) in a.iter().zip(b.iter()) {
+        acc += (*a) * (*b);
     }
+
+    acc
 }
 
 /// Divides polynomial `a` in `X` by `X - b` with

--- a/halo2_backend/src/arithmetic.rs
+++ b/halo2_backend/src/arithmetic.rs
@@ -86,15 +86,33 @@ pub(crate) fn eval_polynomial<F: Field>(poly: &[F], point: F) -> F {
 ///
 /// This function will panic if the two vectors are not the same size.
 pub(crate) fn compute_inner_product<F: Field>(a: &[F], b: &[F]) -> F {
-    // TODO: parallelize?
     assert_eq!(a.len(), b.len());
 
-    let mut acc = F::ZERO;
-    for (a, b) in a.iter().zip(b.iter()) {
-        acc += (*a) * (*b);
+    let n = a.len();
+    let num_threads = multicore::current_num_threads();
+    if n * 2 < num_threads {
+        let mut acc = F::ZERO;
+        for (a, b) in a.iter().zip(b.iter()) {
+            acc += (*a) * (*b);
+        }
+        acc
+    } else {
+        let chunk_size = (n + num_threads - 1) / num_threads;
+        let mut parts = vec![F::ZERO; num_threads];
+        multicore::scope(|scope| {
+            for (chunk_idx, (out, a)) in parts.chunks_mut(1).zip(a.chunks(chunk_size)).enumerate()
+            {
+                scope.spawn(move |_| {
+                    let mut acc = F::ZERO;
+                    for (a, b) in a.iter().zip(&b[chunk_idx * chunk_size..]) {
+                        acc += (*a) * (*b);
+                    }
+                    out[0] = acc;
+                });
+            }
+        });
+        parts.iter().fold(F::ZERO, |acc, coeff| acc + coeff)
     }
-
-    acc
 }
 
 /// Divides polynomial `a` in `X` by `X - b` with

--- a/halo2_backend/src/plonk/circuit.rs
+++ b/halo2_backend/src/plonk/circuit.rs
@@ -4,15 +4,12 @@ use halo2_middleware::expression::{Expression, Variable};
 use halo2_middleware::poly::Rotation;
 use halo2_middleware::{lookup, permutation::ArgumentMid, shuffle};
 
-// TODO: Reuse ColumnMid inside this.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct QueryBack {
     /// Query index
     pub(crate) index: usize,
-    /// Column index
-    pub(crate) column_index: usize,
-    /// The type of the column.
-    pub(crate) column_type: Any,
+    /// Column
+    pub(crate) column: ColumnMid,
     /// Rotation of this query
     pub(crate) rotation: Rotation,
 }

--- a/halo2_backend/src/plonk/evaluation.rs
+++ b/halo2_backend/src/plonk/evaluation.rs
@@ -701,17 +701,17 @@ impl<C: CurveAffine> GraphEvaluator<C> {
             ExpressionBack::Constant(scalar) => self.add_constant(scalar),
             ExpressionBack::Var(VarBack::Query(query)) => {
                 let rot_idx = self.add_rotation(&query.rotation);
-                match query.column_type {
+                match query.column.column_type {
                     Any::Fixed => self.add_calculation(Calculation::Store(ValueSource::Fixed(
-                        query.column_index,
+                        query.column.index,
                         rot_idx,
                     ))),
                     Any::Advice => self.add_calculation(Calculation::Store(ValueSource::Advice(
-                        query.column_index,
+                        query.column.index,
                         rot_idx,
                     ))),
                     Any::Instance => self.add_calculation(Calculation::Store(
-                        ValueSource::Instance(query.column_index, rot_idx),
+                        ValueSource::Instance(query.column.index, rot_idx),
                     )),
                 }
             }
@@ -863,10 +863,10 @@ pub(crate) fn evaluate<F: Field, B: LagrangeBasis>(
                     VarBack::Challenge(challenge) => challenges[challenge.index()],
                     VarBack::Query(query) => {
                         let rot_idx = get_rotation_idx(idx, query.rotation.0, rot_scale, isize);
-                        match query.column_type {
-                            Any::Fixed => fixed[query.column_index][rot_idx],
-                            Any::Advice => advice[query.column_index][rot_idx],
-                            Any::Instance => instance[query.column_index][rot_idx],
+                        match query.column.column_type {
+                            Any::Fixed => fixed[query.column.index][rot_idx],
+                            Any::Advice => advice[query.column.index][rot_idx],
+                            Any::Instance => instance[query.column.index][rot_idx],
                         }
                     }
                 },
@@ -883,7 +883,7 @@ pub(crate) fn evaluate<F: Field, B: LagrangeBasis>(
 mod test {
     use crate::plonk::circuit::{ExpressionBack, QueryBack, VarBack};
     use crate::poly::LagrangeCoeff;
-    use halo2_middleware::circuit::{Any, ChallengeMid};
+    use halo2_middleware::circuit::{Any, ChallengeMid, ColumnMid};
     use halo2_middleware::poly::Rotation;
     use halo2curves::pasta::pallas::{Affine, Scalar};
 
@@ -954,8 +954,10 @@ mod test {
             check_expr(
                 ExpressionBack::Var(Query(QueryBack {
                     index: 0,
-                    column_index: col,
-                    column_type: Any::Fixed,
+                    column: ColumnMid {
+                        index: col,
+                        column_type: Any::Fixed,
+                    },
                     rotation: Rotation(rot),
                 })),
                 expected,
@@ -965,8 +967,10 @@ mod test {
             check_expr(
                 ExpressionBack::Var(Query(QueryBack {
                     index: 0,
-                    column_index: col,
-                    column_type: Any::Advice,
+                    column: ColumnMid {
+                        index: col,
+                        column_type: Any::Advice,
+                    },
                     rotation: Rotation(rot),
                 })),
                 expected,
@@ -976,8 +980,10 @@ mod test {
             check_expr(
                 ExpressionBack::Var(Query(QueryBack {
                     index: 0,
-                    column_index: col,
-                    column_type: Any::Instance,
+                    column: ColumnMid {
+                        index: col,
+                        column_type: Any::Instance,
+                    },
                     rotation: Rotation(rot),
                 })),
                 expected,
@@ -1007,8 +1013,10 @@ mod test {
         let two = || {
             Box::new(ExpressionBack::<Scalar>::Var(Query(QueryBack {
                 index: 0,
-                column_index: 0,
-                column_type: Any::Fixed,
+                column: ColumnMid {
+                    index: 0,
+                    column_type: Any::Fixed,
+                },
                 rotation: Rotation(0),
             })))
         };
@@ -1016,8 +1024,10 @@ mod test {
         let three = || {
             Box::new(ExpressionBack::<Scalar>::Var(Query(QueryBack {
                 index: 0,
-                column_index: 0,
-                column_type: Any::Fixed,
+                column: ColumnMid {
+                    index: 0,
+                    column_type: Any::Fixed,
+                },
                 rotation: Rotation(1),
             })))
         };

--- a/halo2_backend/src/plonk/keygen.rs
+++ b/halo2_backend/src/plonk/keygen.rs
@@ -218,8 +218,10 @@ impl QueriesMap {
                 let index = self.add(column, query.rotation);
                 ExpressionBack::Var(VarBack::Query(QueryBack {
                     index,
-                    column_index: query.column_index,
-                    column_type: query.column_type,
+                    column: ColumnMid {
+                        index: query.column_index,
+                        column_type: query.column_type,
+                    },
                     rotation: query.rotation,
                 }))
             }

--- a/halo2_backend/src/plonk/lookup/verifier.rs
+++ b/halo2_backend/src/plonk/lookup/verifier.rs
@@ -119,13 +119,13 @@ impl<C: CurveAffine> Evaluated<C> {
                             &|scalar| scalar,
                             &|var| match var {
                                 VarBack::Challenge(challenge) => challenges[challenge.index],
-                                VarBack::Query(QueryBack {
-                                    index, column_type, ..
-                                }) => match column_type {
-                                    Any::Fixed => fixed_evals[index],
-                                    Any::Advice => advice_evals[index],
-                                    Any::Instance => instance_evals[index],
-                                },
+                                VarBack::Query(QueryBack { index, column, .. }) => {
+                                    match column.column_type {
+                                        Any::Fixed => fixed_evals[index],
+                                        Any::Advice => advice_evals[index],
+                                        Any::Instance => instance_evals[index],
+                                    }
+                                }
                             },
                             &|a| -a,
                             &|a, b| a + b,

--- a/halo2_backend/src/plonk/permutation.rs
+++ b/halo2_backend/src/plonk/permutation.rs
@@ -6,8 +6,7 @@ use crate::{
     helpers::{polynomial_slice_byte_length, read_polynomial_vec, write_polynomial_slice},
     poly::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial},
 };
-// TODO: Remove the renaming
-pub use halo2_middleware::permutation::ArgumentMid as Argument;
+pub use halo2_middleware::permutation::ArgumentMid;
 
 use std::io;
 
@@ -34,7 +33,7 @@ impl<C: CurveAffine> VerifyingKey<C> {
 
     pub(crate) fn read<R: io::Read>(
         reader: &mut R,
-        argument: &Argument,
+        argument: &ArgumentMid,
         format: SerdeFormat,
     ) -> io::Result<Self>
     where

--- a/halo2_backend/src/plonk/permutation/keygen.rs
+++ b/halo2_backend/src/plonk/permutation/keygen.rs
@@ -2,7 +2,7 @@ use group::Curve;
 use halo2_middleware::ff::{Field, PrimeField};
 use halo2_middleware::zal::impls::H2cEngine;
 
-use super::{Argument, ProvingKey, VerifyingKey};
+use super::{ProvingKey, VerifyingKey};
 use crate::{
     arithmetic::{parallelize, CurveAffine},
     plonk::Error,
@@ -40,7 +40,7 @@ impl Assembly {
         Ok(assembly)
     }
 
-    pub(crate) fn new(n: usize, p: &Argument) -> Self {
+    pub(crate) fn new(n: usize, p: &ArgumentMid) -> Self {
         // Initialize the copy vector to keep track of copy constraints in all
         // the permutation arguments.
         let mut columns = vec![];
@@ -121,7 +121,7 @@ impl Assembly {
         self,
         params: &P,
         domain: &EvaluationDomain<C::Scalar>,
-        p: &Argument,
+        p: &ArgumentMid,
     ) -> VerifyingKey<C> {
         build_vk(params, domain, p, |i, j| self.mapping[i][j])
     }
@@ -130,7 +130,7 @@ impl Assembly {
         self,
         params: &P,
         domain: &EvaluationDomain<C::Scalar>,
-        p: &Argument,
+        p: &ArgumentMid,
     ) -> ProvingKey<C> {
         build_pk(params, domain, p, |i, j| self.mapping[i][j])
     }
@@ -139,7 +139,7 @@ impl Assembly {
 pub(crate) fn build_pk<C: CurveAffine, P: Params<C>>(
     params: &P,
     domain: &EvaluationDomain<C::Scalar>,
-    p: &Argument,
+    p: &ArgumentMid,
     mapping: impl Fn(usize, usize) -> (usize, usize) + Sync,
 ) -> ProvingKey<C> {
     // Compute [omega^0, omega^1, ..., omega^{params.n - 1}]
@@ -215,7 +215,7 @@ pub(crate) fn build_pk<C: CurveAffine, P: Params<C>>(
 pub(crate) fn build_vk<C: CurveAffine, P: Params<C>>(
     params: &P,
     domain: &EvaluationDomain<C::Scalar>,
-    p: &Argument,
+    p: &ArgumentMid,
     mapping: impl Fn(usize, usize) -> (usize, usize) + Sync,
 ) -> VerifyingKey<C> {
     // Compute [omega^0, omega^1, ..., omega^{params.n - 1}]

--- a/halo2_backend/src/plonk/permutation/prover.rs
+++ b/halo2_backend/src/plonk/permutation/prover.rs
@@ -2,12 +2,11 @@ use group::{
     ff::{BatchInvert, Field},
     Curve,
 };
-use halo2_middleware::zal::traits::MsmAccel;
 use halo2_middleware::{ff::PrimeField, zal::impls::PlonkEngine};
+use halo2_middleware::{permutation::ArgumentMid, zal::traits::MsmAccel};
 use rand_core::RngCore;
 use std::iter::{self, ExactSizeIterator};
 
-use super::Argument;
 use crate::{
     arithmetic::{eval_polynomial, parallelize, CurveAffine},
     plonk::{self, permutation::ProvingKey, ChallengeBeta, ChallengeGamma, ChallengeX, Error},
@@ -62,7 +61,7 @@ pub(in crate::plonk) fn permutation_commit<
     M: MsmAccel<C>,
 >(
     engine: &PlonkEngine<C, M>,
-    arg: &Argument,
+    arg: &ArgumentMid,
     params: &P,
     pk: &plonk::ProvingKey<C>,
     pkey: &ProvingKey<C>,

--- a/halo2_backend/src/plonk/permutation/verifier.rs
+++ b/halo2_backend/src/plonk/permutation/verifier.rs
@@ -1,7 +1,10 @@
-use halo2_middleware::ff::{Field, PrimeField};
+use halo2_middleware::{
+    ff::{Field, PrimeField},
+    permutation::ArgumentMid,
+};
 use std::iter;
 
-use super::{Argument, VerifyingKey};
+use super::VerifyingKey;
 use crate::{
     arithmetic::CurveAffine,
     plonk::{self, ChallengeBeta, ChallengeGamma, ChallengeX, Error},
@@ -35,7 +38,7 @@ pub(crate) fn permutation_read_product_commitments<
     E: EncodedChallenge<C>,
     T: TranscriptRead<C, E>,
 >(
-    arg: &Argument,
+    arg: &ArgumentMid,
     vk: &plonk::VerifyingKey<C>,
     transcript: &mut T,
 ) -> Result<Committed<C>, Error> {
@@ -102,7 +105,7 @@ impl<C: CurveAffine> Evaluated<C> {
     pub(in crate::plonk) fn expressions<'a>(
         &'a self,
         vk: &'a plonk::VerifyingKey<C>,
-        p: &'a Argument,
+        p: &'a ArgumentMid,
         common: &'a CommonEvaluated<C>,
         advice_evals: &'a [C::Scalar],
         fixed_evals: &'a [C::Scalar],

--- a/halo2_backend/src/plonk/shuffle/verifier.rs
+++ b/halo2_backend/src/plonk/shuffle/verifier.rs
@@ -78,13 +78,13 @@ impl<C: CurveAffine> Evaluated<C> {
                             &|scalar| scalar,
                             &|var| match var {
                                 VarBack::Challenge(challenge) => challenges[challenge.index],
-                                VarBack::Query(QueryBack {
-                                    index, column_type, ..
-                                }) => match column_type {
-                                    Any::Fixed => fixed_evals[index],
-                                    Any::Advice => advice_evals[index],
-                                    Any::Instance => instance_evals[index],
-                                },
+                                VarBack::Query(QueryBack { index, column, .. }) => {
+                                    match column.column_type {
+                                        Any::Fixed => fixed_evals[index],
+                                        Any::Advice => advice_evals[index],
+                                        Any::Instance => instance_evals[index],
+                                    }
+                                }
                             },
                             &|a| -a,
                             &|a, b| a + b,

--- a/halo2_backend/src/plonk/vanishing/prover.rs
+++ b/halo2_backend/src/plonk/vanishing/prover.rs
@@ -117,7 +117,12 @@ impl<C: CurveAffine> Committed<C> {
         let h_poly = domain.divide_by_vanishing_poly(h_poly);
 
         // Obtain final h(X) polynomial
-        let h_poly = domain.extended_to_coeff(h_poly);
+        let mut h_poly = domain.extended_to_coeff(h_poly);
+
+        // Truncate it to match the size of the quotient polynomial; the
+        // evaluation domain might be slightly larger than necessary because
+        // it always lies on a power-of-two boundary.
+        h_poly.truncate(((1u64 << domain.k()) as usize) * domain.get_quotient_poly_degree());
 
         // Split h(X) up into pieces
         let h_pieces = h_poly

--- a/halo2_backend/src/plonk/verifier.rs
+++ b/halo2_backend/src/plonk/verifier.rs
@@ -388,7 +388,7 @@ where
                             gate.poly.evaluate(
                                 &|scalar| scalar,
                                 &|var| match var {
-                                    VarBack::Query(query) => match query.column_type {
+                                    VarBack::Query(query) => match query.column.column_type {
                                         Any::Fixed => fixed_evals[query.index],
                                         Any::Advice => advice_evals[query.index],
                                         Any::Instance => instance_evals[query.index],

--- a/halo2_backend/src/poly/domain.rs
+++ b/halo2_backend/src/poly/domain.rs
@@ -328,7 +328,6 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
     ///
     /// This function will panic if the provided vector is not the correct
     /// length.
-    // TODO/FIXME: caller should be responsible for truncating
     pub fn extended_to_coeff(&self, mut a: Polynomial<F, ExtendedLagrangeCoeff>) -> Vec<F> {
         assert_eq!(a.values.len(), self.extended_len());
 
@@ -343,12 +342,6 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
         // Distribute powers to move from coset; opposite from the
         // transformation we performed earlier.
         self.distribute_powers_zeta(&mut a.values, false);
-
-        // Truncate it to match the size of the quotient polynomial; the
-        // evaluation domain might be slightly larger than necessary because
-        // it always lies on a power-of-two boundary.
-        a.values
-            .truncate((self.n * self.quotient_poly_degree) as usize);
 
         a.values
     }

--- a/halo2_proofs/tests/compress_selectors.rs
+++ b/halo2_proofs/tests/compress_selectors.rs
@@ -494,13 +494,13 @@ fn test_key_compression() -> Result<(), halo2_proofs::plonk::Error> {
     // vk & pk keygen both WITH compression
     test_result(
         || test_mycircuit(true, true).expect("should pass"),
-        "acae50508de5ead584170dd83b139daf40e1026b6debbb78eb05d515173fc2dd",
+        "44130c6388df3d99263be8da4a280b426dc05f1f315d35d3827347761534bf08",
     );
 
     // vk & pk keygen both WITHOUT compression
     test_result(
         || test_mycircuit(false, false).expect("should pass"),
-        "f9c99bd341705ac6a13724a526dd28df0bac1c745e0cde40ab39cab3e1b95309",
+        "9f58d7a0088fa2c614e8d67bd238f61bc160300e72f5ffd5d52485ed5fb06752",
     );
 
     Ok(())

--- a/halo2_proofs/tests/frontend_backend_split.rs
+++ b/halo2_proofs/tests/frontend_backend_split.rs
@@ -545,7 +545,7 @@ fn test_mycircuit_full_legacy() {
 
             proof
         },
-        "78aadfd46b5cc58b90d832ee47e4df57af3dfc28d1457c4ceeb5d0323a72f130",
+        "44a4bca99aec990b2f382d9c2e1dcc8d8e254d49c2e47cab7556918105346474",
     );
 }
 
@@ -626,6 +626,6 @@ fn test_mycircuit_full_split() {
 
             proof
         },
-        "78aadfd46b5cc58b90d832ee47e4df57af3dfc28d1457c4ceeb5d0323a72f130",
+        "44a4bca99aec990b2f382d9c2e1dcc8d8e254d49c2e47cab7556918105346474",
     );
 }

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -602,7 +602,7 @@ fn plonk_api() {
 
                 proof
             },
-            "f87ba1010dede5a2148ed94403ca12a566d3154ebb12ccb6c20a330e9b280af8",
+            "da790e980ea5a871e7b713f781fb7d6905a321d25427dc54b3accac2aa0d8860",
         );
     }
 
@@ -639,7 +639,7 @@ fn plonk_api() {
 
                 proof
             },
-            "0fc67d890faef0ef8ea7ef680cc566b2ab7dabef12fcceb74d3655a0fb08c708",
+            "88c7197240d5a8db1b51d82e7a2a6d49e8593d64aed624e2a72c2b75fbac0357",
         );
     }
 

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -707,8 +707,10 @@ fn plonk_api() {
                                     Query(
                                         QueryBack {
                                             index: 0,
-                                            column_index: 1,
-                                            column_type: Advice,
+                                            column: ColumnMid {
+                                                column_type: Advice,
+                                                index: 1,
+                                            },
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -719,8 +721,10 @@ fn plonk_api() {
                                     Query(
                                         QueryBack {
                                             index: 0,
-                                            column_index: 2,
-                                            column_type: Fixed,
+                                            column: ColumnMid {
+                                                column_type: Fixed,
+                                                index: 2,
+                                            },
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -733,8 +737,10 @@ fn plonk_api() {
                                     Query(
                                         QueryBack {
                                             index: 1,
-                                            column_index: 2,
-                                            column_type: Advice,
+                                            column: ColumnMid {
+                                                column_type: Advice,
+                                                index: 2,
+                                            },
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -745,8 +751,10 @@ fn plonk_api() {
                                     Query(
                                         QueryBack {
                                             index: 1,
-                                            column_index: 3,
-                                            column_type: Fixed,
+                                            column: ColumnMid {
+                                                column_type: Fixed,
+                                                index: 3,
+                                            },
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -761,8 +769,10 @@ fn plonk_api() {
                                     Query(
                                         QueryBack {
                                             index: 0,
-                                            column_index: 1,
-                                            column_type: Advice,
+                                            column: ColumnMid {
+                                                column_type: Advice,
+                                                index: 1,
+                                            },
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -773,8 +783,10 @@ fn plonk_api() {
                                     Query(
                                         QueryBack {
                                             index: 1,
-                                            column_index: 2,
-                                            column_type: Advice,
+                                            column: ColumnMid {
+                                                column_type: Advice,
+                                                index: 2,
+                                            },
                                             rotation: Rotation(
                                                 0,
                                             ),
@@ -786,8 +798,10 @@ fn plonk_api() {
                                 Query(
                                     QueryBack {
                                         index: 2,
-                                        column_index: 1,
-                                        column_type: Fixed,
+                                        column: ColumnMid {
+                                            column_type: Fixed,
+                                            index: 1,
+                                        },
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -802,8 +816,10 @@ fn plonk_api() {
                                 Query(
                                     QueryBack {
                                         index: 2,
-                                        column_index: 3,
-                                        column_type: Advice,
+                                        column: ColumnMid {
+                                            column_type: Advice,
+                                            index: 3,
+                                        },
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -814,8 +830,10 @@ fn plonk_api() {
                                 Query(
                                     QueryBack {
                                         index: 3,
-                                        column_index: 4,
-                                        column_type: Fixed,
+                                        column: ColumnMid {
+                                            column_type: Fixed,
+                                            index: 4,
+                                        },
                                         rotation: Rotation(
                                             0,
                                         ),
@@ -830,8 +848,10 @@ fn plonk_api() {
                         Query(
                             QueryBack {
                                 index: 4,
-                                column_index: 0,
-                                column_type: Fixed,
+                                column: ColumnMid {
+                                    column_type: Fixed,
+                                    index: 0,
+                                },
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -843,8 +863,10 @@ fn plonk_api() {
                             Query(
                                 QueryBack {
                                     index: 3,
-                                    column_index: 4,
-                                    column_type: Advice,
+                                    column: ColumnMid {
+                                        column_type: Advice,
+                                        index: 4,
+                                    },
                                     rotation: Rotation(
                                         1,
                                     ),
@@ -855,8 +877,10 @@ fn plonk_api() {
                             Query(
                                 QueryBack {
                                     index: 4,
-                                    column_index: 0,
-                                    column_type: Advice,
+                                    column: ColumnMid {
+                                        column_type: Advice,
+                                        index: 0,
+                                    },
                                     rotation: Rotation(
                                         -1,
                                     ),
@@ -871,8 +895,10 @@ fn plonk_api() {
                     Query(
                         QueryBack {
                             index: 5,
-                            column_index: 5,
-                            column_type: Fixed,
+                            column: ColumnMid {
+                                column_type: Fixed,
+                                index: 5,
+                            },
                             rotation: Rotation(
                                 0,
                             ),
@@ -884,8 +910,10 @@ fn plonk_api() {
                         Query(
                             QueryBack {
                                 index: 0,
-                                column_index: 1,
-                                column_type: Advice,
+                                column: ColumnMid {
+                                    column_type: Advice,
+                                    index: 1,
+                                },
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -897,8 +925,10 @@ fn plonk_api() {
                             Query(
                                 QueryBack {
                                     index: 0,
-                                    column_index: 0,
-                                    column_type: Instance,
+                                    column: ColumnMid {
+                                        column_type: Instance,
+                                        index: 0,
+                                    },
                                     rotation: Rotation(
                                         0,
                                     ),
@@ -1110,8 +1140,10 @@ fn plonk_api() {
                         Query(
                             QueryBack {
                                 index: 0,
-                                column_index: 1,
-                                column_type: Advice,
+                                column: ColumnMid {
+                                    column_type: Advice,
+                                    index: 1,
+                                },
                                 rotation: Rotation(
                                     0,
                                 ),
@@ -1124,8 +1156,10 @@ fn plonk_api() {
                         Query(
                             QueryBack {
                                 index: 6,
-                                column_index: 6,
-                                column_type: Fixed,
+                                column: ColumnMid {
+                                    column_type: Fixed,
+                                    index: 6,
+                                },
                                 rotation: Rotation(
                                     0,
                                 ),

--- a/halo2_proofs/tests/serialization.rs
+++ b/halo2_proofs/tests/serialization.rs
@@ -219,6 +219,6 @@ fn test_serialization() {
 
             proof
         },
-        "b51ea51140e9fbd1f0c665c788bab9e4b3e648ac674b6d07a24ca0844f0962ad",
+        "0be5dca07d18b9ad4ccfbf27fc58a7359d1909e5f762cf5df07ce02d0ab96f94",
     );
 }

--- a/halo2_proofs/tests/serialization.rs
+++ b/halo2_proofs/tests/serialization.rs
@@ -8,8 +8,8 @@ use halo2_debug::test_rng;
 use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
     plonk::{
-        create_proof, keygen_pk, keygen_vk_custom, pk_read, verify_proof_multi, vk_read, Advice, Circuit,
-        Column, ConstraintSystem, ErrorFront, Fixed, Instance,
+        create_proof, keygen_pk, keygen_vk_custom, pk_read, verify_proof_multi, vk_read, Advice,
+        Circuit, Column, ConstraintSystem, ErrorFront, Fixed, Instance,
     },
     poly::{
         kzg::{
@@ -213,12 +213,7 @@ fn test_serialization() {
                     Challenge255<G1Affine>,
                     Blake2bRead<&[u8], G1Affine, Challenge255<G1Affine>>,
                     SingleStrategy<Bn256>,
-                >(
-                    &verifier_params,
-                    &vk,
-                    instances.as_slice(),
-                    &mut transcript
-                ),
+                >(&verifier_params, &vk, instances.as_slice(), &mut transcript),
                 "failed to verify proof"
             );
 

--- a/halo2_proofs/tests/shuffle.rs
+++ b/halo2_proofs/tests/shuffle.rs
@@ -327,7 +327,7 @@ fn test_shuffle() {
 
     halo2_debug::test_result(
         || test_prover::<EqAffine, W, H>(K, circuit.clone(), true),
-        "8526b66a372eaeccb687c21daf358d4fdb1c9d2b7e81470317c472634c5c1470",
+        "08d9c3129b4e2f6dd63cfc2cc23577fb7a39d5f8b333e3fb4e1eb2b223059338",
     );
 
     #[cfg(not(feature = "sanity-checks"))]

--- a/halo2_proofs/tests/shuffle_api.rs
+++ b/halo2_proofs/tests/shuffle_api.rs
@@ -214,6 +214,6 @@ fn test_shuffle_api() {
             prover.assert_satisfied();
             test_prover::<EqAffine>(K, circuit, true)
         },
-        "54f4fec1776178aadf8816754d7877f1de685e0ffb5b6af4db20f557d87550d6",
+        "bf0868d8eb50e3ea00aee981070b8ebf551f24b24792f6157048f605e4c8cf12",
     );
 }

--- a/halo2_proofs/tests/vector-ops-unblinded.rs
+++ b/halo2_proofs/tests/vector-ops-unblinded.rs
@@ -545,13 +545,13 @@ fn test_vector_ops_unbinded() {
     // the commitments will be the first columns of the proof transcript so we can compare them easily
     let proof_1 = halo2_debug::test_result(
         || test_prover::<halo2curves::pasta::EqAffine>(k, mul_circuit.clone(), true, c_mul.clone()),
-        "1f726eaddd926057e6c2aa8a364d1b4192da27f53c38c9f21d8924ef3eb0f0ab",
+        "8fb24ffebec78e9667e9f9eab6b4b8974d95b5db9023ef78788a08b3daf4b138",
     );
 
     // the commitments will be the first columns of the proof transcript so we can compare them easily
     let proof_2 = halo2_debug::test_result(
         || test_prover::<halo2curves::pasta::EqAffine>(k, add_circuit.clone(), true, c_add.clone()),
-        "a42eb2f3e4761e6588bfd8db7e7035ead1cc1331017b6b09a7b75ddfbefefc58",
+        "ded7a6e1f2463fc1bc40311d409af170d57b3e32fe8d60f53403043ae718f4f9",
     );
 
     // the commitments will be the first columns of the proof transcript so we can compare them easily


### PR DESCRIPTION
## Description
- Take care of some TODOs throughout the repo

## Related issues
-

## Changes
- ~~parallelize `compute_inner_product` utility~~
- use `ColumnMid` in `QueryBack`
- remove renaming in `halo2_backend/plonk/permutation`
- refactor the `EvaluationDomain::extended_to_coeff` function