### PR TITLE
Expose required types and functions for external verifier generation

### DIFF
--- a/halo2_backend/src/plonk.rs
+++ b/halo2_backend/src/plonk.rs
@@ -13,14 +13,14 @@ use crate::helpers::{
     polynomial_slice_byte_length, read_polynomial_vec, write_polynomial_slice, SerdeCurveAffine,
     SerdeFormat, SerdePrimeField,
 };
-use crate::plonk::circuit::{ConstraintSystemBack, PinnedConstraintSystem};
+use crate::plonk::circuit::PinnedConstraintSystem;
 use crate::poly::{
     Coeff, EvaluationDomain, ExtendedLagrangeCoeff, LagrangeCoeff, PinnedEvaluationDomain,
     Polynomial,
 };
 use crate::transcript::{ChallengeScalar, EncodedChallenge, Transcript};
+pub use circuit::{ConstraintSystemBack, QueryBack, VarBack};
 pub(crate) use evaluation::Evaluator;
-
 use std::io;
 
 mod circuit;
@@ -235,7 +235,7 @@ impl<C: CurveAffine> VerifyingKey<C> {
     }
 
     /// Returns `ConstraintSystem`
-    pub(crate) fn cs(&self) -> &ConstraintSystemBack<C::Scalar> {
+    pub fn cs(&self) -> &ConstraintSystemBack<C::Scalar> {
         &self.cs
     }
 

--- a/halo2_backend/src/plonk.rs
+++ b/halo2_backend/src/plonk.rs
@@ -230,6 +230,10 @@ impl<C: CurveAffine> VerifyingKey<C> {
         &self.fixed_commitments
     }
 
+    pub fn permutation_commitments(&self) -> &[C] {
+        self.permutation.commitments()
+    }
+
     /// Returns `ConstraintSystem`
     pub(crate) fn cs(&self) -> &ConstraintSystemBack<C::Scalar> {
         &self.cs

--- a/halo2_backend/src/plonk/circuit.rs
+++ b/halo2_backend/src/plonk/circuit.rs
@@ -15,6 +15,20 @@ pub struct QueryBack {
     pub(crate) rotation: Rotation,
 }
 
+impl QueryBack {
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    pub fn column(&self) -> ColumnMid {
+        self.column
+    }
+
+    pub fn rotation(&self) -> Rotation {
+        self.rotation
+    }
+}
+
 /// Represent the `Query` and `Challenge`, for backwards compatibility
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum VarBack {
@@ -75,34 +89,34 @@ pub struct ConstraintSystemBack<F: Field> {
 
     pub(crate) gates: Vec<GateBack<F>>,
     pub(crate) advice_queries: Vec<(ColumnMid, Rotation)>,
-    // Contains an integer for each advice column
-    // identifying how many distinct queries it has
-    // so far; should be same length as num_advice_columns.
+    /// Contains an integer for each advice column
+    /// identifying how many distinct queries it has
+    /// so far; should be same length as num_advice_columns.
     pub(crate) num_advice_queries: Vec<usize>,
     pub(crate) instance_queries: Vec<(ColumnMid, Rotation)>,
     pub(crate) fixed_queries: Vec<(ColumnMid, Rotation)>,
 
-    // Permutation argument for performing equality constraints
+    /// Permutation argument for performing equality constraints
     pub(crate) permutation: PermutationArgumentBack,
 
-    // Vector of lookup arguments, where each corresponds to a sequence of
-    // input expressions and a sequence of table expressions involved in the lookup.
+    /// Vector of lookup arguments, where each corresponds to a sequence of
+    /// input expressions and a sequence of table expressions involved in the lookup.
     pub(crate) lookups: Vec<LookupArgumentBack<F>>,
 
-    // Vector of shuffle arguments, where each corresponds to a sequence of
-    // input expressions and a sequence of shuffle expressions involved in the shuffle.
+    /// Vector of shuffle arguments, where each corresponds to a sequence of
+    /// input expressions and a sequence of shuffle expressions involved in the shuffle.
     pub(crate) shuffles: Vec<ShuffleArgumentBack<F>>,
 
-    // The minimum degree required by the circuit, which can be set to a
-    // larger amount than actually needed. This can be used, for example, to
-    // force the permutation argument to involve more columns in the same set.
+    /// The minimum degree required by the circuit, which can be set to a
+    /// larger amount than actually needed. This can be used, for example, to
+    /// force the permutation argument to involve more columns in the same set.
     pub(crate) minimum_degree: Option<usize>,
 }
 
 impl<F: Field> ConstraintSystemBack<F> {
     /// Compute the degree of the constraint system (the maximum degree of all
     /// constraints).
-    pub(crate) fn degree(&self) -> usize {
+    pub fn degree(&self) -> usize {
         // The permutation argument will serve alongside the gates, so must be
         // accounted for.
         let mut degree = permutation_argument_required_degree();
@@ -145,7 +159,7 @@ impl<F: Field> ConstraintSystemBack<F> {
 
     /// Compute the number of blinding factors necessary to perfectly blind
     /// each of the prover's witness polynomials.
-    pub(crate) fn blinding_factors(&self) -> usize {
+    pub fn blinding_factors(&self) -> usize {
         // All of the prover's advice columns are evaluated at no more than
         let factors = *self.num_advice_queries.iter().max().unwrap_or(&1);
         // distinct points during gate checks.
@@ -229,6 +243,71 @@ impl<F: Field> ConstraintSystemBack<F> {
             shuffles: &self.shuffles,
             minimum_degree: &self.minimum_degree,
         }
+    }
+
+    /// Returns the number of advice columns.
+    pub fn num_advice_columns(&self) -> usize {
+        self.num_advice_columns
+    }
+
+    /// Returns the number of fixed columns.
+    pub fn num_fixed_columns(&self) -> usize {
+        self.num_fixed_columns
+    }
+
+    /// Returns the number of instance columns.
+    pub fn num_instance_columns(&self) -> usize {
+        self.num_instance_columns
+    }
+
+    /// Returns the number of challenges.
+    pub fn num_challenges(&self) -> usize {
+        self.num_challenges
+    }
+
+    /// Returns the indices of the advice columns left unblinded.
+    pub fn unblinded_advice_columns(&self) -> &[usize] {
+        &self.unblinded_advice_columns
+    }
+
+    /// Returns the phase for each advice column.
+    pub fn advice_column_phase(&self) -> &[u8] {
+        &self.advice_column_phase
+    }
+
+    /// Returns the phase for each challenge.
+    pub fn challenge_phase(&self) -> &[u8] {
+        &self.challenge_phase
+    }
+
+    /// Returns the advice queries.
+    pub fn advice_queries(&self) -> &[(ColumnMid, Rotation)] {
+        &self.advice_queries
+    }
+
+    /// Returns the instance queries.
+    pub fn instance_queries(&self) -> &[(ColumnMid, Rotation)] {
+        &self.instance_queries
+    }
+
+    /// Returns the fixed queries.
+    pub fn fixed_queries(&self) -> &[(ColumnMid, Rotation)] {
+        &self.fixed_queries
+    }
+
+    /// Returns the permutation columns.
+    pub fn permutation_columns(&self) -> &[ColumnMid] {
+        &self.permutation.columns
+    }
+
+    /// Returns the gates.
+    pub fn gates(&self) -> &[GateBack<F>] {
+        &self.gates
+    }
+
+    /// Returns the number of lookup arguments.
+    pub fn lookups(&self) -> &[lookup::Argument<F, VarBack>] {
+        &self.lookups
     }
 }
 

--- a/halo2_backend/src/plonk/permutation.rs
+++ b/halo2_backend/src/plonk/permutation.rs
@@ -21,6 +21,11 @@ pub(crate) struct VerifyingKey<C: CurveAffine> {
 }
 
 impl<C: CurveAffine> VerifyingKey<C> {
+    /// Returns commitments of sigma polynomials
+    pub fn commitments(&self) -> &[C] {
+        &self.commitments
+    }
+
     pub(crate) fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()>
     where
         C: SerdeCurveAffine,

--- a/halo2_backend/src/poly/commitment.rs
+++ b/halo2_backend/src/poly/commitment.rs
@@ -80,6 +80,9 @@ pub trait ParamsProver<C: CurveAffine>: Params<C> {
         poly: &Polynomial<C::ScalarExt, Coeff>,
         r: Blind<C::ScalarExt>,
     ) -> C::CurveExt;
+
+    /// Getter for g generators
+    fn get_g(&self) -> &[C];
 }
 
 /// Verifier specific functionality with circuit constraints

--- a/halo2_backend/src/poly/kzg/commitment.rs
+++ b/halo2_backend/src/poly/kzg/commitment.rs
@@ -254,6 +254,16 @@ where
         }
     }
 
+    /// Returns generator on G2
+    pub fn g2(&self) -> E::G2Affine {
+        self.g2
+    }
+
+    /// Returns first power of secret on G2
+    pub fn s_g2(&self) -> E::G2Affine {
+        self.s_g2
+    }
+
     /// Writes parameters to buffer
     pub fn write_custom<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()>
     where
@@ -445,6 +455,10 @@ where
         let size = scalars.len();
         assert!(bases.len() >= size);
         engine.msm(&scalars, &bases[0..size])
+    }
+
+    fn get_g(&self) -> &[E::G1Affine] {
+        &self.g
     }
 }
 


### PR DESCRIPTION
# Summary
Recent changes in the `halo2` repository (e.g., #307 #318) have restricted access to certain types, functions, and data, making it difficult to generate verifiers outside the `halo2` repository. This PR re-exposes the necessary components, enabling external tools — such as [`halo2-solidity-verifier`](https://github.com/privacy-scaling-explorations/halo2-solidity-verifier) — to work with the latest `halo2` versions.  

# Motivation  
Several projects rely on `halo2` for zero-knowledge proof generation and verification, including generating Solidity verifiers. However, the recent changes in `halo2` have made this nearly impossible, as critical elements are now private. By exposing the required types and functions, this PR restores the ability to implement external verifiers.

# Changes Introduced  
- exposed `ConstraintSystemBack`, `QueryBack` and `VarBack` types from `halo2_backend`; these structs have been already `pub` (not `pub(crate)`)
- exposed `VerifyingKey::permutation_commitments(&self)` (without leaking private intermediate type `permutation::VerifyingKey`); this required exposing `permutation::VerifyingKey::commitments(&self)`
- exposed `VerifyingKey::cs(&self)`
- getters for `QueryBack`
- getters for `ConstraintSystemBack` (without any type leakage)
- change `//` to proper `///` docs in few places
- exposed `ConstraintSystemBack::degree(&self)` and `ConstraintSystemBack::blinding_factors(&self)`
- brought back `ParamsProver::get_g(&self)`
- brought back `ParamsKZG::s_g2(&self)` and `ParamsKZG::g2(&self)`

# Proof of Concept
To demonstrate the necessity and correctness of these changes, I have prepared a PR: https://github.com/privacy-scaling-explorations/halo2-solidity-verifier/pull/21 that updates `halo2-solidity-verifier` to use the latest `halo2` (`v0.4.0`), incorporating these modifications (very slightly differing by the commits after `0.4.0` release). With this update, the Solidity verifier generation process compiles correctly (although tests fail because of the out-of-date `halo2wrong` dev-dependency).  

Looking forward to your feedback! 🚀